### PR TITLE
Fixes #87: Marking news item read didn't affect RecyclerView until re-drawn

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -177,19 +177,19 @@ dependencies {
 	// https://developer.android.com/jetpack/androidx/releases/appcompat
 	implementation 'androidx.appcompat:appcompat:1.1.0'
 	// https://developer.android.com/jetpack/androidx/releases/browser
-	implementation 'androidx.browser:browser:1.2.0-alpha09'
+	implementation 'androidx.browser:browser:1.2.0'
 	// https://developer.android.com/jetpack/androidx/releases/constraintlayout
-	implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta3'
+	implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta4'
 	// https://developer.android.com/jetpack/androidx/releases/fragment
-	implementation 'androidx.fragment:fragment:1.2.0-rc02'
+	implementation 'androidx.fragment:fragment:1.2.0-rc04'
 	// https://developer.android.com/jetpack/androidx/releases/preference
 	implementation 'androidx.preference:preference:1.1.0'
 	// https://developer.android.com/jetpack/androidx/releases/recyclerview
-	implementation 'androidx.recyclerview:recyclerview:1.1.0-rc01'
+	implementation 'androidx.recyclerview:recyclerview:1.1.0'
 
 	// Google Material Components for Android
 	// https://github.com/material-components/material-components-android/releases
-	implementation 'com.google.android.material:material:1.2.0-alpha01'
+	implementation 'com.google.android.material:material:1.2.0-alpha02'
 
 	// JSON libraries
 	implementation 'com.fasterxml.jackson.core:jackson-core:2.9.9'
@@ -202,7 +202,7 @@ dependencies {
 	// Google Firebase
 	// https://firebase.google.com/support/release-notes/android
 	implementation 'com.google.firebase:firebase-ads:18.3.0'
-	implementation 'com.google.firebase:firebase-messaging:20.0.0'
+	implementation 'com.google.firebase:firebase-messaging:20.1.0'
 	implementation 'com.google.android.gms:play-services-base:17.1.0'
 	implementation 'com.crashlytics.sdk.android:crashlytics:2.10.1'
 

--- a/app/src/main/java/com/arjanvlek/oxygenupdater/news/NewsFragment.java
+++ b/app/src/main/java/com/arjanvlek/oxygenupdater/news/NewsFragment.java
@@ -19,6 +19,7 @@ import com.arjanvlek.oxygenupdater.views.AbstractFragment;
 import com.arjanvlek.oxygenupdater.views.AlphaInAnimationAdapter;
 import com.arjanvlek.oxygenupdater.views.MainActivity;
 import com.arjanvlek.oxygenupdater.views.NewsAdapter;
+import com.arjanvlek.oxygenupdater.views.NewsAdapter.NewsItemReadListener;
 
 import java.util.List;
 
@@ -27,10 +28,12 @@ import java8.util.function.Consumer;
 import static com.arjanvlek.oxygenupdater.internal.logger.Logger.logDebug;
 import static com.arjanvlek.oxygenupdater.internal.logger.Logger.logError;
 
-public class NewsFragment extends AbstractFragment {
+public class NewsFragment extends AbstractFragment implements NewsItemReadListener {
 
 	private static final String TAG = "NewsFragment";
 	private boolean hasBeenLoadedOnce = false;
+
+	private AlphaInAnimationAdapter alphaInAnimationAdapter;
 
 	@Override
 	public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
@@ -62,7 +65,7 @@ public class NewsFragment extends AbstractFragment {
 		RecyclerView newsContainer = view.findViewById(R.id.newsContainer);
 
 		// animate items when they load
-		AlphaInAnimationAdapter alphaInAnimationAdapter = new AlphaInAnimationAdapter(new NewsAdapter(getContext(), (MainActivity) getActivity(), newsItems));
+		alphaInAnimationAdapter = new AlphaInAnimationAdapter(new NewsAdapter(getContext(), (MainActivity) getActivity(), this, newsItems));
 		alphaInAnimationAdapter.setFirstOnly(false);
 		newsContainer.setAdapter(alphaInAnimationAdapter);
 		newsContainer.setLayoutManager(new LinearLayoutManager(getContext()));
@@ -89,5 +92,10 @@ public class NewsFragment extends AbstractFragment {
 		}
 
 		return 10;
+	}
+
+	@Override
+	public void onNewsItemRead(int position) {
+		alphaInAnimationAdapter.notifyItemChanged(position);
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ buildscript {
 		google()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:3.5.2'
-		classpath 'com.google.gms:google-services:4.3.2'
+		classpath 'com.android.tools.build:gradle:3.5.3'
+		classpath 'com.google.gms:google-services:4.3.3'
 		classpath 'io.fabric.tools:gradle:1.31.0'
 
 		// NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
## What's changed?
- `RecyclerView` only updates views when it needs to. Had to call `adapter.notifyItemChanged(position)` to reflect changes in underlying data correctly
- This PR also includes dependency updates
