### PR TITLE
Fixed News and FAQ not working on older devices

### DIFF
--- a/app/src/main/java/com/arjanvlek/oxygenupdater/internal/WebViewClient.kt
+++ b/app/src/main/java/com/arjanvlek/oxygenupdater/internal/WebViewClient.kt
@@ -88,6 +88,8 @@ class WebViewClient(
 
     /**
      * Just invokes the callback, nothing special
+     * Used on API 23+
+     * (see https://developer.android.com/reference/android/webkit/WebViewClient#onPageCommitVisible(android.webkit.WebView,%20java.lang.String))
      */
     override fun onPageCommitVisible(
         view: WebView?,
@@ -95,6 +97,17 @@ class WebViewClient(
     ) = super.onPageCommitVisible(view, url).also {
         logDebug(TAG, "Page commit visible for: $url")
         pageCommitVisibleCallback.invoke(error)
+    }
+
+    /**
+     * Just invokes the callback, nothing special
+     * Used on API 21 and 22
+     */
+    override fun onPageFinished(view: WebView?, url: String?) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            logDebug(TAG, "Page finished for: $url")
+            pageCommitVisibleCallback.invoke(error);
+        }
     }
 
     /**


### PR DESCRIPTION
## What's changed?
When taking a look at the new versions 4.0.0 and 4.0.1, I saw that the
news and FAQ were not working anymore. It turned out these were broken
on very old Android versions (API < 23) only.

I've fixed it mainly for an upcoming video about what the app has
become since I've transferred ownership. I don't expect much users on
these old Android versions to be affected.

Note: while the pages load now, The layout has whitespace issues at the
top and bottom once scrolling down the page. I don't know if these are
also specific to the ancient device I'm using, but i'd like to mention
it anyway.

## Screenshots:

Before patch:
![B81455C0-198F-441D-B2B1-E0DC47FC330C](https://user-images.githubusercontent.com/10106652/79139319-63cb2900-7db6-11ea-884a-73bdbc765cf9.jpeg)

After patch:
![8C08A9C4-BD86-4C75-9341-FC845A067FFC](https://user-images.githubusercontent.com/10106652/79139325-66c61980-7db6-11ea-8d32-38217aee5cf9.jpeg)

