### PR TITLE
Play Store account transfer (including AdMob, Firebase, etc.)

### DIFF
--- a/app/google-services.json
+++ b/app/google-services.json
@@ -42,7 +42,7 @@
           ]
         }
       },
-      "admob_app_id": "ca-app-pub-0760639008316468~7665206420"
+      "admob_app_id": "ca-app-pub-1816831161514116~4275332954"
     },
     {
       "client_info": {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -233,7 +233,7 @@
 
 		<meta-data
 			android:name="com.google.android.gms.ads.APPLICATION_ID"
-			android:value="ca-app-pub-0760639008316468~7665206420" />
+			android:value="@string/advertising_app_id" />
 
 	</application>
 </manifest>

--- a/app/src/main/java/com/arjanvlek/oxygenupdater/news/NewsActivity.java
+++ b/app/src/main/java/com/arjanvlek/oxygenupdater/news/NewsActivity.java
@@ -158,7 +158,7 @@ public class NewsActivity extends SupportActionBarActivity {
 									if (getIntent().getBooleanExtra(INTENT_START_WITH_AD, false)
 											&& !new SettingsManager(getApplication()).getPreference(SettingsManager.PROPERTY_AD_FREE, false)) {
 										InterstitialAd interstitialAd = new InterstitialAd(getApplication());
-										interstitialAd.setAdUnitId(getString(R.string.news_ad_unit_id));
+										interstitialAd.setAdUnitId(getString(R.string.advertising_interstitial_unit_id));
 										interstitialAd.loadAd(ApplicationData.buildAdRequest());
 
 										// The ad will be shown after 10 seconds.

--- a/app/src/main/java/com/arjanvlek/oxygenupdater/news/NewsActivity.java
+++ b/app/src/main/java/com/arjanvlek/oxygenupdater/news/NewsActivity.java
@@ -29,6 +29,8 @@ public class NewsActivity extends SupportActionBarActivity {
 	public static final String INTENT_NEWS_ITEM_ID = "NEWS_ITEM_ID";
 	public static final String INTENT_START_WITH_AD = "START_WITH_AD";
 
+	private WebView webView;
+
 	@SuppressLint("SetJavaScriptEnabled")
 	// JS is required to load videos and other dynamic content.
 	@Override
@@ -43,6 +45,37 @@ public class NewsActivity extends SupportActionBarActivity {
 		setContentView(R.layout.loading);
 
 		loadNewsItem();
+	}
+
+	@Override
+	protected void onResume() {
+		if (webView != null) {
+			webView.onResume();
+		}
+
+		super.onResume();
+	}
+
+	@Override
+	protected void onPause() {
+		if (webView != null) {
+			webView.onPause();
+		}
+
+		super.onPause();
+	}
+
+	@Override
+	protected void onDestroy() {
+		if (webView != null) {
+			webView.loadUrl("");
+			webView.stopLoading();
+			webView.destroy();
+		}
+
+		webView = null;
+
+		super.onDestroy();
 	}
 
 	private void loadNewsItem() {
@@ -66,8 +99,8 @@ public class NewsActivity extends SupportActionBarActivity {
 						} else {
 							String newsContents = getString(R.string.news_load_error);
 
-							WebView contentView = findViewById(R.id.newsContent);
-							contentView.loadDataWithBaseURL("", newsContents, "text/html", "UTF-8", "");
+							webView = findViewById(R.id.newsContent);
+							webView.loadDataWithBaseURL("", newsContents, "text/html", "UTF-8", "");
 
 							// Hide the title, author name and last updated views.
 							findViewById(R.id.newsTitle).setVisibility(View.GONE);
@@ -96,15 +129,15 @@ public class NewsActivity extends SupportActionBarActivity {
 					titleView.setText(newsItem.getTitle(locale));
 
 					// Display the contents of the article.
-					WebView contentView = findViewById(R.id.newsContent);
-					contentView.setVisibility(View.VISIBLE);
-					contentView.getSettings().setJavaScriptEnabled(true);
+					webView = findViewById(R.id.newsContent);
+					webView.setVisibility(View.VISIBLE);
+					webView.getSettings().setJavaScriptEnabled(true);
 
 					String newsContents = newsItem.getText(locale);
 
 					if (newsContents.isEmpty()) {
 						newsContents = getString(R.string.news_empty);
-						contentView.loadDataWithBaseURL("", newsContents, "text/html", "UTF-8", "");
+						webView.loadDataWithBaseURL("", newsContents, "text/html", "UTF-8", "");
 					} else {
 						String newsLanguage = locale == Locale.NL ? "NL" : "EN";
 						String newsContentUrl = BuildConfig.SERVER_BASE_URL + "news-content/" + newsItem.getId() + "/" + newsLanguage + "/";
@@ -116,8 +149,8 @@ public class NewsActivity extends SupportActionBarActivity {
 								? "Dark"
 								: "Light";
 
-						contentView.getSettings().setUserAgentString(ApplicationData.APP_USER_AGENT);
-						contentView.loadUrl(newsContentUrl);
+						webView.getSettings().setUserAgentString(ApplicationData.APP_USER_AGENT);
+						webView.loadUrl(newsContentUrl);
 					}
 
 					// Display the name of the author of the article

--- a/app/src/main/java/com/arjanvlek/oxygenupdater/views/AbstractFragment.java
+++ b/app/src/main/java/com/arjanvlek/oxygenupdater/views/AbstractFragment.java
@@ -15,7 +15,7 @@ import static com.arjanvlek.oxygenupdater.internal.logger.Logger.logError;
 public abstract class AbstractFragment extends Fragment {
 
 	//Test devices for ads.
-	public static final List<String> ADS_TEST_DEVICES = Arrays.asList("BE7E0AF85E0332807B1EA3FE4236F93C", "0FD2DE005EB9DD19BD02FB2CD4D87902");
+	public static final List<String> ADS_TEST_DEVICES = Arrays.asList("B5EB6278CE611E4A14FCB2E2DDF48993", "AA361A327964F1B961D98E98D8BB9843");
 	private ApplicationData applicationData;
 	private SettingsManager settingsManager;
 

--- a/app/src/main/java/com/arjanvlek/oxygenupdater/views/MainActivity.java
+++ b/app/src/main/java/com/arjanvlek/oxygenupdater/views/MainActivity.java
@@ -14,7 +14,6 @@ import android.os.Handler;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.CheckBox;
-import android.widget.FrameLayout;
 import android.widget.FrameLayout.LayoutParams;
 import android.widget.Toast;
 
@@ -250,7 +249,7 @@ public class MainActivity extends AppCompatActivity implements OnMenuItemClickLi
 		// instead of staying hidden until the user scrolls the ViewPager
 		// which hides the AppBar and shows AdView
 		appBar.addOnOffsetChangedListener((appBarLayout, verticalOffset) -> {
-			FrameLayout.LayoutParams layoutParams = (LayoutParams) adView.getLayoutParams();
+			LayoutParams layoutParams = (LayoutParams) adView.getLayoutParams();
 			layoutParams.bottomMargin = appBarLayout.getTotalScrollRange() - abs(verticalOffset);
 
 			// keep AdView at the bottom

--- a/app/src/main/java/com/arjanvlek/oxygenupdater/views/MainActivity.java
+++ b/app/src/main/java/com/arjanvlek/oxygenupdater/views/MainActivity.java
@@ -10,9 +10,12 @@ import android.content.pm.PackageManager;
 import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Handler;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.CheckBox;
+import android.widget.FrameLayout;
+import android.widget.FrameLayout.LayoutParams;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -34,16 +37,24 @@ import com.arjanvlek.oxygenupdater.news.NewsFragment;
 import com.arjanvlek.oxygenupdater.notifications.MessageDialog;
 import com.arjanvlek.oxygenupdater.notifications.NotificationTopicSubscriber;
 import com.arjanvlek.oxygenupdater.settings.SettingsManager;
+import com.arjanvlek.oxygenupdater.settings.adFreeVersion.util.IabHelper;
+import com.arjanvlek.oxygenupdater.settings.adFreeVersion.util.PK1;
+import com.arjanvlek.oxygenupdater.settings.adFreeVersion.util.PK2;
 import com.arjanvlek.oxygenupdater.updateinformation.UpdateInformationFragment;
+import com.google.android.gms.ads.AdView;
 import com.google.android.gms.ads.InterstitialAd;
 import com.google.android.gms.ads.MobileAds;
+import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.tabs.TabLayout;
 
 import org.joda.time.LocalDateTime;
 
+import java.util.Collections;
+
 import java8.util.function.Consumer;
 
 import static android.widget.Toast.LENGTH_LONG;
+import static com.arjanvlek.oxygenupdater.settings.SettingsActivity.SKU_AD_FREE;
 import static com.arjanvlek.oxygenupdater.settings.SettingsManager.PROPERTY_ADVANCED_MODE;
 import static com.arjanvlek.oxygenupdater.settings.SettingsManager.PROPERTY_AD_FREE;
 import static com.arjanvlek.oxygenupdater.settings.SettingsManager.PROPERTY_CONTRIBUTE;
@@ -53,6 +64,7 @@ import static com.arjanvlek.oxygenupdater.settings.SettingsManager.PROPERTY_NOTI
 import static com.arjanvlek.oxygenupdater.settings.SettingsManager.PROPERTY_SETUP_DONE;
 import static com.arjanvlek.oxygenupdater.settings.SettingsManager.PROPERTY_SHOW_IF_SYSTEM_IS_UP_TO_DATE;
 import static com.arjanvlek.oxygenupdater.settings.SettingsManager.PROPERTY_UPDATE_CHECKED_DATE;
+import static java.lang.Math.abs;
 
 public class MainActivity extends AppCompatActivity implements OnMenuItemClickListener {
 
@@ -73,6 +85,7 @@ public class MainActivity extends AppCompatActivity implements OnMenuItemClickLi
 
 	private Consumer<Boolean> downloadPermissionCallback;
 	private int activeFragmentPosition;
+	private AdView adView;
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
@@ -134,6 +147,7 @@ public class MainActivity extends AppCompatActivity implements OnMenuItemClickLi
 			// getPreference method has a generic signature, we need to force its return type to be an int,
 			// otherwise it triggers a ClassCastException (which occurs when coming from older app versions)
 			// whilst not assigning it converts it to a long
+			//noinspection unused
 			int downloadId = settingsManager.getPreference(PROPERTY_DOWNLOAD_ID, -1);
 		} catch (ClassCastException e) {
 			settingsManager.deletePreference(PROPERTY_DOWNLOAD_ID);
@@ -217,16 +231,109 @@ public class MainActivity extends AppCompatActivity implements OnMenuItemClickLi
 		ApplicationData application = (ApplicationData) getApplication();
 
 		if (application.checkPlayServices(this, false)) {
-			MobileAds.initialize(this, "ca-app-pub-0760639008316468~7665206420");
+			MobileAds.initialize(this, getString(R.string.advertising_app_id));
 		} else {
 			Toast.makeText(application, getString(R.string.notification_no_notification_support), LENGTH_LONG).show();
 		}
 
 		if (!settingsManager.getPreference(PROPERTY_AD_FREE, false)) {
 			newsAd = new InterstitialAd(this);
-			newsAd.setAdUnitId(getString(R.string.news_ad_unit_id));
+			newsAd.setAdUnitId(getString(R.string.advertising_interstitial_unit_id));
 			newsAd.loadAd(ApplicationData.buildAdRequest());
 		}
+
+		adView = findViewById(R.id.updateInformationAdView);
+
+		AppBarLayout appBar = findViewById(R.id.app_bar);
+		// Since we're using an AppBarLayout with scrollFlags set,
+		// we need to ensure AdView stays at the bottom of the screen
+		// instead of staying hidden until the user scrolls the ViewPager
+		// which hides the AppBar and shows AdView
+		appBar.addOnOffsetChangedListener((appBarLayout, verticalOffset) -> {
+			FrameLayout.LayoutParams layoutParams = (LayoutParams) adView.getLayoutParams();
+			layoutParams.bottomMargin = appBarLayout.getTotalScrollRange() - abs(verticalOffset);
+
+			// keep AdView at the bottom
+			adView.setLayoutParams(layoutParams);
+		});
+
+		checkAdSupportStatus(adsAreSupported -> {
+			if (adsAreSupported) {
+				showAds();
+			}
+		});
+	}
+
+	@Override
+	public void onResume() {
+		super.onResume();
+		if (adView != null) {
+			adView.resume();
+		}
+	}
+
+	@Override
+	public void onPause() {
+		super.onPause();
+		if (adView != null) {
+			adView.pause();
+		}
+	}
+
+	@Override
+	public void onDestroy() {
+		super.onDestroy();
+		if (adView != null) {
+			adView.destroy();
+		}
+	}
+
+	/**
+	 * Checks if ads should be shown
+	 *
+	 * @param callback the callback that receives the result: false if user has purchased ad-free, true otherwise
+	 */
+	private void checkAdSupportStatus(Consumer<Boolean> callback) {
+		IabHelper helper = new IabHelper(this, PK1.A + "/" + PK2.B);
+
+		helper.startSetup(setupResult -> {
+			if (!setupResult.isSuccess()) {
+				// Failed to setup IAB, so we might be offline or the device does not support IAB. Return the last stored value of the ad-free status.
+				callback.accept(!settingsManager.getPreference(PROPERTY_AD_FREE, false));
+				return;
+			}
+
+			try {
+				helper.queryInventoryAsync(true, Collections.singletonList(SKU_AD_FREE), null, (queryResult, inventory) -> {
+					if (!queryResult.isSuccess()) {
+						// Failed to check inventory, so we might be offline. Return the last stored value of the ad-free status.
+						callback.accept(!settingsManager.getPreference(PROPERTY_AD_FREE, false));
+						return;
+					}
+
+					if (queryResult.isSuccess()) {
+						if (inventory.hasPurchase(SKU_AD_FREE)) {
+							// User has bought the upgrade. Save this to the app's settings and return that ads may not be shown.
+							settingsManager.savePreference(PROPERTY_AD_FREE, true);
+							callback.accept(false);
+						} else {
+							// User has not bought the item and we're online, so ads are definitely supported
+							callback.accept(true);
+						}
+					}
+				});
+			} catch (IabHelper.IabAsyncInProgressException e) {
+				// A check is already in progress, so wait 3 secs and try to check again.
+				new Handler().postDelayed(() -> checkAdSupportStatus(callback), 3000);
+			}
+		});
+	}
+
+	/**
+	 * Loads an ad
+	 */
+	private void showAds() {
+		adView.loadAd(ApplicationData.buildAdRequest());
 	}
 
 	public void displayUnsupportedDeviceMessage() {
@@ -265,7 +372,7 @@ public class MainActivity extends AppCompatActivity implements OnMenuItemClickLi
 			return newsAd;
 		} else if (mayShowNewsAd()) {
 			InterstitialAd interstitialAd = new InterstitialAd(this);
-			interstitialAd.setAdUnitId(getString(R.string.news_ad_unit_id));
+			interstitialAd.setAdUnitId(getString(R.string.advertising_interstitial_unit_id));
 			interstitialAd.loadAd(ApplicationData.buildAdRequest());
 			newsAd = interstitialAd;
 			return newsAd;
@@ -275,10 +382,9 @@ public class MainActivity extends AppCompatActivity implements OnMenuItemClickLi
 	}
 
 	public boolean mayShowNewsAd() {
-		return !settingsManager.getPreference(PROPERTY_AD_FREE, false) &&
-				LocalDateTime.parse(settingsManager.getPreference(PROPERTY_LAST_NEWS_AD_SHOWN, "1970-01-01T00:00:00.000"))
-						.isBefore(LocalDateTime.now().minusMinutes(5));
-
+		return !settingsManager.getPreference(PROPERTY_AD_FREE, false)
+				&& LocalDateTime.parse(settingsManager.getPreference(PROPERTY_LAST_NEWS_AD_SHOWN, "1970-01-01T00:00:00.000"))
+				.isBefore(LocalDateTime.now().minusMinutes(5));
 	}
 
 	public ActivityLauncher getActivityLauncher() {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -44,6 +44,6 @@
 			android:layout_height="wrap_content"
 			android:layout_gravity="bottom|center_horizontal"
 			app:adSize="BANNER"
-			app:adUnitId="@string/advertising_app_id" />
+			app:adUnitId="@string/advertising_banner_unit_id" />
 	</FrameLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -28,9 +28,22 @@
 			app:tabMode="auto" />
 	</com.google.android.material.appbar.AppBarLayout>
 
-	<androidx.viewpager.widget.ViewPager
-		android:id="@+id/viewpager"
+	<FrameLayout
 		android:layout_width="match_parent"
 		android:layout_height="match_parent"
-		app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+		app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+		<androidx.viewpager.widget.ViewPager
+			android:id="@+id/viewpager"
+			android:layout_width="match_parent"
+			android:layout_height="match_parent" />
+
+		<com.google.android.gms.ads.AdView
+			android:id="@+id/updateInformationAdView"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_gravity="bottom|center_horizontal"
+			app:adSize="BANNER"
+			app:adUnitId="@string/advertising_app_id" />
+	</FrameLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_update_information.xml
+++ b/app/src/main/res/layout/fragment_update_information.xml
@@ -1,5 +1,4 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-	xmlns:ads="http://schemas.android.com/apk/res-auto"
 	xmlns:tools="http://schemas.android.com/tools"
 	android:id="@+id/updateInformationFragmentTop"
 	android:layout_width="match_parent"
@@ -19,7 +18,6 @@
 		android:id="@+id/updateInformationRefreshLayout"
 		android:layout_width="match_parent"
 		android:layout_height="match_parent"
-		android:layout_above="@+id/updateInformationAdView"
 		android:visibility="gone"
 		tools:visibility="visible">
 
@@ -190,8 +188,8 @@
 		android:id="@+id/updateInformationSystemIsUpToDateRefreshLayout"
 		android:layout_width="match_parent"
 		android:layout_height="match_parent"
-		android:layout_above="@+id/updateInformationAdView"
-		android:visibility="gone">
+		android:visibility="gone"
+		tools:visibility="visible">
 
 		<androidx.core.widget.NestedScrollView
 			android:layout_width="match_parent"
@@ -244,13 +242,4 @@
 			</LinearLayout>
 		</androidx.core.widget.NestedScrollView>
 	</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
-
-	<com.google.android.gms.ads.AdView
-		android:id="@+id/updateInformationAdView"
-		android:layout_width="wrap_content"
-		android:layout_height="wrap_content"
-		android:layout_alignParentBottom="true"
-		android:layout_centerHorizontal="true"
-		ads:adSize="BANNER"
-		ads:adUnitId="@string/advertising_id" />
 </RelativeLayout>

--- a/app/src/main/res/layout/loading.xml
+++ b/app/src/main/res/layout/loading.xml
@@ -1,14 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:app="http://schemas.android.com/apk/res-auto"
 	android:layout_width="match_parent"
-	android:layout_height="match_parent"
-	android:gravity="center_vertical"
-	android:orientation="vertical">
+	android:layout_height="match_parent">
+
+	<com.google.android.material.appbar.AppBarLayout
+		android:id="@+id/app_bar"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content">
+
+		<androidx.appcompat.widget.Toolbar
+			android:id="@+id/toolbar"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+			app:popupTheme="@style/ToolbarPopupStyle"
+			app:title="@string/app_name" />
+	</com.google.android.material.appbar.AppBarLayout>
 
 	<ProgressBar
 		style="?android:attr/progressBarStyleLarge"
 		android:layout_width="70dp"
 		android:layout_height="70dp"
-		android:layout_gravity="center_horizontal" />
-
-</LinearLayout>
+		android:layout_gravity="center_horizontal"
+		app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -404,8 +404,9 @@
 	<string name="loading">Loading…</string>
 	<string name="processing">Processing…</string>
 	<string name="choose_file">Select a file</string>
-	<string name="advertising_id" translatable="false">ca-app-pub-0760639008316468/9141939623</string>
-	<string name="news_ad_unit_id" translatable="false">ca-app-pub-0760639008316468/3566614035</string>
+	<string name="advertising_app_id" translatable="false">ca-app-pub-1816831161514116~4275332954</string>
+	<string name="advertising_banner_unit_id" translatable="false">ca-app-pub-1816831161514116/9792024147</string>
+	<string name="advertising_interstitial_unit_id" translatable="false">ca-app-pub-1816831161514116/8641953374</string>
 	<string name="root_install_logger_service_name">Update installation logger</string>
 	<string name="delayed_push_notification_displayer_service_name">Push Notification Service</string>
 	<string name="download_service_name">Update downloader</string>

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 		google()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:3.4.2'
+		classpath 'com.android.tools.build:gradle:3.5.0'
 		classpath 'com.google.gms:google-services:4.3.0'
 		classpath 'io.fabric.tools:gradle:1.31.0'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri May 31 17:32:03 CEST 2019
+#Wed Aug 21 11:23:25 IST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
_Relevant APKs have been uploaded to our drive for testing_

## What's changed?
- Updated advertising IDs to prepare for Play Store and AdMob account transfer
- Fixed UI bug which hid the AdView from the user until he scrolled downwards  
  This wasn't an issue in `v2.7.6`. Cropped up after we switched to `AppBarLayout` in `v3.0.0`, because of `scrollFlags` being set to `scroll|snap|enterAlways`  
  Fix was to move `AdView` out of `UpdateInformationFragment`, and make it persistent in `MainActivity`.  
  **Need feedback on this: user will now see an ad on all 3 screens (_News_, _Update Information_, _My Device_). Earlier the ad was only visible in _Update Information_.** Discuss in Discord

## TODO
- Update `google-services.json` after linking AdMob to Firebase (that file currently contains an old `advertising_app_id`