### PR TITLE
bugfix: AdView occupies space when not needed

### DIFF
--- a/app/src/main/java/com/arjanvlek/oxygenupdater/views/MainActivity.java
+++ b/app/src/main/java/com/arjanvlek/oxygenupdater/views/MainActivity.java
@@ -258,7 +258,10 @@ public class MainActivity extends AppCompatActivity implements OnMenuItemClickLi
 
 		checkAdSupportStatus(adsAreSupported -> {
 			if (adsAreSupported) {
+				adView.setVisibility(View.VISIBLE);
 				showAds();
+			} else {
+				adView.setVisibility(View.GONE);
 			}
 		});
 	}


### PR DESCRIPTION
#74 introduced a layout bug where the AdView occupied space even when ads aren't shown.

Fixed by setting view visibility to `GONE`
