### PR TITLE
Removed redundant logging messages of fragments not being added

### DIFF
--- a/app/src/main/java/com/arjanvlek/oxygenupdater/deviceinformation/DeviceInformationFragment.java
+++ b/app/src/main/java/com/arjanvlek/oxygenupdater/deviceinformation/DeviceInformationFragment.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java8.util.stream.StreamSupport;
 
 import static com.arjanvlek.oxygenupdater.ApplicationData.NO_OXYGEN_OS;
+import static com.arjanvlek.oxygenupdater.internal.logger.Logger.logDebug;
 import static com.arjanvlek.oxygenupdater.internal.logger.Logger.logError;
 import static com.arjanvlek.oxygenupdater.internal.logger.Logger.logWarning;
 
@@ -44,7 +45,7 @@ public class DeviceInformationFragment extends AbstractFragment {
 	@Override
 	public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
 		if (!isAdded()) {
-			logError(TAG, new OxygenUpdaterException("Fragment not added. Can not create the view!"));
+			logDebug(TAG, "Fragment not added. Can not create the view!");
 			return;
 		}
 
@@ -54,7 +55,7 @@ public class DeviceInformationFragment extends AbstractFragment {
 
 	private void displayFormattedDeviceName(List<Device> devices) {
 		if (!isAdded()) {
-			logError(TAG, new OxygenUpdaterException("Fragment not added. Can not display formatted device name!"));
+			logDebug(TAG, "Fragment not added. Can not display formatted device name!");
 			return;
 		}
 
@@ -71,7 +72,7 @@ public class DeviceInformationFragment extends AbstractFragment {
 
 	private void displayDeviceInformation() {
 		if (!isAdded()) {
-			logError(TAG, new OxygenUpdaterException("Fragment not added. Can not display device information!"));
+			logDebug(TAG, "Fragment not added. Can not display device information!");
 			return;
 		}
 

--- a/app/src/main/java/com/arjanvlek/oxygenupdater/installation/manual/InstallGuideFragment.java
+++ b/app/src/main/java/com/arjanvlek/oxygenupdater/installation/manual/InstallGuideFragment.java
@@ -33,6 +33,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 
 import static com.arjanvlek.oxygenupdater.ApplicationData.NUMBER_OF_INSTALL_GUIDE_PAGES;
+import static com.arjanvlek.oxygenupdater.internal.logger.Logger.logDebug;
 import static com.arjanvlek.oxygenupdater.internal.logger.Logger.logError;
 import static com.arjanvlek.oxygenupdater.internal.logger.Logger.logWarning;
 import static com.arjanvlek.oxygenupdater.settings.SettingsManager.PROPERTY_DEVICE_ID;
@@ -119,7 +120,7 @@ public class InstallGuideFragment extends Fragment {
 	private void displayInstallGuide(View installGuideView, InstallGuidePage installGuidePage, int pageNumber, boolean isFirstPage) {
 		if (!isAdded()) {
 			// Happens when a page is scrolled too far outside the screen (2 or more rows) and content then gets resolved from the server.
-			logError(TAG, new OxygenUpdaterException("isAdded() returned false (displayInstallGuide)"));
+			logDebug(TAG, "isAdded() returned false (displayInstallGuide)");
 			return;
 		}
 

--- a/app/src/main/java/com/arjanvlek/oxygenupdater/news/NewsFragment.java
+++ b/app/src/main/java/com/arjanvlek/oxygenupdater/news/NewsFragment.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import java8.util.function.Consumer;
 
+import static com.arjanvlek.oxygenupdater.internal.logger.Logger.logDebug;
 import static com.arjanvlek.oxygenupdater.internal.logger.Logger.logError;
 
 public class NewsFragment extends AbstractFragment {
@@ -67,7 +68,7 @@ public class NewsFragment extends AbstractFragment {
 		newsContainer.setLayoutManager(new LinearLayoutManager(getContext()));
 
 		if (!isAdded()) {
-			logError(TAG, new OxygenUpdaterException("isAdded() returned false (displayNewsItems)"));
+			logDebug(TAG, "isAdded() returned false (displayNewsItems)");
 			return;
 		}
 

--- a/app/src/main/res/values-nl-rBE/strings.xml
+++ b/app/src/main/res/values-nl-rBE/strings.xml
@@ -76,7 +76,7 @@
 	<string name="download_progress_text_one_minute_remaining">%1$d%%, ongeveer een minuut resterend</string>
 	<string name="download_progress_text_seconds_remaining">%1$d%%, enkele seconden resterend</string>
 	<string name="download_progress_text_unknown_time_remaining">%1$d%%, resterende tijd berekenen…</string>
-	<string name="download_progress_text_verifying">100 %, controleren op fouten…</string>
+	<string name="download_progress_text_verifying">100%%, controleren op fouten…</string>
 	<string name="download_progress_text_paused">%1$d%%, gepauzeerd…</string>
 	<string name="download_waiting_for_network">%1$d%%, wachten op een netwerkverbinding…</string>
 

--- a/app/src/main/res/values-nl-rNL/strings.xml
+++ b/app/src/main/res/values-nl-rNL/strings.xml
@@ -76,7 +76,7 @@
 	<string name="download_progress_text_one_minute_remaining">%1$d%%, ongeveer een minuut resterend</string>
 	<string name="download_progress_text_seconds_remaining">%1$d%%, enkele seconden resterend</string>
 	<string name="download_progress_text_unknown_time_remaining">%1$d%%, resterende tijd berekenen…</string>
-	<string name="download_progress_text_verifying">100 %, controleren op fouten…</string>
+	<string name="download_progress_text_verifying">100%%, controleren op fouten…</string>
 	<string name="download_progress_text_paused">%1$d%%, gepauzeerd…</string>
 	<string name="download_waiting_for_network">%1$d%%, wachten op een netwerkverbinding…</string>
 


### PR DESCRIPTION
## What's changed?

These messages cluttered up the logs a lot and are common due to the 
async nature of the app. As long as these are handled correctly 
(and they already were) this is not an important event that 
should be logged.

![useless-error-loggings](https://user-images.githubusercontent.com/10106652/63972021-23799d80-caa8-11e9-8bc3-eb4507e783f3.png)


Also fixed build errors in Dutch / Belgian strings (% needs to be
escaped by writing it as %%).

```
Errors found:

  C:\Users\Arjan\development\oxygen-updater\oxygen-updater-app\app\src\main\res\values-nl-rBE\strings.xml:79: Error: Incorrect formatting string download_progress_text_verifying; missing conversion character in '%, c' ? [StringFormatInvalid]
   <string name="download_progress_text_verifying">100 %, controleren op foutenà</string>
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  C:\Users\Arjan\development\oxygen-updater\oxygen-updater-app\app\src\main\res\values-nl-rNL\strings.xml:79: Error: Incorrect formatting string download_progress_text_verifying; missing conversion character in '%, c' ? [StringFormatInvalid]
   <string name="download_progress_text_verifying">100 %, controleren op foutenà</string>
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```