### PR TITLE
Added support for reading `ro.build.eu` and `ro.vendor.build.eu`

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,8 +19,8 @@ android {
 		applicationId 'com.arjanvlek.oxygenupdater'
 		minSdkVersion 21
 		targetSdkVersion 28
-		versionCode 62
-		versionName '3.7.0'
+		versionCode 63
+		versionName '3.8.0'
 		testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
 		proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
 	}

--- a/app/src/main/java/com/arjanvlek/oxygenupdater/ApplicationData.java
+++ b/app/src/main/java/com/arjanvlek/oxygenupdater/ApplicationData.java
@@ -71,7 +71,7 @@ public class ApplicationData extends Application {
 		// Store the system version properties in a cache, to prevent unnecessary calls to the native "getProp" command.
 		if (systemVersionProperties == null) {
 			logVerbose(TAG, "Creating new SystemVersionProperties instance...");
-			systemVersionProperties = new SystemVersionProperties();
+			systemVersionProperties = new SystemVersionProperties(this);
 		} else {
 			logVerbose(TAG, "Using cached instance of SystemVersionProperties");
 		}

--- a/app/src/main/java/com/arjanvlek/oxygenupdater/installation/InstallActivity.java
+++ b/app/src/main/java/com/arjanvlek/oxygenupdater/installation/InstallActivity.java
@@ -203,7 +203,7 @@ public class InstallActivity extends SupportActionBarActivity {
 			boolean rebootDevice = settingsManager.getPreference(SettingsManager.PROPERTY_REBOOT_AFTER_INSTALL, true);
 
 			// Plan install verification on reboot.
-			SystemVersionProperties systemVersionProperties = new SystemVersionProperties();
+			SystemVersionProperties systemVersionProperties = new SystemVersionProperties(this);
 			String currentOSVersion = systemVersionProperties.getOxygenOSOTAVersion();
 			boolean isAbPartitionLayout = systemVersionProperties.isABPartitionLayout();
 			String targetOSVersion = updateData.getOtaVersionNumber();

--- a/app/src/main/java/com/arjanvlek/oxygenupdater/installation/automatic/VerifyInstallationReceiver.java
+++ b/app/src/main/java/com/arjanvlek/oxygenupdater/installation/automatic/VerifyInstallationReceiver.java
@@ -39,7 +39,7 @@ public class VerifyInstallationReceiver extends BroadcastReceiver {
 					.equals("android.intent.action.BOOT_COMPLETED")) {
 				settingsManager.savePreference(SettingsManager.PROPERTY_VERIFY_SYSTEM_VERSION_ON_REBOOT, false);
 
-				SystemVersionProperties properties = new SystemVersionProperties();
+				SystemVersionProperties properties = new SystemVersionProperties(context);
 
 				// Don't check on unsupported devices.
 				if (properties.getOxygenOSVersion()

--- a/app/src/main/java/com/arjanvlek/oxygenupdater/internal/server/ServerConnector.java
+++ b/app/src/main/java/com/arjanvlek/oxygenupdater/internal/server/ServerConnector.java
@@ -273,6 +273,7 @@ public class ServerConnector implements Cloneable {
 		JSONObject postBody = new JSONObject();
 		try {
 			postBody.put("filename", filename);
+			postBody.put("isEuBuild", settingsManager.getPreference(SettingsManager.PROPERTY_IS_EU_BUILD, false));
 		} catch (JSONException e) {
 			ServerPostResult errorResult = new ServerPostResult();
 			errorResult.setSuccess(false);

--- a/app/src/main/java/com/arjanvlek/oxygenupdater/settings/SettingsManager.java
+++ b/app/src/main/java/com/arjanvlek/oxygenupdater/settings/SettingsManager.java
@@ -46,6 +46,7 @@ public class SettingsManager {
 	public static final String PROPERTY_LAST_NEWS_AD_SHOWN = "lastNewsAdShown";
 	public static final String PROPERTY_CONTRIBUTE = "contribute";
 	public static final String PROPERTY_CONTRIBUTION_COUNT = "contribution_count";
+	public static final String PROPERTY_IS_EU_BUILD = "isEuBuild";
 
 	// Offline cache properties
 	public static final String PROPERTY_OFFLINE_ID = "offlineId";


### PR DESCRIPTION
OB1 for 7T-series introduced these fields, which were only present on EU builds.
This info is useful to differentiate between EU and global builds (OB1 for 7T-series had no clear distinction in the file name for this purpose).

The value of these fields (either `true` or `false`) is sent as part of the body of the POST request `/submit-update-file`. The backend then constructs the webhook accordingly, which helps contributors immediately know for sure, which region is the ZIP meant for (for the `#contributors` channel in our [Discord server](https://discord.gg/5TXdhKJ))

Read https://oxygenupdater.com/api/v2.4/news-content/102/EN for more info.
