### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains all the code of the Oxygen Updater Android application.
 ## Building and running
 ### Required tools
 The application should be buildable with Android Studio 3.4.2 and later.
-The app targets Android Pie (api 28) and the minimum is Android Lollipop (API 21). Make sure you've got both platforms installed!
+The app targets Android Pie (API 28) and the minimum is Android Lollipop (API 21). Make sure you've got both platforms installed!
 
 ### Key store / signing
 Before you can run the non-debug variants of the app, you'll need to create a `key store` to sign the app.
@@ -35,5 +35,5 @@ To test automatic update installations and other root features, you'll need to r
 See [`CONTRIBUTING.md`](./CONTRIBUTING.md).
 
 ## References to oxygenupdater.com/api (server side)
-The app communicates with server code, of which sources are available at https://github.com/arjanvlek/oxygen-updater-backend
+The app communicates with server code, of which sources are available at https://github.com/oxygen-updater/oxygen-updater-backend
 If you want to run the app with this backend locally hosted (e.g. via Docker), please use the `localDebug` build variant.


### PR DESCRIPTION
## What's changed?

"API" wasn't written in capital letters everywhere and repo has been moved to https://github.com/oxygen-updater/oxygen-updater-backend