### PR TITLE
Commit SettingsFragment synchronously to avoid crash during IAB setup

### DIFF
--- a/app/src/main/java/com/arjanvlek/oxygenupdater/settings/SettingsActivity.java
+++ b/app/src/main/java/com/arjanvlek/oxygenupdater/settings/SettingsActivity.java
@@ -70,7 +70,7 @@ public class SettingsActivity extends SupportActionBarActivity implements InAppP
 		getSupportFragmentManager().beginTransaction()
 				.setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
 				.replace(R.id.settings_container, settingsFragment, "Settings")
-				.commit();
+				.commitNow();
 
 		settingsManager = new SettingsManager(getApplicationContext());
 


### PR DESCRIPTION
## Bug
- On some devices, `SettingsFragment` wasn't attached to the activity before `setupIabHelper` was called.  

This lead to a rare crash with the following pseudo-stacktrace:
```kotlin
SettingsActivity.setupIabHelper()
    -> SettingsActivity.logIABError()
    -> SettingsFragment.setupBuyAdFreePreference()
    -> [crash due to null context]
```
Crash occurred due to `SettingsFragment.setupBuyAdFreePreference()` being called before the fragment was attached to the activity (meaning null context and uninitialised preference views)

## Fix
- Commit synchronously instead
