### PR TITLE
[v6] String-only changes relative to v5.11.3 (last release before v6)

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools" tools:keep="@string/install_guide_page_*_*">
-	<!-- TODO: translate this string below -->
-	<string name="device_chooser_error_title">Couldn\'t retrieve list of supported devices</string>
-
+<resources>
 	<!-- Update information strings-->
 	<!-- TODO: translate this string below -->
 	<string name="enable">ممكن</string>
-	<string name="update_information_description_not_available">لا توجد بيانات رسمية عن الميزات الجديدة التي يقدمها هذا التحديث. عادتاً, تحديث كهذا يقدم إصلاحات لأخطاء برمجية, وتحسينات في الأداء, و \ أو تحديثات أمنية حرجة لجهازك.</string>
+	<string name="update_information_description_not_available">لا توجد بيانات رسمية عن الميزات الجديدة التي يقدمها هذا التحديث. عادتاً, تحديث كهذا يقدم إصلاحات لأخطاء برمجية, وتحسينات في الأداء, و / أو تحديثات أمنية حرجة لجهازك.</string>
 	<string name="update_information_file_name">إسم الملف: %1$s</string>
 	<!-- TODO: translate this line below -->
 	<string name="update_information_md5">MD5: %1$s</string>
@@ -16,13 +13,12 @@
 	<!-- TODO: translate these 6 strings below -->
 	<string name="update_information_error_title">Couldn\'t retrieve latest update data information</string>
 	<string name="update_information_banner_server">Tap here to view important notices</string>
-	<string name="update_information_banner_advanced_mode_tip">You\'ve selected the \"%1$s\" update track. Enable الوضع المطور if you plan to switch to this update track.</string>
+	<string name="update_information_banner_advanced_mode_tip">You\'ve selected the \"%1$s\" update method. Enable الوضع المطور if you plan to switch to this update method.</string>
 	<string name="update_information_header_advanced_mode_hint">الوضع المتقدم ممكّن</string>
-	<string name="update_information_header_advanced_mode_helper">Since you\'ve enabled الوضع المطور, you can download the latest ZIP for \"%1$s\".\n\nYou can turn الوضع المطور off from settings.</string>
-	<string name="update_information_different_version_changelog_notice">You\'re viewing a changelog for the latest update in the \"%1$s\" upgrade track. If you intend to install this update, you must turn الوضع المطور on first (in settings).\n\nHowever, if you wish to see the changelog for the currently installed version instead, you\'ll need to switch back to the correct update method.</string>
-	<string name="update_information_last_checked_on">أخر فحص تم في: %1$s</string>
+	<string name="update_information_header_advanced_mode_helper">Since you\'ve enabled الوضع المطور, you can download the latest ZIP for \"%1$s\". You can turn الوضع المطور off from settings.</string>
+	<string name="update_information_different_version_changelog_notice_base">ملاحظة: سجل التغيير هذا لأحدث إصدار متوفر (%1$s) في طريقة التحديث \"%2$s\"</string>
+	<string name="update_information_different_version_changelog_notice_advanced">. إذا كنت تنوي تثبيت هذا التحديث ، يجب تمكين \"الوضع المطور\" في الإعدادات.</string>
 	<string name="update_information_no_update_data_available">لا توجد بيانات متاحة عن التحديث</string>
-	<string name="update_information_oxygen_os_version">OxygenOS %1$s</string>
 	<string name="update_information_system_is_up_to_date">نظامك محدث بالفعل</string>
 	<string name="update_information_unknown_update_name">تحديث بلا إسم لـ %1$s</string>
 	<string name="update_information_view_update_information">مشاهدة بيانات التحديث</string>
@@ -93,9 +89,7 @@ If you\'d like to know more, feel free to contact us either via <a href="mailto:
 	<string name="summary_please_wait">فضلاً إنتظر…</string>
 	<string name="summary_update_method">إختر جهازاً أولاً</string>
 	<!-- TODO: check the following translation -->
-	<string name="summary_important_notifications_disabled">تم تعطيل بعض الإشعارات المهمة: \"%1$s\"</string>
-	<string name="summary_theme">تعيين شكل</string>
-	<string name="summary_language">لغة مجموعة</string>
+	<string name="summary_important_notifications_disabled">تم تعطيل بعض الإشعارات المهمة:</string>
 	<string name="summary_privacy_policy">مشاهدة حية</string>
 	<string name="summary_rate_app">أترك مراجعة من خمس نجوم</string>
 	<string name="label_buy_ad_free">إزالة الإعلانات</string>
@@ -122,74 +116,41 @@ If you\'d like to know more, feel free to contact us either via <a href="mailto:
 	<string name="settings_contribute_label">المساعدة في تحسين التطبيق</string>
 	<string name="settings_device">الجهاز</string>
 	<string name="settings_entered_incorrectly">خطأ في حفظ إعداداتك. فضلاً عد وإختر جهازك وطريقة التحديث مرة أخرى.</string>
-	<string name="settings_explanation_incremental_full_update">التحديث التدريجي يمكن تثبيته فوق أي إصدار ( ماعدا اذا قمت بفك البوت لودر; إذاً فمن الأفضل دائماً إختيار التحديث الشامل كطريقة التحديث المثلى).\n\nA التحديث التجريبي من نظام أكسجين يمكن تثبيته دائماً, حتى اذا كنت على إصدار مستقر. للإنتقال من إصدار مستقر لإصدار تجريبي, يجب عليك تفعيل الوضع المطور من داخل الإعدادات. أما للإصدارات التجريبية فالتحديثات التدريجية والكاملة تعمل بنفس الطريقة السابقة كأن جهازك يعمل فعلاً بإصدار مستقر حالي.</string>
 	<string name="settings_push_from_server">رسائل معلوماتية وتحذيرية</string>
 	<string name="settings_saving">جاري حفظ إعداداتك. اذا إستغرق ذلك وقتاً طويلاً: أفحص اتصالك, وأخرج من التطبيق وأفتحه مجدداً.</string>
 	<string name="settings_advanced_mode">الوضع المطور</string>
-	<string name="settings_advanced_mode_explanation">الوضع المطور يقوم بإخفاء رسالة (نظامك محدث بالفعل) سامحاً لك بتحميل وتثبيت جميع التحديثات, حتى وإن لم تكن متوافقة مع جهازك. ربما يكون هذا مفيداً في حالة الترقية من إصدار إعتيادي إلى إصدار تجريبي أو العكس, (لا تنسى إعادة تهيئة جهازك).</string>
+	<string name="settings_advanced_mode_explanation">"عادةً ، يعرض لك التطبيق تحديثات بناءً على إصدار نظام التشغيل الحالي لديك. مع الوضع المتقدم ، سيتم دائمًا عرض آخر تحديث متوفر بغض النظر عن توافق الجهاز / الإصدار.
+
+يمكن أن يكون هذا مفيدًا إذا كنت تريد:"</string>
+	<string name="settings_advanced_mode_uses">"&#8226; أعد تنزيل أحدث إصدار حتى إذا كنت تستخدمه بالفعل
+&#8226; التبديل إلى مسار تحديث مختلف"</string>
+	<string name="settings_advanced_mode_caption">"قد تكون هناك حاجة إلى الوضع المتقدم فقط في المواقف المذكورة أعلاه. يجب ألا تقوم بتمكينه إلا إذا كنت تعرف ما تفعله."</string>
 	<string name="settings_update_method">طريقة التحديث</string>
 	<string name="settings_upload_logs">مشاركة بيانات الإستخدام والسجل</string>
+	<string name="settings_ad_privacy">الموافقة على إعلان القانون العام لحماية البيانات (GDPR).</string>
+	<string name="settings_ad_privacy_subtitle">"لمستخدمي المنطقة الاقتصادية الأوروبية/المملكة المتحدة"</string>
 
 	<!-- FAQ strings -->
 	<string name="faq">التعليمات</string>
 	<string name="faq_menu_item">التعليمات</string>
 
 	<!-- First-time setup strings -->
-	<string name="onboarding">مرحباً</string>
+	<string name="onboarding">نصب</string>
 	<string name="onboarding_finished_button">بدء التطبيق</string>
-	<string name="onboarding_page_1_title">مرحباً بك في Oxygen Updater!</string>
-	<string name="onboarding_page_1_text">هذا التطبيق يتيح لك:\n\n&#8226; الوصول سريعاً إلى آخر تحديثات أندرويد لنظام أكسجين\n\n&#8226; التحديث بشكل مبسط للأجهزة التي تملك (روت)\n\n&#8226; مشاهدة كل ماهو جديد في النظام الذي تستعمله حالياً\n\n&#8226; قراءة أخر الأخبار حول جهاز ون بلس ونظام أكسجين\n\nإسحب إلى اليسار للإستمرار.</string>
-	<string name="onboarding_page_1_caption">هذا التطبيق لا يعتبر تطبيق رسمي من شركة ون بلس. وإستعمال هذا التطبيق على مسؤوليتك الخاصة كاملاً. لا شركة ون بلس ولا المطور مسؤولين عن أعمالك ويشتمل ذلك أي أضرار تنتج عن إستعمال هذا التطبيق.\n\nبإستعمالك هذا التطبيق فأنت تعتبر موافقاً على الأحكام والشروط التي ذكرت بالأعلى.</string>
-	<string name="onboarding_page_2_title">إختر جهازك</string>
-	<string name="onboarding_page_2_caption">جهازك غالباً تم إختياره بالأعلى. إذا لم يكن كذلك قم انت بإختياره من الأعلى.\n\إسحب إلى اليسار للإستمرار.</string>
-	<string name="onboarding_page_3_title">إختر الطريقة التي تفضلها للتحديث</string>
-	<string name="onboarding_page_3_caption">عادتاً, التحديث التدريجي هو الإختيار الأمثل هنا, لعرضه تحميلات أسرع وأصغر.\n\nعلى كل حال, لا يعتبر ذلك مناسباً للأجهزة التي تملك (روت). اذا كنت تملك جهاز ذو (روت) مفعل, فأختر التحديث الكامل.</string>
-	<string name="onboarding_page_4_title">هل انت جاهز للبدء!</string>
-	<string name="onboarding_page_4_text">إستمتع بهذا التطبيق!\n\nيمكنك دائماً تغيير إعداداتك لاحقاً. لعمل ذلك كل ما عليك هو: الضغط على الثلاث نقاط المتواجدة في أعلى الجانب الأيمن, وأضغط على \"الإعدادات\".</string>
+	<string name="onboarding_app_uses">هذا التطبيق يتيح لك:\n\n&#8226; الوصول سريعاً إلى آخر تحديثات أندرويد لنظام أكسجين\n&#8226; التحديث بشكل مبسط للأجهزة التي تملك (روت)\n&#8226; مشاهدة كل ماهو جديد في النظام الذي تستعمله حالياً\n&#8226; قراءة أخر الأخبار حول جهاز ون بلس ونظام أكسجين</string>
+	<string name="onboarding_disclaimer">هذا التطبيق لا يعتبر تطبيق رسمي من شركة ون بلس. وإستعمال هذا التطبيق على مسؤوليتك الخاصة كاملاً. لا شركة ون بلس ولا المطور مسؤولين عن أعمالك ويشتمل ذلك أي أضرار تنتج عن إستعمال هذا التطبيق. بإستعمالك هذا التطبيق فأنت تعتبر موافقاً على الأحكام والشروط التي ذكرت بالأعلى.</string>
+	<string name="onboarding_device_chooser_title">إختر جهازك</string>
+	<string name="onboarding_device_chooser_caption">جهازك غالباً تم إختياره بالأعلى. إذا لم يكن كذلك قم انت بإختياره من الأعلى.إسحب إلى اليسار للإستمرار.</string>
+	<string name="onboarding_method_chooser_title">إختر الطريقة التي تفضلها للتحديث</string>
+	<string name="onboarding_method_chooser_caption">عادتاً, التحديث التدريجي هو الإختيار الأمثل هنا, لعرضه تحميلات أسرع وأصغر. على كل حال, لا يعتبر ذلك مناسباً للأجهزة التي تملك (روت). اذا كنت تملك جهاز ذو (روت) مفعل, فأختر التحديث الكامل.</string>
+	<string name="onboarding_caption">إستمتع بهذا التطبيق! يمكنك دائماً تغيير إعداداتك لاحقاً.</string>
 
 	<!-- Automatic install strings -->
 	<string name="install">تثبيت</string>
 
 	<!-- Install guide strings -->
-	<string name="install_guide_no_root">قم بتثبيت التحديث وفقًا للإرشادات الموضحة في دليل التثبيت.</string>
 	<string name="install_guide">دليل التثبيت</string>
-	<string name="install_guide_subtitle">دليل التثبيت - %1$d من %2$d</string>
-	<string name="install_guide_tip">&#8226; يوصى بتدوين جميع الخطوات ، حيث ستحتاج إلى إيقاف تشغيل الجهاز أثناء تثبيت التحديث.</string>
-	<string name="install_guide_page_1_title">تحميل التحديث</string>
-	<string name="install_guide_page_1_text">&#8226; اضغط على زر تحميل لبدء تحميل التحديث.\n\n&#8226; سيظهر لك تقدم التحميل في التطبيق، وكإشعار في منطقة الإشعارات الخاصة بك.\n\n&#8226; عند إنتهاء التحميل، سترى إشعاراً بأنه \"تم التحميل\".\nفي حالة حدوث خطأ في التحميل، إفتح التطبيق وحاول تحميل التحديث مرة أخرى. إذا لم ينجح ذلك ، فتأكد من أن لديك إتصال إنترنت فعال. وخلافاً لذلك، إتصل بمطور التطبيق. ويمكنك القيام بذلك عن طريق زيارة قائمة \"تطبيقاتي\" في متجر بلاي.</string>
-
-	<!-- TODO: translate these 2 strings below -->
-	<string name="install_guide_page_2_title">Prepare for installation</string>
-	<string name="install_guide_page_2_text">"Note: The installation of the update takes place from a special page of the standard System Updates section of your device. If, for some reason, a system update appears when opening this section, you may also opt to install that update first. Afterwards, open Oxygen Updater again to see if you're completely up-to-date.
-
-Instructions:
-&#8226; Close Oxygen Updater by pressing the home button.
-
-&#8226; Open the Settings app. It should be located in your app drawer.
-
-&#8226; Scroll down until you see System updates. Tap on it."</string>
-
-	<!-- TODO: translate these 2 strings below -->
-	<string name="install_guide_page_3_title">Install the update</string>
-	<string name="install_guide_page_3_text">"Now that you're in the System Updates app, it's time to install the update.
-
-&#8226; Within the System Updates section, tap the gear icon in the top right
-
-&#8226; Now, select \"Local upgrade\". A file selection screen should appear.
-
-&#8226; In this screen, tap on the update file you downloaded using Oxygen Updater. Its name should start with \"%1$sOxygen\".
-
-&#8226; Tap on \"Upgrade Now\". The installation should start automatically."</string>
-
-	<!-- TODO: translate these 2 strings below -->
-	<string name="install_guide_page_4_title">Wait until the installation completes</string>
-	<string name="install_guide_page_4_text">"&#8226; The phone will now install the update and displays a progress bar. Please wait until the installation has finished. Installation may take anywhere from a few minutes up to 15 minutes.
-
-&#8226; Afterwards, your phone will restart to complete the update."</string>
-
-	<string name="install_guide_page_5_title">تم. إستمتع بإصدار نظام أكسجين الجديد!</string>
-	<string name="install_guide_page_5_text">&#8226; بعد إنتهاء جهازك من تحسين التطبيقات ، سيكون قد تم تثبيت التحديث بنجاح.\nللتحقق من ذلك، يمكنك التحقق من الإصدار الحالي من نظامك على النحو التالي:\n\n&#8226; انتقل إلى الإعدادات ، انقر فوق \"حول الهاتف\" "، وتحقق من إصدار نظام أكسجين.\n\n&#8226; إذا أعجبك هذا التطبيق ، فإمنحه خمس نجوم على متجر بلاي!</string>
-	<string name="install_guide_close_button">إغلاق دليل التثبيت</string>
+	<string name="install_guide_download_instructions">&#8226; اضغط على زر تحميل لبدء تحميل التحديث.\n&#8226; سيظهر لك تقدم التحميل في التطبيق، وكإشعار في منطقة الإشعارات الخاصة بك.\n&#8226; عند إنتهاء التحميل، سترى إشعاراً بأنه \"تم التحميل\". في حالة حدوث خطأ في التحميل، إفتح التطبيق وحاول تحميل التحديث مرة أخرى. إذا لم ينجح ذلك ، فتأكد من أن لديك إتصال إنترنت فعال. وخلافاً لذلك، إتصل بمطور التطبيق. ويمكنك القيام بذلك عن طريق زيارة قائمة \"تطبيقاتي\" في متجر بلاي.</string>
 
 	<!-- Device information strings -->
 	<!-- TODO: translate these 4 strings below -->
@@ -228,6 +189,8 @@ Instructions:
 	<string name="about_email_button_text">البريد الإلكتروني</string>
 
 	<!-- LocalNotifications strings -->
+	<string name="notification_permission_title">ابق على اطلاع</string>
+	<string name="notification_permission_text">يرجى السماح للتطبيق بإعلامك بتحديثات OTA والأخبار وحالة التنزيل المستمرة والأشياء المهمة الأخرى. يمكنك ضبط تفضيلاتك لاحقًا في إعدادات التطبيق.</string>
 	<string name="notification_new_device_text">%1$s مدعوم الآن. إفتح التطبيق لإختيار هذا الجهاز.</string>
 	<string name="notification_no_notification_support">ثبت أو حدث خدمات متجر بلاي لتمكين الإشعارات.</string>
 	<string name="notification_version">%1$s متاح الآن لجهاز %2$s!</string>
@@ -252,26 +215,12 @@ Instructions:
 	<string name="news_notification_channel_description">Get notified when we publish a news article</string>
 	<string name="device_notification_channel_description">Get notified when the app adds support for a new device</string>
 	<string name="general_notification_channel_description">General notifications that don\'t fit into other categories</string>
-	<string name="url_submitted_notification_channel_description">احصل على إشعار عند إرسال عناوين URL لـ OTA بنجاح إلى فريقنا. \ n يمكنك إلغاء الاشتراك في إرسال عناوين URL تلقائيًا في إعدادات التطبيق.</string>
-
-	<!-- Help strings -->
-	<string name="help">مساعدة</string>
-	<string name="help_updating_your_device_title">تحديث جهازك</string>
-	<string name="help_updating_your_device_text">عند فتح التطبيق ، سترى ما إذا كان هنا تحديث للنظام متاحًا أم لا. إذا كان هناك تحديث متوفر ، يمكنك تثبيته.\n\nلبدء التثبيت، أنقر فوق زر \"تحميل\" (أسفل وصف التحديث) لبدء التحميل. عند إنتهاء التحميل، ستنبثق شاشة التثبيت. إذا تركت التطبيق أو لم تظهر إليك الشاشة المنبثقة، فأنقر فوق زر \"تثبيت\"، والذي سيكون ظاهراً بجوار زر \"تحميل\".\n\nستقوم شاشة التثبيت أولاً بفحص ما إذا كان لديك روت على الجهاز. إذا كان لديك روت، فإمنح الإذن للروت عند الطلب وإختر الطريقة التي تريد تثبيت التحديث بها. أما خلاف ذلك، فإتبع الإرشادات الخاصة بالتثبيت اليدوي.\n\nالتثبيت التلقائي:\nليس عليك سوى اختيار خيارات التثبيت الخاصة بك. يوصى بإستعمال الإعدادات الإفتراضية، باستثناء أنه يتعين عليك تحديد حزمة الروت التي يجب إعادة تثبيتها. حدد حزمة الروت عبارة عن (ملف مضغوط) بإستخدام زر المجلد الأزرق وإضغط على \"بدء التثبيت\" لبدء التثبيت.\n\nالتثبيت اليدوي:\nسترى دليل التثبيت على الشاشة. دون الإرشادات وقم بتنفيذها كما هو موضح لتثبيت التحديث.</string>
-	<string name="help_reading_news_title">قراءة آخر الأخبار</string>
-	<string name="help_reading_news_text">يتم عرض الأخبار على يسار شاشة التحديث. تظهر العناصر الأحدث في الأعلى. ما عليك سوى النقر على عنصر لقراءته.\nاضغط على سهم العودة للخلف أو إضغط على مفتاح الرجوع للعودة إلى شاشة عناصر الأخبار.</string>
-	<string name="help_device_information_title">مشاهدة بيانات جهازك</string>
-	<string name="help_device_information_text">يمكنك عرض البعض من مواصفات جهازك بإستخدام الشاشة على يمين شاشة التحديث. يكون هذا مفيدًا عند تقديم طلب دعم فني، والتي قد تُطلب منك الحصول على بعض مواصفات جهازك خلاله.</string>
-	<string name="help_change_settings_title">تغيير الإعدادات</string>
-	<string name="help_change_settings_text">يمكنك تغيير الإعدادات الخاصة بك عن طريق النقر على النقاط الثلاثة في أعلى اليمين تتبعها بنقرة على زر الإعدادات.\nيمكنك تغيير الإعدادات التالية:\n\n• طريقة الجهاز والتحديث\n• الإشعارات\n• إشعارات داخل التطبيق\n• إعدادات الخصوصية (رفع السجل).\n\nإستخدم رموز التبديل لتشغيل وإيقاف إعدادات الإشعارات أوالخصوصية. حدد جهازاً و / أو طريقة التحديث بإستخدام القوائم المنسدلة الموضحة أعلى المفاتيح. القوائم المنسدلة غير مرئية؟ تحقق من اتصالك بالإنترنت وإفتح شاشة الإعدادات مرة أخرى.</string>
+	<string name="url_submitted_notification_channel_description">احصل على إشعار عند إرسال عناوين URL لـ OTA بنجاح إلى فريقنا. \n يمكنك إلغاء الاشتراك في إرسال عناوين URL تلقائيًا في إعدادات التطبيق.</string>
 
 	<!-- News strings -->
 	<string name="news">أخبار</string>
-	<string name="news_date_published">آخر تحديث: %1$s</string>
-	<string name="news_empty">لا توجد محتويات داخل هذا المقال.</string>
 	<string name="news_load_network_error">فشل فتح المقال. تحقق من اتصالك واضغط على زر \'إعادة المحاولة\' لفتح المقال.</string>
 	<!-- TODO: translate this string below -->
-	<string name="news_load_id_error"><![CDATA[Failed to open article from an invalid URL: %1$s. Check the URL or report this to us either via <a href="mailto:support@oxygenupdater.com">email</a> or on our <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
 	<!-- TODO: translate these 2 strings below -->
 	<string name="news_unread_count_1">You have %1$d unread news articles. Tap here to view them.</string>
 	<string name="news_unread_count_2">You have %1$d unread news articles. Tap to show all articles.</string>
@@ -299,13 +248,11 @@ Instructions:
 	<string name="error_app_outdated">كلا!</string>
 	<string name="error_app_outdated_message">هذا الإصدار من التطبيق قديم. لقد حان الوقت لتحديثه! اضغط على \"متجر بلاي\" أدناه. ومن داخل متجر بلاي ، انقر فوق زر \"تحديث\".</string>
 	<string name="error_app_requires_network_connection">لا يوجد إتصال</string>
-	<string name="error_app_requires_network_connection_message">فشل الاتصال بالخادم. يرجى التأكد من أن لديك إتصال فعال بالإنترنت. سيتم إغلاق التطبيق الآن.</string>
 	<string name="error_google_play_button_text">متجر بلاي</string>
-	<string name="error_no_internet_connection">لا يوجد إتصال.</string>
 	<string name="error_maintenance">صيانة الخادم</string>
 	<string name="error_maintenance_message">فضلاً إنتظر. سيكون الخادم متاح قريباً جداً.</string>
 	<!-- TODO: translate this string below -->
-	<string name="error_maintenance_retry">The server may be down for maintenance. Try again after some time, or report it to us either via <a href="mailto:support@oxygenupdater.com">email</a> or on our <a href="https://discord.gg/5TXdhKJ">Discord server</a>.</string>
+	<string name="error_maintenance_retry"><![CDATA[The server may be down for maintenance. Try again after some time, or report it to us either via <a href="mailto:support@oxygenupdater.com">email</a> or on our <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
 	<string name="error_reload">أعد التحميل</string>
 	<string name="error_unable_to_rate_app">لا يمكنك تقييم التطبيق ، لأن متجر بلاي غير متواجد على جهازك.</string>
 
@@ -332,7 +279,6 @@ Instructions:
 
 	<!-- Other strings-->
 	<!-- TODO: translate this string below -->
-	<string name="error">خطأ</string>
 	<string name="icon">أيقونة</string>
 	<string name="loading">جاري التحميل…</string>
 	<string name="processing">جاري المعالجة…</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="device_chooser_error_title">Nelze načíst seznam podporovaných zařízení</string>
-
 	<!-- Aktualizace informačních řetězců-->
 	<string name="enable">Povolit</string>
 	<string name="update_information_description_not_available">Nejsou k dispozici žádné oficiální informace o nových funkcích, které tato aktualizace poskytuje. Obvykle taková aktualizace poskytuje opravy chyb, vylepšení výkonu a/nebo kritické aktualizace zabezpečení vašeho zařízení.</string>
@@ -13,11 +11,10 @@
 	<string name="update_information_banner_server">Klepnutím sem zobrazíte důležitá upozornění</string>
 	<string name="update_information_banner_advanced_mode_tip">Vybrali jste aktualizační stopu \"%1$s\". Pokud plánujete přejít na tuto aktualizační stopu, zapněte pokročilý režim.</string>
 	<string name="update_information_header_advanced_mode_hint">Pokročilý režim je povolen</string>
-	<string name="update_information_header_advanced_mode_helper">Protože jste povolili pokročilý režim, můžete si stáhnout nejnovější ZIP pro \"%1$s\".\n\nPokročilý režim můžete vypnout v nastavení.</string>
-	<string name="update_information_different_version_changelog_notice">Prohlížíte si seznam změn pro nejnovější aktualizaci ve stopě aktualizací \"%1$s\". Pokud hodláte tuto aktualizaci nainstalovat, musíte nejprve zapnout rozšířený režim (v nastavení).\n\nPokud však chcete místo toho zobrazit seznam změn pro aktuálně nainstalovanou verzi, musíte se přepnout zpět na správný způsob aktualizace.</string>
-	<string name="update_information_last_checked_on">Poslední kontrola: %1$s</string>
+	<string name="update_information_header_advanced_mode_helper">Protože jste povolili pokročilý režim, můžete si stáhnout nejnovější ZIP pro \"%1$s\". Pokročilý režim můžete vypnout v nastavení.</string>
+	<string name="update_information_different_version_changelog_notice_base">Poznámka: tento seznam změn se týká poslední dostupné verze (%1$s) v metodě aktualizace \"%2$s\"</string>
+	<string name="update_information_different_version_changelog_notice_advanced">. Pokud chcete tuto aktualizaci nainstalovat, musíte v nastavení povolit \"Pokročilý režim\".</string>
 	<string name="update_information_no_update_data_available">Není k dispozici žádná informace o aktualizaci</string>
-	<string name="update_information_oxygen_os_version">OxygenOS %1$s</string>
 	<string name="update_information_system_is_up_to_date">Váš systém je aktuální</string>
 	<string name="update_information_unknown_update_name">Nejmenovaná aktualizace pro %1$s</string>
 	<string name="update_information_view_update_information">Zobrazit informace o aktualizaci</string>
@@ -52,8 +49,8 @@
 Pokud se chcete dozvědět více, neváhejte nás kontaktovat buď prostřednictvím <a href="mailto:support@oxygenupdater.com">e-mailu</a> nebo na našem <a href="https://discord.gg/5TXdhKJ">Discord serveru</a>.]]></string>
 	<string name="download_error_could_not_move_temp_file">Soubor byl stažen, ale nepodařilo se jej přesunout do správného adresáře. Otevřete správce souborů, přejděte na \"%1$s\" a ručně přesuňte soubor do nejvyššího adresáře interního úložiště.</string>
 
-	<string name="download_error_retry">ZKUSIT ZNOVU</string>
-	<string name="download_error_resume">POKRAČOVAT</string>
+	<string name="download_error_retry">Zkusit znovu</string>
+	<string name="download_error_resume">Pokračovat</string>
 	<string name="download_error_storage">Na vašem zařízení není k dispozici dostatek místa pro stažení aktualizace. Odstraňte prosím některé soubory a zkuste ji stáhnout znovu.</string>
 
 	<string name="download_failed">Stahování se nezdařilo</string>
@@ -90,9 +87,7 @@ Pokud se chcete dozvědět více, neváhejte nás kontaktovat buď prostřednict
 	<string name="summary_please_wait">Prosím, počkejte…</string>
 	<string name="summary_update_method">Nejprve vyberte zařízení</string>
 	<!-- TODO: check the following translation -->
-	<string name="summary_important_notifications_disabled">Některá důležitá oznámení jsou zakázána: \"%1$s\"</string>
-	<string name="summary_theme">Nastavení vzhledu</string>
-	<string name="summary_language">Nastavení jazyka</string>
+	<string name="summary_important_notifications_disabled">Některá důležitá oznámení jsou zakázána:</string>
 	<string name="summary_privacy_policy">Podívat se online</string>
 	<string name="summary_rate_app">Zanechat pětihvězdičkové hodnocení</string>
 
@@ -123,78 +118,46 @@ Pokud se chcete dozvědět více, neváhejte nás kontaktovat buď prostřednict
 
 	<string name="settings_device">Zařízení</string>
 	<string name="settings_entered_incorrectly">Chyba uložení nastavení. Vraťte se prosím zpět a vyberte své zařízení / způsob aktualizace znovu.</string>
-	<string name="settings_explanation_incremental_full_update">Aktualizaci typu incremental lze nainstalovat z libovolné verze (kromě případů, kdy máte odemčený zavaděč - bootloader; pak byste měli jako metodu aktualizace vždy zvolit aktualizaci typu full).\n\nAktualizaci beta verze systému OxygenOS lze nainstalovat vždy, stejně jako když máte nainstalovanou stabilní verzi. Chcete-li přejít ze stabilní verze na beta verzi, musíte v nastavení povolit rozšířený režim. U beta verzí fungují metody full a incremental stejně jako u stabilních verzí.</string>
 
 	<string name="settings_push_from_server">Informační a varovné zprávy</string>
 
 	<string name="settings_saving">Vaše nastavení se stále ukládá. Pokud to trvá příliš dlouho: Zkontrolujte připojení k síti, ukončete aplikaci a spusťte ji znovu.</string>
 
 	<string name="settings_advanced_mode">Pokročilý režim</string>
-	<string name="settings_advanced_mode_explanation">Pokročilý režim skrývá zprávu \"Váš systém je aktuální\" a umožňuje vám stáhnout a nainstalovat všechny aktualizace, i když nemusí být kompatibilní s vaším zařízením. \To může být užitečné při:\n&#8226; Aktualizaci z běžné verze na beta verzi\n&#8226; Návratu z beta verze na běžnou verzi (nezapomeňte obnovit tovární nastavení zařízení)\n&#8226; Přeinstalaci aktuální verze systému.</string>
+	<string name="settings_advanced_mode_explanation">"Obvykle aplikace zobrazuje aktualizace na základě aktuální verze operačního systému. V rozšířeném režimu se vždy zobrazí nejnovější dostupná aktualizace bez ohledu na kompatibilitu zařízení/verze.
+
+To může být užitečné, pokud chcete:"</string>
+	<string name="settings_advanced_mode_uses">"&#8226; Znovu stáhnout nejnovější verzi, i když ji již používáte
+&#8226; Přepnout na jinou aktualizační stopu"</string>
+	<string name="settings_advanced_mode_caption">"Rozšířený režim může být potřebný pouze ve výše uvedených situacích. Neměli byste jej povolovat, pokud nevíte, co děláte."</string>
 
 	<string name="settings_update_method">Způsob aktualizace</string>
 	<string name="settings_upload_logs">Sdílení dat o používání a sdílení protokolů</string>
+	<string name="settings_ad_privacy">Souhlas s reklamou podle GDPR</string>
+	<string name="settings_ad_privacy_subtitle">"Pro uživatele v EHP/UK"</string>
 
 	<!-- Řetězce FAQ -->
 	<string name="faq">FAQ</string>
 	<string name="faq_menu_item">FAQ</string>
 
 	<!-- Řetězce pro první zapnutí -->
-	<string name="onboarding">Vítejte</string>
+	<string name="onboarding">Nastavení</string>
 	<string name="onboarding_finished_button">Spustit aplikaci</string>
 
-	<string name="onboarding_page_1_title">Vítejte v aplikaci Oxygen Updater!</string>
-	<string name="onboarding_page_1_text">Tato aplikace vám umožní:\n\n&#8226; Získat rychlejší přístup k nejnovějším aktualizacím systému Android pro vaše zařízení s operačním systémem OxygenOS\n\n&#8226; Snadno aktualizovat zařízení s rootem\n\n&#8226; Prohlédnout si novinky o systémovém softwaru, který právě používáte\n\n&#8226; Přečíst si nejnovější zprávy o společnosti OnePlus a OxygenOS\n\nPřejeďte doleva pro pokračování. </string>
-	<string name="onboarding_page_1_caption">Nejedná se o oficiální aplikaci společnosti OnePlus. Používání této aplikace je zcela na vaše vlastní riziko. Společnost OnePlus ani vývojář aplikace nenesou odpovědnost za vaše jednání, včetně jakýchkoli škod způsobených používáním této aplikace.\n\nPoužíváním této aplikace souhlasíte s výše uvedenými podmínkami.</string>
-	<string name="onboarding_page_2_title">Vyberte své zařízení</string>
-	<string name="onboarding_page_2_caption">Vaše zařízení je obvykle již vybráno výše. Pokud ne, vyberte jej.</string>
-	<string name="onboarding_page_3_title">Vyberte způsob aktualizace</string>
-	<string name="onboarding_page_3_caption">Obvykle je zde správnou volbou aktualizace typu incremental, protože nabízí mnohem rychlejší a menší objem dat ke stažení.\n\nNení však kompatibilní se zařízeními s rootem. Pokud máte zařízení s rootem, zvolte plnou aktualizaci.\n\nPokud máte beta verzi systému OxygenOS, zvolte jednu z metod aktualizace Open Beta.</string>
-	<string name="onboarding_page_4_title">Jste připraveni!</string>
-	<string name="onboarding_page_4_text">Užívejte si používání této aplikace!\n\nVždy můžete později změnit nastavení. Můžete tak učinit klepnutím na tři tečky v pravém horním rohu a klepněte na \"Nastavení\".</string>
+	<string name="onboarding_app_uses">Tato aplikace vám umožní:\n\n&#8226; Získat rychlejší přístup k nejnovějším aktualizacím systému Android pro vaše zařízení s operačním systémem OxygenOS\n&#8226; Snadno aktualizovat zařízení s rootem\n&#8226; Prohlédnout si novinky o systémovém softwaru, který právě používáte\n&#8226; Přečíst si nejnovější zprávy o společnosti OnePlus a OxygenOS</string>
+	<string name="onboarding_disclaimer">Nejedná se o oficiální aplikaci společnosti OnePlus. Používání této aplikace je zcela na vaše vlastní riziko. Společnost OnePlus ani vývojář aplikace nenesou odpovědnost za vaše jednání, včetně jakýchkoli škod způsobených používáním této aplikace. Používáním této aplikace souhlasíte s výše uvedenými podmínkami.</string>
+	<string name="onboarding_device_chooser_title">Vyberte své zařízení</string>
+	<string name="onboarding_device_chooser_caption">Vaše zařízení je obvykle již vybráno výše. Pokud ne, vyberte jej.</string>
+	<string name="onboarding_method_chooser_title">Vyberte způsob aktualizace</string>
+	<string name="onboarding_method_chooser_caption">Obvykle je zde správnou volbou aktualizace typu incremental, protože nabízí mnohem rychlejší a menší objem dat ke stažení. Není však kompatibilní se zařízeními s rootem. Pokud máte zařízení s rootem, zvolte plnou aktualizaci. Pokud máte beta verzi systému OxygenOS, zvolte jednu z metod aktualizace Open Beta.</string>
+	<string name="onboarding_caption">Užívejte si používání této aplikace! Vždy můžete později změnit nastavení.</string>
 
 	<!-- Řetězce pro automatickou instalaci -->
 	<string name="install">Instalovat</string>
 
 	<!-- Řetězce průvodce instalací -->
-	<string name="install_guide_no_root">Instalujte aktualizaci podle pokynů uvedených v průvodci instalací.</string>
 	<string name="install_guide">Průvodce instalací</string>
-	<string name="install_guide_subtitle">Průvodce instalací - %1$d z %2$d</string>
-	<string name="install_guide_tip">&#8226; Doporučujeme zapsat si všechny kroky, protože během instalace aktualizace budete muset zařízení vypnout.</string>
-
-	<string name="install_guide_page_1_title">Stáhněte si aktualizaci</string>
-	<string name="install_guide_page_1_text">&#8226; Stisknutím tlačítka Stáhnout zahájíte stahování aktualizace.\n\n&#8226; Průběh stahování se zobrazí v aplikaci a jako oznámení na obrazovce oznámení.\n\n&#8226; Po dokončení stahování se zobrazí oznámení s textem \"Stahování dokončeno\".\nPokud došlo k chybě při stahování, otevřete aplikaci a zkuste stáhnout aktualizaci znovu. Pokud se to nepodaří, zkontrolujte, zda máte funkční připojení. V opačném případě kontaktujte vývojáře aplikace. Můžete tak učinit v sekci \"Moje aplikace\" v obchodě Google Play.</string>
-
-	<string name="install_guide_page_2_title">Příprava na instalaci</string>
-	<string name="install_guide_page_2_text">"Poznámka: Instalace aktualizace probíhá ze speciální stránky standardní sekce Aktualizace systému vašeho zařízení. Pokud se při otevření této sekce z nějakého důvodu objeví aktualizace systému, můžete se také rozhodnout nejprve nainstalovat tuto aktualizaci. Poté znovu otevřete nástroj Oxygen Updater a zkontrolujte, zda je zařízené zcela aktualizované.
-
-Pokyny:
-&#8226; Stisknutím tlačítka Domů zavřete aplikaci Oxygen Updater.
-
-&#8226; Otevřete aplikaci Nastavení. Měla by se nacházet v přehledu aplikací.
-
-&#8226; Přejděte dolů, dokud neuvidíte položku Aktualizace systému. Klepněte na ni."</string>
-
-	<string name="install_guide_page_3_title">Instalace aktualizace</string>
-	<string name="install_guide_page_3_text">"Nyní, když jste v aplikaci Aktualizace systému, je čas nainstalovat aktualizaci.
-
-&#8226; V části Aktualizace systému klepněte na ikonu ozubeného kola v pravém horním rohu.
-
-&#8226; Nyní vyberte možnost \"Místní aktualizace\". Měla by se zobrazit obrazovka pro výběr souboru.
-
-&#8226; Na této obrazovce klepněte na aktualizační soubor, který jste stáhli pomocí nástroje Oxygen Updater. Jeho název by měl začínat \"%1$sOxygen\".
-
-&#8226; Klepněte na \"Aktualizovat nyní\". Instalace by se měla spustit automaticky."</string>
-
-	<string name="install_guide_page_4_title">Počkejte, dokud se instalace nedokončí</string>
-	<string name="install_guide_page_4_text">"&#8226; Telefon nyní nainstaluje aktualizaci a zobrazí ukazatel průběhu. Vyčkejte, dokud se instalace nedokončí. Instalace může trvat od několika málo minut až po cca 15 minut.
-
-&#8226; Poté se telefon restartuje a dokončí aktualizaci."</string>
-
-	<string name="install_guide_page_5_title">Dokončeno. Užijte si novou verzi systému OxygenOS!</string>
-	<string name="install_guide_page_5_text">&#8226; Poté, co vaše zařízení dokončí optimalizaci aplikací, byla aktualizace úspěšně nainstalována.\nPro ověření můžete zkontrolovat aktuální verzi systému následujícím způsobem:\n\n&#8226; Přejděte do Nastavení, klepněte na \"O telefonu\" a zkontrolujte verzi OxygenOS.\n\n&#8226; Pokud se vám tato aplikace líbí, dejte jí na Google Play 5 hvězdiček!</string>
-
-	<string name="install_guide_close_button">Zavřít instalační příručku</string>
+	<string name="install_guide_download_instructions">&#8226; Stisknutím tlačítka Stáhnout zahájíte stahování aktualizace.\n&#8226; Průběh stahování se zobrazí v aplikaci a jako oznámení na obrazovce oznámení.\n&#8226; Po dokončení stahování se zobrazí oznámení s textem \"Stahování dokončeno\". Pokud došlo k chybě při stahování, otevřete aplikaci a zkuste stáhnout aktualizaci znovu. Pokud se to nepodaří, zkontrolujte, zda máte funkční připojení. V opačném případě kontaktujte vývojáře aplikace. Můžete tak učinit v sekci \"Moje aplikace\" v obchodě Google Play.</string>
 
 	<!-- Řetězce informací o zařízení -->
 	<string name="device_information_supported_oxygen_os">Vaše zařízení je podporováno</string>
@@ -205,13 +168,13 @@ Pokyny:
 	<string name="device_information_hardware_header">Hardware</string>
 	<string name="device_information_software_header">Software</string>
 
-	<string name="device_information_amount_of_memory">Paměť RAM</string>
+	<string name="device_information_amount_of_memory">Množství paměti RAM</string>
 	<string name="device_information_cpu_frequency">Frekvence procesoru</string>
 	<string name="device_information_header">Zařízení</string>
 	<string name="device_information_image_description">Obrázek zařízení</string>
 	<string name="device_information_incremental_os_version">Inkrementální verze OS</string>
 	<string name="device_information_os_version">Verze systému Android</string>
-	<string name="device_information_oxygen_os_version">OxygenOS verze</string>
+	<string name="device_information_oxygen_os_version">OS verze</string>
 	<string name="device_information_oxygen_os_ota_version">OTA verze</string>
 	<string name="device_information_patch_level_version">Datum bezpečnostní záplaty</string>
 	<string name="device_information_serial_number">Sériové číslo</string>
@@ -230,6 +193,8 @@ Pokyny:
 	<string name="about_email_button_text">Email</string>
 
 	<!-- Řetězce LocalNotifications -->
+	<string name="notification_permission_title">"Zůstaňte informováni"</string>
+	<string name="notification_permission_text">"Povolte aplikaci, aby vás upozorňovala na aktualizace OTA, novinky, průběžný stav stahování a další důležité věci. Své preference můžete později doladit v nastavení aplikace."</string>
 	<string name="notification_new_device_text">Nyní je podporován %1$s. Otevřete aplikaci a vyberte toto zařízení.</string>
 	<string name="notification_no_notification_support">Instalace nebo aktualizace služeb Google Play pro povolení push oznámení.</string>
 	<string name="notification_version">%1$s je nyní k dispozici pro %2$s!</string>
@@ -256,22 +221,10 @@ Pokyny:
 	<string name="url_submitted_notification_channel_description">Dostávejte upozornění, když našemu týmu úspěšně odešlete adresy URL OTA.\nAutomatické odesílání adres URL můžete zrušit v nastavení aplikace.</string>
 
 	<!-- Nápovědné řetězce -->
-	<string name="help">Nápověda</string>
-	<string name="help_updating_your_device_title">Aktualizace zařízení</string>
-	<string name="help_updating_your_device_text">Při otevření aplikace uvidíte, zda je k dispozici aktualizace systému. Pokud je aktualizace k dispozici, můžete ji nainstalovat.\n\nChcete-li zahájit instalaci, klepněte na tlačítko \"Stáhnout\" (pod popisem aktualizace), čímž zahájíte stahování. Po dokončení stahování se zobrazí obrazovka instalace. Pokud jste aplikaci opustili nebo se obrazovka neobjevila, klepněte na tlačítko \"Instalovat\", které se nyní zobrazuje vedle tlačítka \"Stáhnout\".\n\nInstalační obrazovka nejprve zkontroluje, zda máte zařízení s rootem. Pokud máte zařízení s rootem, udělte na dotaz oprávnění root a vyberte způsob instalace aktualizace. V opačném případě postupujte podle pokynů pro ruční instalaci.\n\nAutomatická instalace:\n\budete muset pouze vybrat možnosti instalace. Výchozí nastavení jsou doporučená, s výjimkou toho, že musíte zadat kořenový balíček, který je třeba (pře)instalovat. Vyberte kořenový balíček (soubor zip) pomocí modrého tlačítka složky a klepnutím na \"Spustit instalaci\" spusťte instalaci.\n\nRuční instalace:\nNa obrazovce se zobrazí průvodce instalací. Zapište si pokyny a proveďte je podle pokynů pro instalaci aktualizace.</string>
-	<string name="help_reading_news_title">Přečtení nejnovějších zpráv</string>
-	<string name="help_reading_news_text">Novinky se zobrazují vlevo na obrazovce aktualizace. Nejnovější položky se zobrazují nahoře. Klepnutím na položku ji přečtete.\nKlepnutím na šipku zpět nebo stisknutím klávesy zpět se vrátíte na obrazovku novinek.</string>
-	<string name="help_device_information_title">Zobrazení informací o vašem zařízení</string>
-	<string name="help_device_information_text">Na obrazovce vpravo od obrazovky Aktualizace si můžete prohlédnout některé specifikace svého zařízení. To se hodí při zadávání požadavku na podporu, během kterého můžete být požádáni o některé specifikace vašeho zařízení.</string>
-	<string name="help_change_settings_title">Změna nastavení</string>
-	<string name="help_change_settings_text">Nastavení můžete změnit klepnutím na tři tečky v pravém horním rohu a následným klepnutím na Nastavení.\nMůžete změnit následující nastavení:\n\n• Způsob zařízení a aktualizace\n• Push oznámení\n• Oznámení v aplikaci\n• Nastavení soukromí (nahrávání záznamů).\n\nPřepínači zapnete a vypnete nastavení oznámení / soukromí. Pomocí rozbalovacích nabídek zobrazených nad přepínači vyberte zařízení a/nebo způsob aktualizace. Rozbalovací nabídky nejsou viditelné? Zkontrolujte připojení k internetu a znovu otevřete obrazovku Nastavení.</string>
 
 	<!-- News strings -->
 	<string name="news">Novinky</string>
-	<string name="news_date_published">Poslední aktualizace: %1$s</string>
-	<string name="news_empty">Tento článek nemá žádný obsah</string>
-	<string name="news_load_network_error">Nepodařilo se otevřít článek. Zkontrolujte připojení a stisknutím tlačítka \"OPAKOVAT\" článek otevřete.</string>
-	<string name="news_load_id_error"><![CDATA[Chyba otevření článku z neplatné adresy: %1$s. Zkontrolujte adresu URL nebo nám to nahlaste buď prostřednictvím <a href="mailto:support@oxygenupdater.com">e-mailu</a>, nebo na našem <a href="https://discord.gg/5TXdhKJ">Discord serveru</a>.]]></string>
+	<string name="news_load_network_error">Nepodařilo se otevřít článek. Zkontrolujte připojení a stisknutím tlačítka \"Opakovat\" článek otevřete.</string>
 	<string name="news_unread_count_1">Máte %1$d nepřečtených novinek. Klepněte sem pro jejich zobrazení.</string>
 	<string name="news_unread_count_2">Máte %1$d nepřečtených novinových článků. Klepnutím na zobrazíte všechny články.</string>
 	<string name="news_mark_read">Označit jako přečtené</string>
@@ -297,12 +250,10 @@ Pokyny:
 	<string name="error_app_outdated">Ale ne!</string>
 	<string name="error_app_outdated_message">Tato verze aplikace je zastaralá. Je čas ji aktualizovat! Klepněte na \"Google Play\" níže. V Google Play klepněte na \"Aktualizovat\".</string>
 	<string name="error_app_requires_network_connection">Není připojení</string>
-	<string name="error_app_requires_network_connection_message">Nepodařilo se připojit k serveru. Ujistěte se, že máte funkční připojení. Aplikace se nyní zavře.</string>
 	<string name="error_google_play_button_text">Google Play</string>
-	<string name="error_no_internet_connection">Není dostupné žádné připojení.</string>
 	<string name="error_maintenance">Údržba serveru</string>
 	<string name="error_maintenance_message">Počkejte prosím. Server bude brzy k dispozici.</string>
-	<string name="error_maintenance_retry">Server může být odstaven z důvodu údržby. Zkuste to znovu po nějaké době nebo nám to nahlaste prostřednictvím <a href="mailto:support@oxygenupdater.com">email</a> na našem <a href="https://discord.gg/5TXdhKJ">Discord serveru</a>.</string>
+	<string name="error_maintenance_retry"><![CDATA[Server může být odstaven z důvodu údržby. Zkuste to znovu po nějaké době nebo nám to nahlaste prostřednictvím <a href="mailto:support@oxygenupdater.com">email</a> na našem <a href="https://discord.gg/5TXdhKJ">Discord serveru</a>.]]></string>
 	<string name="error_reload">Znovu načíst</string>
 
 	<string name="error_unable_to_rate_app">Aplikaci nemůžete hodnotit, protože ve vašem zařízení chybí obchod Google Play.</string>
@@ -327,7 +278,6 @@ Pokyny:
 	<string name="purchase_error_after_payment">Nákup verze bez reklam se nezdařil, protože došlo k interní chybě. Zkuste to prosím za několik minut znovu. Pokud jste již zaplatili, kontaktujte prosím podporu Google Play a požádejte o pomoc.</string>
 
 	<!-- Other strings-->
-	<string name="error">Chyba</string>
 	<string name="icon">Ikona</string>
 	<string name="loading">Načítání…</string>
 	<string name="processing">Zpracovávání…</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1,24 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools" tools:keep="@string/install_guide_page_*_*">
-	<string name="device_chooser_error_title">Liste af supporterede enheder kunne ikke udhentes</string>
-
+<resources>
 	<!-- Update information strings-->
 	<string name="enable">Aktiver</string>
 	<string name="update_information_description_not_available">Der er ingen officiel information om nye egenskaber, som denne opdatering indeholder. Normalt tilbyder denne slags opdatering eks. fejlretninger, forbedringer af ydeevnen, og/eller kritiske sikkerhedsopdateringer til din egen enhed.</string>
 	<string name="update_information_file_name">Filnavn: %1$s</string>
 	<string name="update_information_md5">MD5: %1$s</string>
-	<string name="update_information_download_link">Pga. downloadfejlen skal downloaden genstartes. Du kan bruge dette link til at downloade filen via en browser i stedet. Du skal (måske) efterfølgende flytte filen fra \Downloads\ til hovedfolderen. Linket er det samme som programmet bruger til at downloade fra dvs. en officiel OnePlus OTA server:\n%1$s</string>
+	<string name="update_information_download_link">Pga. downloadfejlen skal downloaden genstartes. Du kan bruge dette link til at downloade filen via en browser i stedet. Du skal (måske) efterfølgende flytte filen fra \"Downloads\" til hovedfolderen. Linket er det samme som programmet bruger til at downloade fra dvs. en officiel OnePlus OTA server:\n%1$s</string>
 	<string name="update_information_header">Opdatér</string>
 	<string name="update_information_error_title">De seneste update data kunne ikke udhentes</string>
 	<string name="update_information_banner_server">Tryk her for at vise vigtige bemærkninger</string>
 	<string name="update_information_banner_advanced_mode_tip">Du har valgt \"%1$s\" updatemetode. "Enable" avanceret tilstand hvis du planlægger et skifte til denne updatemetode.</string>
 	<string name="update_information_header_advanced_mode_hint">Avanceret tilstand er aktiveret</string>
-	<string name="update_information_header_advanced_mode_helper">Eftersom du har slået avanceret tilstand til, kan du nu downloade den seneste ZIP for \"%1$s\".\n\nDu kan slå avanceret tilstand fra under indstillinger.</string>
-	<!-- TODO: translate this string below -->
-	<string name="update_information_different_version_changelog_notice">Visning af seneste changelog for den seneste update i \"%1$s\" upgrademetoden. If you intend to install this update, you must turn avanceret tilstand on first (in settings).\n\nHowever, if you wish to see the changelog for the currently installed version instead, you\'ll need to switch back to the correct update method.</string>
-	<string name="update_information_last_checked_on">Senest checket den: %1$s</string>
+	<string name="update_information_header_advanced_mode_helper">Eftersom du har slået avanceret tilstand til, kan du nu downloade den seneste ZIP for \"%1$s\". Du kan slå avanceret tilstand fra under indstillinger.</string>
+	<string name="update_information_different_version_changelog_notice_base">Bemærk: Denne changelog er for den seneste tilgængelige version (%1$s) i opdateringsmetoden \"%2$s\"</string>
+	<string name="update_information_different_version_changelog_notice_advanced">. Hvis du vil installere denne opdatering, skal du aktivere "Avanceret tilstand" i indstillingerne.</string>
 	<string name="update_information_no_update_data_available">Ingen opdatering information tilgængelig</string>
-	<string name="update_information_oxygen_os_version">OxygenOS %1$s</string>
 	<string name="update_information_system_is_up_to_date">Dit system er opdateret</string>
 	<string name="update_information_unknown_update_name">Unavngiven opdatering for %1$s</string>
 	<string name="update_information_view_update_information">Se opdateringsinformation</string>
@@ -45,7 +41,7 @@
 	<string name="download_complete_notification">Tryk på: start nstallation</string>
 
 	<string name="download_error">Fejl i download</string>
-	<string name="download_error_close">LUK</string>
+	<string name="download_error_close">Luk</string>
 	<string name="download_error_corrupt">Den downloadede fil er beskadiget! Forsøg at downloade den igen.</string>
 	<string name="download_error_server">En netværksfejl opstod under forsøget på at downloade opdateringen. Forsøg at downloade opdateringen igen.</string>
 	<string name="download_error_internal">Desværre opstod der en teknisk fejl, i forsøget på at downloade opdateringen. Forsøg at downloade igen. Kontakt udvikleren af denne app, hvis problemet gentager sig.</string>
@@ -55,8 +51,8 @@
 If you\'d like to know more, feel free to contact us either via <a href="mailto:support@oxygenupdater.com">email</a> or on our <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
 	<string name="download_error_could_not_move_temp_file">The file has been downloaded, but couldn\'t be moved to the correct directory. Open a file manager, navigate to \"%1$s\" and manually move the file to the topmost directory of internal storage.</string>
 
-	<string name="download_error_retry">PRØV IGEN</string>
-	<string name="download_error_resume">GENOPTAG</string>
+	<string name="download_error_retry">Prøv igen</string>
+	<string name="download_error_resume">Genoptag</string>
 	<string name="download_error_storage">Der er ikke nok ledig plads tilgængelig på din enhed, til at downloade opdateringerne. Frigør plads på din enhed og forsøg at downloade igen.</string>
 
 	<string name="download_failed">Download fejlede</string>
@@ -93,9 +89,7 @@ If you\'d like to know more, feel free to contact us either via <a href="mailto:
 	<string name="summary_please_wait">Vent venligst …</string>
 	<string name="summary_update_method">vælg en enhed først</string>
 	<!-- TODO: check the following translation -->
-	<string name="summary_important_notifications_disabled">Nogle vigtige meddelelser er deaktiveret: \"%1$s\"</string>
-	<string name="summary_theme">Vælg et tema</string>
-	<string name="summary_language">Indstil sprog</string>
+	<string name="summary_important_notifications_disabled">Nogle vigtige meddelelser er deaktiveret:</string>
 	<string name="summary_privacy_policy">Se online</string>
 	<string name="summary_rate_app">Giv os en 5-stjernet anmeldelse</string>
 
@@ -126,82 +120,47 @@ If you\'d like to know more, feel free to contact us either via <a href="mailto:
 
 	<string name="settings_device">Enhed</string>
 	<string name="settings_entered_incorrectly">Vi kan ikke gemme dine indstillinger. Gå tilbage, og vælg din enhed/opdateringsmetode igen.</string>
-	<string name="settings_explanation_incremental_full_update">En trinvis opdatering kan installeres fra en hvilken som helst version (undtagen hvis du har en ulåst bootloader; da skal du altid vælge fuld opdateringsmetode).\n\nA beta opdatering af OxygenOS kan altid installeres, lige så vel, som når det er en stabil version. For at skifte fra stabil til beta, så skal du aktivere avanceret tilstand, i indstillingerne. Vedrørende beta, den fulde og de trinvise opdaterings-metode, gør det på samme måde som ved den stabile versions.</string>
 
 	<string name="settings_push_from_server">Information- og -advarselsbeskeder</string>
 
 	<string name="settings_saving">Dine indstillinger gemmes. Tager det for lang tid: Check forbindelse til netværket, afslut app\'en, og start den igen.</string>
 
 	<string name="settings_advanced_mode">Avanceret tilstand</string>
-	<string name="settings_advanced_mode_explanation">Avanceret tilstand skjuler beskeden: \"Dit system er opdateret\", hvilket tillader dig at downloade og installere alle opdateringer, selvom de måske ikke er op kompatible med din enhed.\n\nDette kan være nyttigt når:\n&#8226; der opdateres fra en regulær stabil version til en beta version\n&#8226; eller at gå fra en beta til en stabil version. (glem ikke at nulstille enheden til fabriksstandard)\n&#8226; Genindstallerer din nuværende system version.</string>
+	<string name="settings_advanced_mode_explanation">"Normalt viser appen dig opdateringer baseret på din aktuelle OS-version. Med avanceret tilstand vil den seneste tilgængelige opdatering altid blive vist, uanset enhedens/versionens kompatibilitet.
+
+Det kan være nyttigt, hvis du vil:"</string>
+	<string name="settings_advanced_mode_uses">"&#8226; Downloade den nyeste version igen, selvom du allerede er på den
+&#8226; Skifte til et andet opdateringsspor"</string>
+	<string name="settings_advanced_mode_caption">"Avanceret tilstand kan kun være nødvendig i ovenstående situationer. Du bør ikke aktivere den, medmindre du ved, hvad du gør."</string>
 
 	<string name="settings_update_method">Opdateringsmetode</string>
 	<string name="settings_upload_logs">Del brugerdata og logs</string>
+	<string name="settings_ad_privacy">GDPR-samtykke til annoncer</string>
+	<string name="settings_ad_privacy_subtitle">"For brugere i EØS/UK"</string>
 
 	<!-- FAQ strings -->
 	<string name="faq">FAQ</string>
 	<string name="faq_menu_item">FAQ</string>
 
 	<!-- First-time setup strings -->
-	<string name="onboarding">Velkommen …</string>
+	<string name="onboarding">Opsætning</string>
 	<string name="onboarding_finished_button">start app</string>
 
-	<string name="onboarding_page_1_title">Velkommen til Oxygen Updater!</string>
-	<string name="onboarding_page_1_text">Denne app vil tillade dig at:\n\n&#8226; Få hurtigere adgang til de seneste Android opdateringer til din OxygenOS styrede enhed\n\n&#8226; Nem opdatering en root\'et enhed\n\n&#8226; Se hvad der er nyt, i det syste,-software du allerede anvender\n\n&#8226; Læs seneste nyt om OnePlus og OxygenOS\n\nSwipe til venstre, for at fortsætte.</string>
-	<string name="onboarding_page_1_caption">Dette er ikke en officel OnePlus applikation. Brug af denne app, er ene og alene på eget ansvar. Hverken OnePlus eller denne apps udvikler kan drages til ansvar, hverken for dine handlinger, eller eventuelle skader denne app måtte foresage.\n\nVed at anvende denne app, så accepterer du dens vilkår og betingelser, som er angivet herover.</string>
-	<string name="onboarding_page_2_title">Vælg din enhed</string>
-	<string name="onboarding_page_2_caption">Din enhed er normalt allerede valgt ovenfor. Hvis ikke, vælg da din enhed ovenfor.</string>
-	<string name="onboarding_page_3_title">Vælg opdateringsmetode</string>
-	<string name="onboarding_page_3_caption">Normalt, er den trinvise opdatering, det rigtige valg her, fordi den tilbyder hurtigere og mindre downloads.\n\nDog er den ikke kompatibel med root\'ede enheder. Hvis du har en root\'et enhed, så vælg, da en fuld opdatering.\n\nHvis du har en beta version af OxygenOS, vælg (en af) de åbne beta -opdateringsmetoder.</string>
-	<string name="onboarding_page_4_title">Du er nu klar til at fortsætte!</string>
-	<string name="onboarding_page_4_text">Held og lykke med denne app!\n\nDu kan altid ændre dine indstillinger senere. Gør det ved at: Tryk på de tre prikker i øverste højre hjørne, og vælg da\"Indstillinger\".</string>
+	<string name="onboarding_app_uses">Denne app vil tillade dig at:\n\n&#8226; Få hurtigere adgang til de seneste Android opdateringer til din OxygenOS styrede enhed\n&#8226; Nem opdatering en root\'et enhed\n&#8226; Se hvad der er nyt, i det syste,-software du allerede anvender\n&#8226; Læs seneste nyt om OnePlus og OxygenOS</string>
+	<string name="onboarding_disclaimer">Dette er ikke en officel OnePlus applikation. Brug af denne app, er ene og alene på eget ansvar. Hverken OnePlus eller denne apps udvikler kan drages til ansvar, hverken for dine handlinger, eller eventuelle skader denne app måtte foresage. Ved at anvende denne app, så accepterer du dens vilkår og betingelser, som er angivet herover.</string>
+	<string name="onboarding_device_chooser_title">Vælg din enhed</string>
+	<string name="onboarding_device_chooser_caption">Din enhed er normalt allerede valgt ovenfor. Hvis ikke, vælg da din enhed ovenfor.</string>
+	<string name="onboarding_method_chooser_title">Vælg opdateringsmetode</string>
+	<string name="onboarding_method_chooser_caption">Normalt, er den trinvise opdatering, det rigtige valg her, fordi den tilbyder hurtigere og mindre downloads. Dog er den ikke kompatibel med root\'ede enheder. Hvis du har en root\'et enhed, så vælg, da en fuld opdatering. Hvis du har en beta version af OxygenOS, vælg (en af) de åbne beta -opdateringsmetoder.</string>
+	<string name="onboarding_caption">Held og lykke med denne app! Du kan altid ændre dine indstillinger senere.</string>
 
 	<!-- Automatic install strings -->
 	<string name="install">Installér</string>
 
 	<!-- Install guide strings -->
-	<string name="install_guide_no_root">Installer opdatering efter de instruktioner der vises i installations-guiden.</string>
 	<string name="install_guide">Installations guide</string>
-	<string name="install_guide_subtitle">Installations guide - %1$d af %2$d</string>
-	<string name="install_guide_tip">&#8226; Det er anbefalelsesværdigt at notere sig alle punkter ned. da du vil blive bedt om at slukke enheden under selve installationen af opdateringen.</string>
-
-	<string name="install_guide_page_1_title">Download opdateringen</string>
 	<!-- TODO: translate this string below -->
-	<string name="install_guide_page_1_text">&#8226; Tryk på Download knappen, for at starte med at downloade opdateringen.\n\n&#8226; The download progress will appear in the app, and as a notification in your notifications screen.\n\n&#8226; When the download has finished, you\'ll see a notification with the text \"Download complete\".\nIf a download error occurred, open the app and try to downloading the update again. If this doesn\'t work, make sure you have a working connection. Otherwise, contact the developer of the app. You can do this by visiting the \"My apps\" section of the Google Play Store.</string>
-
-	<string name="install_guide_page_2_title">Klargør installation</string>
-	<!-- TODO: translate this string below -->
-	<string name="install_guide_page_2_text">"Bemærk: Installationen af opdateringen sker fra en speciel side af din enheds standard System Updates ("Systemopdatering"). If, for some reason, a system update appears when opening this section, you may also opt to install that update first. Afterwards, open Oxygen Updater again to see if you're completely up-to-date.
-
-Instructions:
-&#8226; Close Oxygen Updater by pressing the home button.
-
-&#8226; Open the Settings app. It should be located in your app drawer.
-
-&#8226; Scroll down until you see System updates. Tap on it."</string>
-
-	<string name="install_guide_page_3_title">Installation af opdateringen</string>
-	<!-- TODO: translate this string below -->
-	<string name="install_guide_page_3_text">"Now that you're in the System Updates app, it's time to install the update.
-
-&#8226; Within the System Updates section, tap the gear icon in the top right
-
-&#8226; Now, select \"Local upgrade\". A file selection screen should appear.
-
-&#8226; In this screen, tap on the update file you downloaded using Oxygen Updater. Its name should start with \"%1$sOxygen\".
-
-&#8226; Tap on \"Upgrade Now\". The installation should start automatically."</string>
-
-	<!-- TODO: translate these 2 strings below -->
-	<string name="install_guide_page_4_title">Wait until the installation completes</string>
-	<string name="install_guide_page_4_text">"&#8226; The phone will now install the update and displays a progress bar. Please wait until the installation has finished. Installation may take anywhere from a few minutes up to 15 minutes.
-
-&#8226; Afterwards, your phone will restart to complete the update."</string>
-
-	<string name="install_guide_page_5_title">Færdig. Nyd den nye OxygenOS version!</string>
-	<string name="install_guide_page_5_text">&#8226; Efter at din enhed er færdig med at optimere dens apps, er opdateringen fejlfri blevet installeret.\nFor at bekræfte dette, så kan du undersøge versionsnummeret af dit system, på følgende vis:\n\n&#8226; Åben Indstillinger, Tryk på \"Om telefon\", og check da OxygenOS Version.\n\n&#8226; Hvis du kan lide denne app, overvej at bedømme den med en 5 stjerner på Google Play!</string>
-
-	<string name="install_guide_close_button">Luk Installationsguide</string>
+	<string name="install_guide_download_instructions">&#8226; Tryk på Download knappen, for at starte med at downloade opdateringen.\n&#8226; The download progress will appear in the app, and as a notification in your notifications screen.\n&#8226; When the download has finished, you\'ll see a notification with the text \"Download complete\". If a download error occurred, open the app and try to download it again. If this doesn\'t work, make sure you have a working connection. Otherwise, contact the developer of the app. You can do this by visiting the \"My apps\" section of the Google Play Store.</string>
 
 	<!-- Device information strings -->
 	<string name="device_information_supported_oxygen_os">Din enhed er supporteret</string>
@@ -218,7 +177,7 @@ Instructions:
 	<string name="device_information_image_description">Enheds billede</string>
 	<string name="device_information_incremental_os_version">Trinvis OS version</string>
 	<string name="device_information_os_version">Android version</string>
-	<string name="device_information_oxygen_os_version">OxygenOS version</string>
+	<string name="device_information_oxygen_os_version">OS version</string>
 	<string name="device_information_oxygen_os_ota_version">OTA version</string>
 	<string name="device_information_patch_level_version">Sikkerheds-snipplet dato</string>
 	<string name="device_information_serial_number">Serie nummer</string>
@@ -238,6 +197,8 @@ Instructions:
 	<string name="about_email_button_text">Email</string>
 
 	<!-- LocalNotifications strings -->
+	<string name="notification_permission_title">"Bliv underrettet"</string>
+	<string name="notification_permission_text">"Tillad venligst, at appen giver dig besked om OTA-opdateringer, nyheder, status for igangværende download og andre vigtige ting. Du kan finjustere dine præferencer senere i appens indstillinger."</string>
 	<string name="notification_new_device_text">Enheden %1$s undertstøttes nu. Åben appen, for at vælge denne enhed.</string>
 	<string name="notification_no_notification_support">Installer eller opdatér Google Play tjenester, for at aktivere push-meddelelser.</string>
 	<string name="notification_version">%1$s er nu tilgængelig til enheden %2$s!</string>
@@ -266,24 +227,10 @@ Instructions:
 	<string name="general_notification_channel_description">General notifications that don\'t fit into other categories</string>
 	<string name="url_submitted_notification_channel_description">Få besked, når du har sendt OTA-URL\'er til vores team.\nDu kan fravælge automatisk indsendelse af URL\'er i appens indstillinger.</string>
 
-	<!-- Help strings -->
-	<string name="help">Hjælp</string>
-	<string name="help_updating_your_device_title">Opdaterer din enhed</string>
-	<string name="help_updating_your_device_text">Når du åbner app\'en, kan du se om der er en system-opdatering tilgængelig. Hvis der er en opdatering tilgængelig - så kan du installere den.\n\nStart installationen ved at trykke på \"Download\" -knappen (under opdaterings-beskrivelsen). Når downlad er færdig, vil installations-skærmen blive vist. Forlod du app\'en, eller blev skærmen ikke vist, klik da på \"Installer\" -knappen, som nu vises ved siden af \"Download\" -knappen.\n\nInstallationsskærmen vil først undersøge om du har en root\'ed enhed. Hvis du har en root\'ed enhed, så giv tilladelse, og angiv hvordan du ønsker at installere opdateringen - ellers følg de anvisninger for manuel installation.\n\nAutomatisk installation:\nDu behøver blot at vælge indstillinger for installation. Standard indstillingen er anebefalet, medmindre du skal specificere rod-pakken, der skal installeret/geninstalleret. Vælg rod-pakke (zip fil) ved at anvende den blå-mappe-knap, opg tryk på: \"Start installation\" for at starte installationen.\n\nManuel installation:\nPå skærmen vildu se en installations-guide. Notér dig alle instruktionerne og udfør dem som anført, for at installere opdateringen.</string>
-	<string name="help_reading_news_title">Læser Sidste Nyt</string>
-	<string name="help_reading_news_text">Nyheder er vist til venste, på opdaterings-skærmen. De mest læste er øverst. Tryk på et, for at læse det.\nTryk på tilbage-pilen eller tryk på tilbage-knappen, for at returnere til skærmen med listen over nyheder.</string>
-	<string name="help_device_information_title">Læser information om din enhed</string>
-	<string name="help_device_information_text">Du kan se nogle af specifikationerne på din enhed device, ved atr bruge skærmen til højre. Dette kan være nyttigt, hvis du vil lave en support-sag, hvilket du kan blive bedt om, med nogle af specifikationerne på din enhed.</string>
-	<string name="help_change_settings_title">Ændre indstillinger</string>
-	<string name="help_change_settings_text">Du kan ændre dine indstillinger ved at trykke på de tre prikke, øverst til højre, efterfølgende med et tryk på Indstillinger.\nDu kan ændre de følgende indstillinger:\n\n• Enhed og opdateringsmetode\n• Push underretninger\n• App meddelelser\n• Privatlivs indstillinger (log uploading).\n\nBrug slå til og fra -switchen, for at slå meddelelser / privatlivsindstillinger til og fra. Vælg en enhed og/eller opdateringsmetode, ved at bruge rullemenuen ovenfor switchene. Vises rullemenuen ikke? Check din internet forbindelse Internet connection og åben skærmen med indstillinger igen.</string>
-
 	<!-- News strings -->
 	<string name="news">Nyheder</string>
-	<string name="news_date_published">Sidst opdateret: %1$s</string>
-	<string name="news_empty">Ingen kommentarer, til denne artikkel.</string>
-	<string name="news_load_network_error">Kan ikke åbne denne artikkel. Check din forbindelse og tryk på \'FORSØG IGEN\' -knappen for at åbne artikllen.</string>
+	<string name="news_load_network_error">Kan ikke åbne denne artikkel. Check din forbindelse og tryk på \'Forsøg igen\' -knappen for at åbne artikllen.</string>
 	<!-- TODO: translate this string below -->
-	<string name="news_load_id_error"><![CDATA[Failed to open article from an invalid URL: %1$s. Check the URL or report this to us either via <a href="mailto:support@oxygenupdater.com">email</a> or on our <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
 	<string name="news_unread_count_1">Du har %1$d ulæst nyhedsartikel. Tryk her for at læse.</string>
 	<string name="news_unread_count_2">Du har %1$d ulæst nyhedsartikel. Tryk her for at få vist alle artikler.</string>
 	<string name="news_mark_read">Marker som læst</string>
@@ -309,13 +256,11 @@ Instructions:
 	<string name="error_app_outdated">Åh nej!</string>
 	<string name="error_app_outdated_message">Appens version er forældet. Det er nu tid til at opdatere den. Tryk på \"Google Play\" herunder. Via Google Play, tryk på \"Opdatér\".</string>
 	<string name="error_app_requires_network_connection">Ingen netværksforbindelse</string>
-	<string name="error_app_requires_network_connection_message">Det lykkedes ikke at forbinde til serveren. Værk sikker på at du har en fungerende internet forbindelse. App\'en vil nu lukke.</string>
 	<string name="error_google_play_button_text">Google Play</string>
-	<string name="error_no_internet_connection">Ingen netværksforbindelse.</string>
 	<string name="error_maintenance">Server vedligeholdelse</string>
 	<string name="error_maintenance_message">Vent venligst. Serveren vil være tilgængelig meget snart.</string>
 	<!-- TODO: translate this string below -->
-	<string name="error_maintenance_retry">The server may be down for maintenance. Try again after some time, or report it to us either via <a href="mailto:support@oxygenupdater.com">email</a> or on our <a href="https://discord.gg/5TXdhKJ">Discord server</a>.</string>
+	<string name="error_maintenance_retry"><![CDATA[The server may be down for maintenance. Try again after some time, or report it to us either via <a href="mailto:support@oxygenupdater.com">email</a> or on our <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
 	<string name="error_reload">Reload</string>
 
 	<string name="error_unable_to_rate_app">Du kan ikke bedømme appen fordi Google Play Store mangler på din enhed.</string>
@@ -329,7 +274,7 @@ Instructions:
 	<!-- TODO: translate the 2 strings below -->
 	<string name="carrier_exclusive_device_warning_message">It looks like you\'re using a carrier-exclusive device. Even though you\'re running OxygenOS, you won\'t be able to install updates. Carriers usually lock down the device so that users can\'t update or modify the firmware without permission from the carrier itself. This is a common practice in the USA: the "Local Upgrade" option is removed from carrier-exclusive versions of OxygenOS. This option is necessary to install updates by yourself, even if you don\'t use this app. Unfortunately, we can\'t do anything about this, as we\'re technically, and possibly, legally limited. Reach out to us via email or Discord for more clarity.</string>
 	<string name="unsupported_device_warning_message">Congratulations on your new OnePlus device! Unfortunately, we haven\'t added support for this device yet. Don\'t worry though, we\'ll add it as soon as we can. We don\'t like making mistakes, and it\'s a time-consuming process to verify and test support for new devices, so please be patient. Email us or join our Discord server if you\'d like to help us, or to get notified when we release a new version of the app that includes support for your device.</string>
-	<string name="unsupported_os_warning_message">Det lader til at din enhed ikke har OxygenOS. Bemærk, at du kan kun installere system opdateringer på enheder der kører med OxygenOS.\n\Andre enheder, her i blandt OnePlus enheder der kører med Brugertilpassede ROM\'s, uderstøttes ikke.</string>
+	<string name="unsupported_os_warning_message">Det lader til at din enhed ikke har OxygenOS. Bemærk, at du kan kun installere system opdateringer på enheder der kører med OxygenOS.\n\nAndre enheder, her i blandt OnePlus enheder der kører med Brugertilpassede ROM\'s, uderstøttes ikke.</string>
 
 	<string name="incorrect_device_warning_title">Valgt enhed stemmer ikke overens</string>
 	<string name="incorrect_device_warning_message">Det ser ud som om du har valgt forkert enhed: \"%1$s\", vælg \"%2$s\". Ændre dit valg i app\'en indstillinger for at sikre at du modtager de rette opdateringer.</string>
@@ -343,7 +288,6 @@ Instructions:
 
 	<!-- Other strings-->
 	<!-- TODO: translate this string below -->
-	<string name="error">Fejl</string>
 	<string name="icon">Ikon</string>
 	<string name="loading">Indlæser…</string>
 	<string name="processing">Arbejder…</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools" tools:keep="@string/install_guide_page_*_*">
-
-	<string name="device_chooser_error_title">Konnte die Liste der unterstützen Geräte nicht abrufen</string>
-
+<resources>
 	<!-- Update information strings -->
 	<string name="enable">Aktivieren</string>
 	<string name="update_information_file_name">"Datei Name: %1$s"</string>
@@ -13,11 +10,10 @@
 	<string name="update_information_banner_server">Tippe hier um wichtige Nachrichten anzuzeigen</string>
 	<string name="update_information_banner_advanced_mode_tip">Du hast den \"%1$s\" Update Zweig ausgewählt. Aktiviere den Fortgeschrittenen Modus um zu diesem Update Zweig zu wechseln.</string>
 	<string name="update_information_header_advanced_mode_hint">Der Fortgeschrittene Modus ist aktiviert</string>
-	<string name="update_information_header_advanced_mode_helper">Da du den Fortgeschrittenen Modus aktiviert hast, kannst du das neueste ZIP für \"%1$s\" herunterladen.\n\nDu kannst den Fortgeschrittenen Modus in den Einstellungen deaktivieren.</string>
-	<string name="update_information_different_version_changelog_notice">Du siehst das Änderungsprotokoll für das aktuellste Update im \"%1$s\" Update Zweig. Wenn du dieses Update installieren willst, musst du zuerst den Fortgeschrittenen Modus in den Einstellungen aktivieren.\n\nWenn du aber das Änderungsprotokoll für deine aktuelle installierte Version anzeigen lassen willst, musst du zu der korrekten Update Methode zurückkehren.</string>
-	<string name="update_information_last_checked_on">"Zuletzt aktualisiert: %1$s"</string>
+	<string name="update_information_header_advanced_mode_helper">Da du den Fortgeschrittenen Modus aktiviert hast, kannst du das neueste ZIP für \"%1$s\" herunterladen. Du kannst den Fortgeschrittenen Modus in den Einstellungen deaktivieren.</string>
+	<string name="update_information_different_version_changelog_notice_base">Hinweis: Dieses Änderungsprotokoll bezieht sich auf die neueste verfügbare Version (%1$s) in der Aktualisierungsmethode \"%2$s\"</string>
+	<string name="update_information_different_version_changelog_notice_advanced">. Wenn Sie dieses Update installieren möchten, müssen Sie in den Einstellungen die Option "Erweiterter Modus" aktivieren.</string>
 	<string name="update_information_no_update_data_available">"Es sind keine Update informationen verfügbar"</string>
-	<string name="update_information_oxygen_os_version">"OxygenOS %1$s"</string>
 	<string name="update_information_system_is_up_to_date">"Dein System ist auf dem neuesten Stand."</string>
 	<string name="update_information_unknown_update_name">"Unbenanntes Update für %1$s"</string>
 	<string name="update_information_view_update_information">"Update Informationen ansehen"</string>
@@ -43,7 +39,7 @@
 	<string name="download_complete">"Download abgeschlossen"</string>
 	<string name="download_complete_notification">"Tippe um die Installation zu starten"</string>
 	<string name="download_error">"Download Fehler"</string>
-	<string name="download_error_close">"SCHLIEẞEN"</string>
+	<string name="download_error_close">"Schließen"</string>
 	<string name="download_error_corrupt">"Die heruntergeladene Update Datei ist beschädigt! Versuche sie erneut herunterzuladen."</string>
 	<string name="download_error_server">"Ein Serverfehler ist während dem herunterladen des Updates aufgetreten. Bitte versuche es erneut herunterzuladen."</string>
 	<string name="download_error_internal">Ein App Fehler ist während dem Herunterladen des Updates aufgetreten. Bitte versuche es erneut herunterzuladen, oder schicke ein Support-Mail wenn es wieder fehlschlagt.</string>
@@ -51,8 +47,8 @@
 
 Wenn du mehr erfahren willst, kannst du uns gerne kontaktieren entweder über <a href="mailto:support@oxygenupdater.com">E-Mail</a> oder über unseren <a href="https://discord.gg/5TXdhKJ">Discord Server</a>.]]></string>
 	<string name="download_error_could_not_move_temp_file">Die Datei wurde heruntergeladen, konnte aber nicht in den richtigen Ordner verschoben werden. Öffnen einen Datei Manager, navigiere zu \"%1$s\" und verschiebe die Datei in die oberste Ebene deines internen Speichers.</string>
-	<string name="download_error_retry">"ERNEUT VERSUCHEN"</string>
-	<string name="download_error_resume">"FORTSETZEN"</string>
+	<string name="download_error_retry">"Erneut versuchen"</string>
+	<string name="download_error_resume">"Fortsetzen"</string>
 	<string name="download_error_storage">"Auf deinem Gerät ist nicht genügend Speicherplatz verfügbar um das Update herunterzuladen. Entferne ein paar Dateien und Versuche erneut es herunterzuladen."</string>
 	<string name="download_failed">"Download fehlgeschlagen"</string>
 	<string name="download_pending">"Der Download wird in Kürze gestartet…"</string>
@@ -88,9 +84,7 @@ Wenn du mehr erfahren willst, kannst du uns gerne kontaktieren entweder über <a
 	<string name="summary_please_wait">Bitte warten…</string>
 	<string name="summary_update_method">Bitte wähle zuerst dein Gerät aus</string>
 	<!-- TODO: check the following translation -->
-	<string name="summary_important_notifications_disabled">Einige wichtige Benachrichtigungen sind deaktiviert: \"%1$s\"</string>
-	<string name="summary_theme">Theme einstellen</string>
-	<string name="summary_language">Sprache einstellen</string>
+	<string name="summary_important_notifications_disabled">Einige wichtige Benachrichtigungen sind deaktiviert:</string>
 	<string name="summary_privacy_policy">Online ansehen</string>
 	<string name="summary_rate_app">Hinterlasse eine 5 Sterne Bewertung</string>
 
@@ -121,115 +115,50 @@ Wenn du mehr erfahren willst, kannst du uns gerne kontaktieren entweder über <a
 
 	<string name="settings_device">"Gerät"</string>
 	<string name="settings_entered_incorrectly">"Fehler beim Speichern der Einstellungen. Bitte wähle dein Gerät und deine Update Methode erneut aus."</string>
-	<string name="settings_explanation_incremental_full_update">"Ein inkrementelles Update kann nur installiert werden wenn du die neuste System Software Version installiert hast bevor dieses Update veröffentlicht wurde.
-
-Ein komplettes Update kann immer installiert werden - egal welche System Software Version aktuell auf deinem Gerät läuft.
-
-Ein OxygenOS Beta Update kann nur installiert werden wenn du bereits eine Beta Version benutzt."</string>
 	<string name="settings_push_from_server">"Informationen und Warnungen"</string>
 	<string name="settings_saving">"Deine Einstellungen werden weiterhin gespeichert. wenn das zu lange dauern sollte: Überprüfe deine Verbindung, schließe die App und starte sie erneut."</string>
 	<string name="settings_advanced_mode">"Fortgeschrittener Modus"</string>
-	<string name="settings_advanced_mode_explanation">"Der Fortgeschrittene Modus deaktiviert die Nachricht \"Dein System ist auf dem neuesten Stand\" und erlaubt es dir sogar Updates herunterzuladen und zu installieren die möglicherweiße nicht mit deinem Gerät kompatibel sind.
+	<string name="settings_advanced_mode_explanation">"Normalerweise zeigt Ihnen die App Updates auf der Grundlage Ihrer aktuellen Betriebssystemversion an. Im erweiterten Modus wird unabhängig von der Geräte-/Versionskompatibilität immer das neueste verfügbare Update angezeigt.
 
-Das könnte nützlich sein wenn du z.B.:
--Von der regulären Version auf eine Beta Version updaten willst
--Von einer Beta Version zur regulären Version zurückkehren willst (Vergiss nicht dein Telefon zurückzusetzen)
--Deine aktuelle Systemversion neuinstallieren willst."</string>
+Dies kann nützlich sein, wenn Sie Folgendes möchten:"</string>
+	<string name="settings_advanced_mode_uses">"&#8226; die neueste Version erneut herunterladen möchten, auch wenn Sie sie bereits installiert haben
+&#8226; Zu einem anderen Update-Track wechseln möchten"</string>
+	<string name="settings_advanced_mode_caption">"Der erweiterte Modus wird nur in den oben genannten Fällen benötigt. Sie sollten ihn nicht aktivieren, wenn Sie nicht wissen, was Sie tun."</string>
 	<string name="settings_update_method">"Aktualisierungsmethode"</string>
 
 	<string name="settings_upload_logs">Teile Nutzungsdaten und Protokolle</string>
+	<string name="settings_ad_privacy">GDPR-Zustimmung zur Werbung</string>
+	<string name="settings_ad_privacy_subtitle">"Für Nutzer in EEA/UK"</string>
 
 	<!-- FAQ strings -->
 	<string name="faq">"FAQ"</string>
 	<string name="faq_menu_item">"FAQ"</string>
 
 	<!-- First-time setup strings -->
-	<string name="onboarding">"Herzlich Willkommen"</string>
+	<string name="onboarding">"Setup"</string>
 	<string name="onboarding_finished_button">"App starten"</string>
-	<string name="onboarding_page_1_title">"Herzlich Willkommen im Oxygen Updater!"</string>
-	<string name="onboarding_page_1_text">"Diese App erlaubt es dir:
+	<string name="onboarding_app_uses">"Diese App erlaubt es dir:
 
-Schneller die neusten Updates für dein OxygenOS Gerät zu bekommen
-
--Ein gerootetes Gerät einfach zu aktualisieren
-
--Zu sehen was in deiner aktuellen Version alles neu ist
-
--Die neusten Updates über OnePlus und OxygenOS zu sehen
-
-Wische nach links um fortzufahren."</string>
-	<string name="onboarding_page_1_caption">"Das ist keine Offizielle OnePlus Applikation. Die Benutzung läuft komplett über deine eigene Verantwortung. Weder OnePlus noch der Entwickler der App haften für deine Aktionen, inbegriffen sind Schäden welche durch die Benutzung dieser App verursacht werden.
-
-durch die Benutzung dieser App stimmst du den oben genannten Nutzungsbedingungen zu.
-
-Wische nach links um fortzufahren."</string>
-	<string name="onboarding_page_2_title">"Wähle dein Gerät"</string>
-	<string name="onboarding_page_2_caption">"Normalerweise sollte dein Gerät bereits oben ausgewählt sein. Falls nicht, wähle dein Gerät oben aus.
-
-Wische nach links um fortzufahren."</string>
-	<string name="onboarding_page_3_title">"Wähle deine Update Methode"</string>
-	<string name="onboarding_page_3_caption">"Für gewöhnlich ist das \"inkrementelle Update\" die richtige Wahl, da es einen schnelleren und kleineren Download bietet.
-
-Dies ist jedoch nicht mit gerooteten Geräten kompatibel. Falls du ein gerootetes Gerät hast dann wähle bitte das \"komplette Update\".
-
-Falls auf deinem Gerät eine Beta Version von OxygenOS läuft, dann wähle eine der offenen Beta Update Methoden.
-
-Wische nach links um fortzufahren."</string>
-	<string name="onboarding_page_4_title">"Du bist fertig!"</string>
-	<string name="onboarding_page_4_text">"Viel Spaß beim Benutzen dieser App!
-
-Du kannst jederzeit die Einstellungen später noch ändern. Drücke dafür auf das drei Punkte Kontext Menü in der rechten oberen Ecke, und drücke auf \"Einstellungen\""</string>
+&#8226; Schneller die neusten Updates für dein OxygenOS Gerät zu bekommen
+&#8226; Ein gerootetes Gerät einfach zu aktualisieren
+&#8226; Zu sehen was in deiner aktuellen Version alles neu ist
+&#8226; Die neusten Updates über OnePlus und OxygenOS zu sehen"</string>
+	<string name="onboarding_disclaimer">"Das ist keine Offizielle OnePlus Applikation. Die Benutzung läuft komplett über deine eigene Verantwortung. Weder OnePlus noch der Entwickler der App haften für deine Aktionen, inbegriffen sind Schäden welche durch die Benutzung dieser App verursacht werden. durch die Benutzung dieser App stimmst du den oben genannten Nutzungsbedingungen zu."</string>
+	<string name="onboarding_device_chooser_title">"Wähle dein Gerät"</string>
+	<string name="onboarding_device_chooser_caption">"Normalerweise sollte dein Gerät bereits oben ausgewählt sein. Falls nicht, wähle dein Gerät oben aus."</string>
+	<string name="onboarding_method_chooser_title">"Wähle deine Update Methode"</string>
+	<string name="onboarding_method_chooser_caption">"Für gewöhnlich ist das \"inkrementelle Update\" die richtige Wahl, da es einen schnelleren und kleineren Download bietet. Dies ist jedoch nicht mit gerooteten Geräten kompatibel. Falls du ein gerootetes Gerät hast dann wähle bitte das \"komplette Update\". Falls auf deinem Gerät eine Beta Version von OxygenOS läuft, dann wähle eine der offenen Beta Update Methoden."</string>
+	<string name="onboarding_caption">"Viel Spaß beim Benutzen dieser App! Du kannst jederzeit die Einstellungen später noch ändern."</string>
 
 	<!-- Automatic install strings -->
 	<string name="install">"Installieren"</string>
 
 	<!-- Install guide strings -->
-	<string name="install_guide_no_root">"Instaliere das Update gemäß den Anweisungen in der Installationsanleitung."</string>
 	<string name="install_guide">"Installationsanleitung"</string>
-	<string name="install_guide_subtitle">"Installationsanleitung - %1$d von %2$d"</string>
-	<string name="install_guide_tip">"&#8226;Es ist empfehlenswert alle Schritte aufzuschreiben, da du dein Gerät während dem Update ausschalten musst."</string>
-	<string name="install_guide_page_1_title">"Update herunterzuladen."</string>
-	<string name="install_guide_page_1_text">"&#8226;Drücke den Download Button um mit dem Hertunterladen des Updates zu starten
-
--Der Download Fortschritt wird in der App angezeigt und als Benachrichtigung in der Benachrichtigungsleiste.
-
--Wenn der Download abgeschlossen ist, wirst du eine Benachrichtigung mit dem Text \"Download abgeschlossen\" erhalten.
+	<string name="install_guide_download_instructions">"&#8226; Drücke den Download Button um mit dem Hertunterladen des Updates zu starten
+&#8226; Der Download Fortschritt wird in der App angezeigt und als Benachrichtigung in der Benachrichtigungsleiste.
+&#8226; Wenn der Download abgeschlossen ist, wirst du eine Benachrichtigung mit dem Text \"Download abgeschlossen\" erhalten.
 Falls es einen Download Fehler gibt, öffne die App und versuche das Update erneut zu downloaden. Wenn das nicht funktioniert, kontrolliere ob du eine funktionierende Internet Verbindung hast. Ansonsten kontaktiere den Entwickler dieser App. Du kannst das wenn du auf \"Meine Apps\" im Google Play Store gehst."</string>
-
-	<string name="install_guide_page_2_title">Installation vorbereiten</string>
-	<string name="install_guide_page_2_text">"Beachte: Die Installation des Updates findet auf einer speziellen Seite deines Systems statt. Sollte aus irgendeinem Grund bereits ein System Update angezeigt werden, installiere dieses zuerst. Danach öffne die App erneut um zu überprüfen ob du auf den neuesten Stand bist.
-
-Anleitung:
-&#8226; Schließe Oxygen Updater durch Drücken des Home Buttons.
-
-&#8226; Öffne deine Systemeinstellungen. Diese sollten über dein App Menü erreichbar sein.
-
-&#8226; Scrolle nach unten bis du System Updates siehst. Klicke darauf."</string>
-
-	<string name="install_guide_page_3_title">Das Update installieren</string>
-	<string name="install_guide_page_3_text">"Da du jetzt in der System Updates App bist ist es Zeit das Update zu installieren.
-
-&#8226; Unter dem Punkt Systemupdate, tippe auf das Zahnrad Symbol in der rechten oberen Ecke.
-
-&#8226; Wähle jetzt \"Lokales Upgrade\" aus. Es sollte ein Bildschirm zur Datei Auswahl erscheinen.
-
-&#8226; In diesem Bildschrim, tippe auf die Update Datei die vom Oxygen Updater heruntergeladen wurde. Der Name sollte mit \"%1$sOxygen\" beginnen.
-
-&#8226; Tippe nun auf \"Upgrade Now\". Die Installation sollte automatisch starten."</string>
-
-	<string name="install_guide_page_4_title">Warte bis die Installation fertiggestellt ist</string>
-	<string name="install_guide_page_4_text">"&#8226; Das Update wird nun installiert und es wird ein Balken mit dem Fortschritt angezeigt. Bitte warte bis die Installation abgeschlossen ist. Installationen können bis zu 15 Minuten dauern.
-
-&#8226; Danach wird dein Handy neugestartet um das Update fertigzustellen."</string>
-
-	<string name="install_guide_page_5_title">"Fertig. Viel Spaß mit der neuen OxygenOS Version!"</string>
-	<string name="install_guide_page_5_text">"&#8226;Sobald dein Gerät das Optimieren der Apps fertiggestellt hat, wurde das Update erfolgreich installiert.
-Um das zu überprüfen, kannst du deine aktuelle Version folgendermaßen kontrollieren:
-
--Gehe in die Einstellungen, tippe auf \"Über das Telefon\", und überprüfe die OxygenOS Version.
-
--Wenn dir die App gefällt, dann gibt ihr doch 5 Sterne im Play Store!"</string>
-	<string name="install_guide_close_button">"Installationsanleitung schließen"</string>
 
 	<!-- Device information strings -->
 	<string name="device_information_supported_oxygen_os">Dein Gerät wird unterstützt</string>
@@ -246,7 +175,7 @@ Um das zu überprüfen, kannst du deine aktuelle Version folgendermaßen kontrol
 	<string name="device_information_image_description">"Geräte Bild"</string>
 	<string name="device_information_incremental_os_version">Inkrementelle OS Version</string>
 	<string name="device_information_os_version">"Android Version"</string>
-	<string name="device_information_oxygen_os_version">"OxygenOS Version"</string>
+	<string name="device_information_oxygen_os_version">"OS Version"</string>
 	<string name="device_information_oxygen_os_ota_version">"OTA Version"</string>
 	<string name="device_information_patch_level_version">Sicherheitspatch-Level</string>
 	<string name="device_information_serial_number">"Seriennummer"</string>
@@ -265,6 +194,8 @@ Um das zu überprüfen, kannst du deine aktuelle Version folgendermaßen kontrol
 	<string name="about_email_button_text">E-Mail</string>
 
 	<!-- LocalNotifications strings -->
+	<string name="notification_permission_title">"Bleiben Sie benachrichtigt"</string>
+	<string name="notification_permission_text">"Bitte erlauben Sie der App, Sie über OTA-Updates, Neuigkeiten, den aktuellen Download-Status und andere wichtige Dinge zu informieren. Sie können Ihre Präferenzen später in den Einstellungen der App feinabstimmen."</string>
 	<string name="notification_new_device_text">"Das %1$s wird jetzt unterstützt. Öffne die App um dieses Gerät auszuwählen."</string>
 	<string name="notification_no_notification_support">"Installiere oder Update die Google Play Dienste um Push Nachrichten zu erlauben."</string>
 	<string name="notification_version">"%1$s ist jetzt verfügbar für das %2$s!"</string>
@@ -290,38 +221,9 @@ Um das zu überprüfen, kannst du deine aktuelle Version folgendermaßen kontrol
 	<string name="general_notification_channel_description">Allgemeine Nachrichten die in keine andere Kategorie passen</string>
 	<string name="url_submitted_notification_channel_description">Sie werden benachrichtigt, wenn Sie OTA-URLs erfolgreich an unser Team übermittelt haben.\nSie können die automatische Übermittlung von URLs in den Einstellungen der App deaktivieren.</string>
 
-	<!-- Help strings -->
-	<string name="help">"Hilfe"</string>
-	<string name="help_updating_your_device_title">"Dein Gerät wird aktualisiert"</string>
-	<string name="help_updating_your_device_text">"Wenn du die App öffnest, siehst du ob ein System Update verfügbar ist. Wenn eines Verfügbar ist, kannst du es installieren.
-
-Um die Installation zu starten, tippe auf den \"Download\" Button (unter der Update Beschreibung) um den Download zu starten. Wenn der Download abgeschlossen wurde, erscheint der Installations Bildschirm. falls du die App verlassen hast oder der Bildschirm nicht erscheint, tippe auf den \"Installieren\" Button, welcher dann statt dem Download Button angezeigt wird.
-
-Der Installationsbildschirm überprüft als erstes ob du ein gerootetes Gerät hast. Falls du ein gerootetes Gerät hast, dann gewähre Root Berechtigung und wähle aus wie du das Update installieren möchtest. Ansonsten befolge die Anleitung für die Manuelle Installation.
-
-Automatisch Installieren:
-Du musst nur deine Installationsoption wählen."</string>
-	<string name="help_reading_news_title">Lese die neuesten Nachrichten</string>
-	<string name="help_reading_news_text">"Neuigkeiten findest du rechts von der Update Seite. Die neusten Neuigkeiten werden oben angezeigt. Tippe einfach darauf zum Anzeigen.
-Tippe auf die Zurück Taste um zurück zu den Neuigkeiten zu kommen."</string>
-	<string name="help_device_information_title">"Informationen über das Gerät anzeigen"</string>
-	<string name="help_device_information_text">"Sie können einige der Spezifikationen ihres Gerätes anschauen indem Sie die Seite rechts neben der \"Update\" Seite benutzen. Dieser Spezifikationen könnten zum Beispiel nützlich sein wenn Sie eine Supportanfrage einreichen."</string>
-	<string name="help_change_settings_title">"Einstellungen ändern"</string>
-	<string name="help_change_settings_text">"Sie können ihre Einstellungen durch das Menü oben rechts (mit der Option \"Einstellungen\") ändern:
-
-• Gerät und Update Methode
-• Mitteilungen (Push)
-• Mitteilungen (In-App)
-• Privatsphäre Einstellungen (Protokol Übermittlung)
-
-Benutzen sie die Schalter zum Ein-/Ausschalten der Mitteilungs- und Privatsphäreoptionen. Wählen sie ein Gerät oder eine Update Methode aus der Liste aus. Liste nicht verfügbar? Überprüfen sie ihre Verbindung und öffnen Sie die Einstellungen erneut."</string>
-
 	<!-- News strings -->
 	<string name="news">"Neuigkeiten"</string>
-	<string name="news_date_published">"Letztes Update: %1$s"</string>
-	<string name="news_empty">"Dieser Artikel hat keinen Inhalt."</string>
-	<string name="news_load_network_error">"Fehler "</string>
-	<string name="news_load_id_error"><![CDATA[Der Artikel konnte nicht über den Link geöffnet werden: %1$s. Überprüfe den Link oder melde ihn uns per <a href="mailto:support@oxygenupdater.com">E-Mail</a> oder über unseren <a href="https://discord.gg/5TXdhKJ">Discord Server</a>.]]></string>
+	<string name="news_load_network_error">"Der Artikel konnte nicht geöffnet werden. Überprüfen Sie Ihre Verbindung und drücken Sie die Taste \"Erneut versuchen\", um den Artikel zu öffnen."</string>
 	<string name="news_unread_count_1">Sie haben %1$d ungelesene Nachrichtenartikel. Tippe hier um sie anzuzeigen.</string>
 	<string name="news_unread_count_2">Sie haben %1$d ungelesene Nachrichtenartikel. Tippe um alle Artikel anzuzeigen.</string>
 	<string name="news_mark_read">Als gelesen markieren</string>
@@ -346,12 +248,10 @@ Benutzen sie die Schalter zum Ein-/Ausschalten der Mitteilungs- und Privatsphär
 	<string name="error_app_outdated">"Oh nein!"</string>
 	<string name="error_app_outdated_message">"Diese Version der App ist veraltet. Es ist Zeit, sie zu aktualisieren! Tippe Sie unten auf \"Google Play\". Tippen Sie im Google Play Store auf \"Aktualisieren\"."</string>
 	<string name="error_app_requires_network_connection">"Keine Verbindung"</string>
-	<string name="error_app_requires_network_connection_message">"Verbindung zum Server fehlgeschlagen. Überprüfen Sie Ihre Verbindung und versuchen Sie es erneut. Die App wird nun beendet."</string>
-	<string name="error_no_internet_connection">"Keine Verbindung"</string>
 	<string name="error_maintenance">"Server Wartungsarbeiten"</string>
 
 	<string name="error_maintenance_message">"Bitte haben Sie Geduld. Der Server wird bald wieder erreichbar sein."</string>
-	<string name="error_maintenance_retry">Möglicherweiße sind die Server gerade wegen Wartungsarbeiten heruntergefahren. Versuchen Sie es später noch einmal oder melden es und entweder über <a href="mailto:support@oxygenupdater.com">E-Mail</a> oder auf unserem <a href="https://discord.gg/5TXdhKJ">Discord Server</a>.</string>
+	<string name="error_maintenance_retry"><![CDATA[Möglicherweiße sind die Server gerade wegen Wartungsarbeiten heruntergefahren. Versuchen Sie es später noch einmal oder melden es und entweder über <a href="mailto:support@oxygenupdater.com">E-Mail</a> oder auf unserem <a href="https://discord.gg/5TXdhKJ">Discord Server</a>.]]></string>
 
 	<string name="error_reload">"Aktualisieren"</string>
 	<string name="error_unable_to_rate_app">"Du kannst die App nicht bewerten, weil auf deinem Gerät kein Google Play Store gefunden wurde."</string>
@@ -379,7 +279,6 @@ Andere Geräte, inklusive OnePlus Geräten mit Custom ROMs, werden nicht unterst
 	<string name="purchase_error_after_payment">"Der Kauf der Werbe-freien Version ist durch einen internen Fehler fehlgeschlagen. Bitte versuche es in ein paar Minuten nochmal. Wenn du bereits bezahlt hast, kontaktiere bitte den Google Play Support für Hilfe."</string>
 	Halte die App auf dem neuesten Stand um sicherzustellen, dass du alle neuen Features und Bugfixes bekommst
 	<!-- Other strings -->
-	<string name="error">Fehler</string>
 	<string name="icon">"Icon"</string>
 	<string name="loading">"Laden…"</string>
 	<string name="processing">"Bearbeiten…"</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools" tools:keep="@string/install_guide_page_*_*">
-	<!-- TODO: translate this string below -->
-	<string name="device_chooser_error_title">Couldn\'t retrieve list of supported devices</string>
-
+<resources>
 	<!-- Update information strings-->
 	<!-- TODO: translate this string below -->
 	<string name="enable">Habilitar</string>
@@ -16,13 +13,12 @@
 	<!-- TODO: translate these 6 strings below -->
 	<string name="update_information_error_title">Couldn\'t retrieve latest update data information</string>
 	<string name="update_information_banner_server">Tap here to view important notices</string>
-	<string name="update_information_banner_advanced_mode_tip">You\'ve selected the \"%1$s\" update track. Enable modo avanzado if you plan to switch to this update track.</string>
+	<string name="update_information_banner_advanced_mode_tip">You\'ve selected the \"%1$s\" update method. Enable modo avanzado if you plan to switch to this update method.</string>
 	<string name="update_information_header_advanced_mode_hint">El modo avanzado está habilitado</string>
-	<string name="update_information_header_advanced_mode_helper">Since you\'ve enabled modo avanzado, you can download the latest ZIP for \"%1$s\".\n\nYou can turn modo avanzado off from settings.</string>
-	<string name="update_information_different_version_changelog_notice">You\'re viewing a changelog for the latest update in the \"%1$s\" upgrade track. If you intend to install this update, you must turn modo avanzado on first (in settings).\n\nHowever, if you wish to see the changelog for the currently installed version instead, you\'ll need to switch back to the correct update method.</string>
-	<string name="update_information_last_checked_on">Última comprobación el: %1$s</string>
+	<string name="update_information_header_advanced_mode_helper">Since you\'ve enabled modo avanzado, you can download the latest ZIP for \"%1$s\". You can turn modo avanzado off from settings.</string>
+	<string name="update_information_different_version_changelog_notice_base">Nota: este registro de cambios corresponde a la última versión disponible (%1$s) en el método de actualización \"%2$s\"</string>
+	<string name="update_information_different_version_changelog_notice_advanced">. Si desea instalar esta actualización, debe activar el "Modo avanzado" en la configuración.</string>
 	<string name="update_information_no_update_data_available">No hay ninguna información de la actualización.</string>
-	<string name="update_information_oxygen_os_version">OxygenOS %1$s</string>
 	<string name="update_information_system_is_up_to_date">Tu sistema está actualizado.</string>
 	<string name="update_information_unknown_update_name">Actualización sin nombre para el %1$s</string>
 	<string name="update_information_view_update_information">Ver las caracterísicas de la actualización</string>
@@ -50,7 +46,7 @@
 	<string name="download_complete_notification">Pulsa para comenzar la instalación</string>
 
 	<string name="download_error">Error de Descarga</string>
-	<string name="download_error_close">CERRAR</string>
+	<string name="download_error_close">Cerrar</string>
 	<string name="download_error_corrupt">¡El archivo de la actualización descargado está dañado! Por favor, intenta descargarlo de nuevo.</string>
 	<string name="download_error_server">Ha ocurrido un error en el servidor mientras se descargaba la actualización. Por favor, intenta descargar la actualización de nuevo.</string>
 	<string name="download_error_internal">Desafortunadamente, un error técnico ha ocurrido mientras se descargaba la actualización. Intenta descargarla de nuevo. Si el error no desaparece, por favor contacta con el desarrollador de esta app para obtener asistencia.</string>
@@ -60,8 +56,8 @@
 If you\'d like to know more, feel free to contact us either via <a href="mailto:support@oxygenupdater.com">email</a> or on our <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
 	<string name="download_error_could_not_move_temp_file">The file has been downloaded, but couldn\'t be moved to the correct directory. Open a file manager, navigate to \"%1$s\" and manually move the file to the topmost directory of internal storage.</string>
 
-	<string name="download_error_retry">REINTENTAR</string>
-	<string name="download_error_resume">RESUMIR</string>
+	<string name="download_error_retry">Reintentar</string>
+	<string name="download_error_resume">Resumir</string>
 	<string name="download_error_storage">No hay suficiente espacio en el dispositivo para descargar la actualización. Por favor, elimina algunos archivos e inténtalo de nuevo.</string>
 
 	<string name="download_failed">Descarga fallida</string>
@@ -99,9 +95,7 @@ If you\'d like to know more, feel free to contact us either via <a href="mailto:
 	<string name="summary_please_wait">Por favor, espera…</string>
 	<string name="summary_update_method">Selecciona un dispositivo primero</string>
 	<!-- TODO: check the following translation -->
-	<string name="summary_important_notifications_disabled">Algunas notificaciones importantes están desactivadas: \"%1$s\"</string>
-	<string name="summary_theme">Establecer tema</string>
-	<string name="summary_language">Elegir lenguaje</string>
+	<string name="summary_important_notifications_disabled">Algunas notificaciones importantes están desactivadas:</string>
 	<string name="summary_privacy_policy">Ver online</string>
 	<string name="summary_rate_app">Deja un comentario de 5 estrellas</string>
 
@@ -132,81 +126,46 @@ If you\'d like to know more, feel free to contact us either via <a href="mailto:
 
 	<string name="settings_device">Dispositivo</string>
 	<string name="settings_entered_incorrectly">Error al guardar tus preferencias. Por favor, regresa y selecciona tu dispositivo de nuevo / método de actualización de nuevo.</string>
-	<string name="settings_explanation_incremental_full_update">Una actualización incremental puede instalarse desde cualquier versión (excepto si tienes el bootloader desbloqueado ya que tendras que usar el paquete completo para actualizar tu dispositivo).\n\nUna actualización beta de OxygenOS siempre podrá ser instalada, incluso cuando estás en la versión estable. Para cambiar de la estable a la beta, activa el modo avanzado en los ajustes. Para las betas, los métodos de actualización incremental y completo funcionan de las misma manera que en la versión estable.</string>
 
 	<string name="settings_push_from_server">Mensajes con avisos disponibles</string>
 
 	<string name="settings_saving">Tus preferencias todavía se están guardando. Si tarda mucho tiempo: Comprueba tu conexión a Internet, sal de la app e iníciala de nuevo.</string>
 
 	<string name="settings_advanced_mode">Modo avanzado</string>
-	<string name="settings_advanced_mode_explanation">El modo avanzado oculta el mensaje \"Tu sisema está actualizado\", permitiéndote descargar e instalar todas las actualizaciones, Incluso cuando estas no sean compatibles con tu dispositivo.\n\nEsto puede resultar útil cuando:\n&#8226; Actualices a una versión beta desde la versión estable\n&#8226; Vuelvas de la versión beta a la estable (no olvides hacer un reseteo de fábrica)\n&#8226; Reinstales tu versión del sistema actual.</string>
+	<string name="settings_advanced_mode_explanation">"Normalmente, la aplicación muestra las actualizaciones en función de la versión actual del sistema operativo. Con el modo avanzado, siempre se mostrará la última actualización disponible, independientemente de la compatibilidad dispositivo/versión.
+
+Esto puede ser útil si quieres:"</string>
+	<string name="settings_advanced_mode_uses">"&#8226; Volver a descargar la última versión aunque ya estés en ella
+&#8226; Cambiar a una pista de actualización diferente"</string>
+	<string name="settings_advanced_mode_caption">"El modo avanzado puede ser necesario sólo en las situaciones anteriores. No deberías activarlo a menos que sepas lo que estás haciendo."</string>
 
 	<string name="settings_update_method">Método de actualización</string>
 	<string name="settings_upload_logs">Comparte con nosotros datos de uso y registros</string>
+	<string name="settings_ad_privacy">Consentimiento de publicidad GDPR</string>
+	<string name="settings_ad_privacy_subtitle">"Para usuarios del EEE/Reino Unido"</string>
 
 	<!-- FAQ strings -->
 	<string name="faq">FAQ</string>
 	<string name="faq_menu_item">FAQ</string>
 
 	<!-- First-time setup strings -->
-	<string name="onboarding">Bienvenido</string>
+	<string name="onboarding">Setup</string>
 	<string name="onboarding_finished_button">iniciar app</string>
 
-	<string name="onboarding_page_1_title">¡Bienvenido a Oxygen Updater!</string>
-	<string name="onboarding_page_1_text">Esta app te permitirá:\n\n&#8226; Acceder rápidamente a nuevas actualizaciones para tu OnePlus gracias a OxygenOS\n\n&#8226; Actualiza fácilmente tu dispositivo con acceso root\n\n&#8226; Ver las novedades del sistema operativo que estás usando actualmente\n\n&#8226; Leer las últimas noticias sobre OnePlus y OxygenOS\n\nDesliza a la izquierda para continuar.</string>
-	<string name="onboarding_page_1_caption">Esta no es una aplicación oficial de OnePlus. El uso de esta app está sujeto a tu propia responsabilidad. Ni OnePlus ni el desarrollador son responsables de tu acciones, incluyendo el daño causado por esta app.\n\nAl usar esta app, aceptas los términos y condiciones arriba mencionados.</string>
-	<string name="onboarding_page_2_title">Elige tu dispositivo</string>
-	<string name="onboarding_page_2_caption">Tu dispositivo suele seleccionarse automáticamente. Si no es así, selecciona tu dispositivo arriba.</string>
-	<string name="onboarding_page_3_title">Elige el método para actualizar</string>
-	<string name="onboarding_page_3_caption">Normalmente, la actualización incremental es la mejor opción ya que ofrece unas descargas menos pesadas y más rápidas.\n\Sin embargo, no es compatible con dispositivos rooteados. Si tu dispositivo tiene root, Elige la actualización completa.\n\nSi tienes una versión beta de OxygenOS, elige (uno de los) método(s) de actualización de la beta abierta.</string>
-	<string name="onboarding_page_4_title">¡Ya estás listo para comenzar!</string>
-	<string name="onboarding_page_4_text">¡Disfruta esta app!\n\nSiempre podrás cambiar las preferencias más tarde. Para hacerlo: Haz click en los tres puntos en la esquina derecha, y selecciona \"Ajustes\".</string>
+	<string name="onboarding_app_uses">Esta app te permitirá:\n\n&#8226; Acceder rápidamente a nuevas actualizaciones para tu OnePlus gracias a OxygenOS\n&#8226; Actualiza fácilmente tu dispositivo con acceso root\n&#8226; Ver las novedades del sistema operativo que estás usando actualmente\n&#8226; Leer las últimas noticias sobre OnePlus y OxygenOS</string>
+	<string name="onboarding_disclaimer">Esta no es una aplicación oficial de OnePlus. El uso de esta app está sujeto a tu propia responsabilidad. Ni OnePlus ni el desarrollador son responsables de tu acciones, incluyendo el daño causado por esta app. Al usar esta app, aceptas los términos y condiciones arriba mencionados.</string>
+	<string name="onboarding_device_chooser_title">Elige tu dispositivo</string>
+	<string name="onboarding_device_chooser_caption">Tu dispositivo suele seleccionarse automáticamente. Si no es así, selecciona tu dispositivo arriba.</string>
+	<string name="onboarding_method_chooser_title">Elige el método para actualizar</string>
+	<string name="onboarding_method_chooser_caption">Normalmente, la actualización incremental es la mejor opción ya que ofrece unas descargas menos pesadas y más rápidas. Sin embargo, no es compatible con dispositivos rooteados. Si tu dispositivo tiene root, Elige la actualización completa. Si tienes una versión beta de OxygenOS, elige (uno de los) método(s) de actualización de la beta abierta.</string>
+	<string name="onboarding_caption">¡Disfruta esta app! Siempre podrás cambiar las preferencias más tarde.</string>
 
 	<!-- Automatic install strings -->
 	<string name="install">Instalar</string>
 
 	<!-- Install guide strings -->
-	<string name="install_guide_no_root">Instalar la actualización basándose en las instrucciones de la guía de instalación.</string>
 	<string name="install_guide">Guía de instalación</string>
-	<string name="install_guide_subtitle">Guía de instalación - %1$d de %2$d</string>
-	<string name="install_guide_tip">&#8226; Es recomendable apuntar todos los pasos a seguir ya que deberás apagar tu dispositivo en el proceso de actualización.</string>
-
-	<string name="install_guide_page_1_title">Descargar la actualización</string>
-	<string name="install_guide_page_1_text">&#8226; Pulsa el botón Descargar para empezar a descargar la actualización.\n\n&#8226; El progreso de la descarga aparecerá en la aplicación y como notificación.\n\n&#8226; Cuando la descarga haya terminado, verás una notificación diciendo \"Descarga completa\".\nSi ocurre algún error durante la descarga, abre la app e intenta descargar la actualización de nuevo. Si esto no funciona, asegúrate de que tienes una conexión a internet. De otra manera, contacta con el desarrollador de esta app. Puedes hacer esto visitando la sección \"Mis aplicaciones\" en Google Play Store.</string>
-
-	<!-- TODO: translate these 2 strings below -->
-	<string name="install_guide_page_2_title">Prepare for installation</string>
-	<string name="install_guide_page_2_text">"Note: The installation of the update takes place from a special page of the standard System Updates section of your device. If, for some reason, a system update appears when opening this section, you may also opt to install that update first. Afterwards, open Oxygen Updater again to see if you're completely up-to-date.
-
-Instructions:
-&#8226; Close Oxygen Updater by pressing the home button.
-
-&#8226; Open the Settings app. It should be located in your app drawer.
-
-&#8226; Scroll down until you see System updates. Tap on it."</string>
-
-	<!-- TODO: translate these 2 strings below -->
-	<string name="install_guide_page_3_title">Install the update</string>
-	<string name="install_guide_page_3_text">"Now that you're in the System Updates app, it's time to install the update.
-
-&#8226; Within the System Updates section, tap the gear icon in the top right
-
-&#8226; Now, select \"Local upgrade\". A file selection screen should appear.
-
-&#8226; In this screen, tap on the update file you downloaded using Oxygen Updater. Its name should start with \"%1$sOxygen\".
-
-&#8226; Tap on \"Upgrade Now\". The installation should start automatically."</string>
-
-	<!-- TODO: translate these 2 strings below -->
-	<string name="install_guide_page_4_title">Wait until the installation completes</string>
-	<string name="install_guide_page_4_text">"&#8226; The phone will now install the update and displays a progress bar. Please wait until the installation has finished. Installation may take anywhere from a few minutes up to 15 minutes.
-
-&#8226; Afterwards, your phone will restart to complete the update."</string>
-
-	<string name="install_guide_page_5_title">Hecho. ¡Disfruta de la nueva versión de OxygenOS!</string>
-	<string name="install_guide_page_5_text">&#8226; Después de que el dispositivo haya terminado de optimizar tus apps, la actualización se habrá instalado correctamente.\nPara verificarlo,puedes comprobar la versión actual del sistema:\n\n&#8226; Ve a ajustes, pulsa en \"Información del teléfono\", y comprueba tu versión de OxygenOS.\n\n&#8226; Si te gusta esta app, ¡valórala con 5 stars en Google Play!</string>
-
-	<string name="install_guide_close_button">Cerrar la guía de instalación</string>
+	<string name="install_guide_download_instructions">&#8226; Pulsa el botón Descargar para empezar a descargar la actualización.\n&#8226; El progreso de la descarga aparecerá en la aplicación y como notificación.\n&#8226; Cuando la descarga haya terminado, verás una notificación diciendo \"Descarga completa\". Si ocurre algún error durante la descarga, abre la app e intenta descargar la actualización de nuevo. Si esto no funciona, asegúrate de que tienes una conexión a internet. De otra manera, contacta con el desarrollador de esta app. Puedes hacer esto visitando la sección \"Mis aplicaciones\" en Google Play Store.</string>
 
 	<!-- Device information strings -->
 	<!-- TODO: translate these 4 strings below -->
@@ -224,7 +183,7 @@ Instructions:
 	<string name="device_information_image_description">Imagen de dispositivo</string>
 	<string name="device_information_incremental_os_version">Versión Incremental del SO</string>
 	<string name="device_information_os_version">Versión de Android</string>
-	<string name="device_information_oxygen_os_version">Versión de OxygenOS</string>
+	<string name="device_information_oxygen_os_version">Versión de OS</string>
 	<string name="device_information_oxygen_os_ota_version">Versión de OTA</string>
 	<string name="device_information_patch_level_version">Fecha del parche de seguridad</string>
 	<string name="device_information_serial_number">Número de serie</string>
@@ -245,6 +204,8 @@ Instructions:
 	<string name="about_email_button_text">Correo electrónico</string>
 
 	<!-- LocalNotifications strings -->
+	<string name="notification_permission_title">"Mantente informado"</string>
+	<string name="notification_permission_text">"Permite que la aplicación te notifique las actualizaciones OTA, las noticias, el estado de las descargas en curso y otras cosas importantes. Puedes ajustar tus preferencias más adelante en los ajustes de la aplicación."</string>
 	<string name="notification_new_device_text">El %1$s está ya soportado. Abre la app para eslegir este dispositivo.</string>
 	<string name="notification_no_notification_support">Instala o actualiza los servicios de Google Play para activar las notificaciones push.</string>
 	<string name="notification_version">%1$s está ahora disponible para el %2$s!</string>
@@ -271,24 +232,10 @@ Instructions:
 	<string name="general_notification_channel_description">General notifications that don\'t fit into other categories</string>
 	<string name="url_submitted_notification_channel_description">Recibe una notificación cuando hayas enviado URL de OTA a nuestro equipo.\nPuedes desactivar el envío automático de URL en los ajustes de la aplicación.</string>
 
-	<!-- Help strings -->
-	<string name="help">Ayuda</string>
-	<string name="help_updating_your_device_title">Actualizar tu dispositivo</string>
-	<string name="help_updating_your_device_text">Al abrir la app, verás si hay alguna actualización disponible. Si hay alguna actualización disponible, podrás instalarla.\n\nPara comenzar la instalación, presiona el botón \"Descargar\" (debajo de la descripción de la actualización) para comenzar la descarga. Cuando se haya terminado de descargar, la pantalla de instalación te mostrará un mensaje. Si has salido de la app o no se te ha mostrado el mensaje, presiona el botón \"Instalar\", que se mostrará al lado del botón \"Descargar\".\n\nPrimero se verificará si tu dispositivo tiene acceso root. Si tu dispositivo está rooteado, dale permisos root y elige cómo quieres instalar la actualización. En caso contrario, Sigue las instrucciones para una instalación manual.\n\nInstalación automática:\nSólo tendrás que elegir las opciones para la actualización. Los ajustes recomendados son los que vienen por defecto, excepto cuando tienes que especificar el paquete root tiene que ser (re)instalado. Selecciona un paquete root (archivo zip) usando el botón azul y pulsa en \"Iniciar instalación\" para comenzar la instalación.\n\nInstalación manual:\nVerás un guía de instalación en tu pantalla. Apunta las instrucciones y síguelas al emepzar a instalar la actualización.</string>
-	<string name="help_reading_news_title">Leer las últimas noticias</string>
-	<string name="help_reading_news_text">Las norticias se muestran a la izquierda de la pantalla de actualización. Las más recientes aparece en la parte superior. Simplemente selecciona un noticia y léela.\nPresiona la flecha de retorno o presiona el botón de volver para ver la pantalla de noticias.</string>
-	<string name="help_device_information_title">Ver la información de tu dispositivo</string>
-	<string name="help_device_information_text">Verás algunas especificaciones de tu dispositivo al deslizar a las izquierda desde la pantalla de actualización. Esta información es útil cuando se realiza una solicitud para soporte, en la cual serás preguntado por algunas especificaciones de tu dispositivo.</string>
-	<string name="help_change_settings_title">Cambiar los ajustes</string>
-	<string name="help_change_settings_text">Puedes cambiar los ajustes pulsando los tres puntos en la esquina derecha, segido por una pulsación en Ajustes.\nPuedes cambiar los siguientes ajustes:\n\n• Dispositivo u método de actualización\n• Notificaciones\n• Notificaciones dentro de la app\n• Ajustes de privacidad(subida de registros de errores).\n\nUsa los botones para activar o desactivar las notificaciones / ajustes de privacidad. Selecciona un dispositivo y / o actualiza el método de actualización usando los menús desplegables debajo de los botones. ¿Los menus desplegables no aparecen? Comprueba tu conexión a Internet y abre los Ajustes de nuevo.</string>
-
 	<!-- News strings -->
 	<string name="news">Noticias</string>
-	<string name="news_date_published">Última actualización: %1$s</string>
-	<string name="news_empty">El artículo no tiene contenido.</string>
-	<string name="news_load_network_error">Error al abrir el artículo. Comprueba tu conexión y pulsa el botón \"REINTENTAR\" para abrir el artículo.</string>
+	<string name="news_load_network_error">Error al abrir el artículo. Comprueba tu conexión y pulsa el botón \"Reintentar\" para abrir el artículo.</string>
 	<!-- TODO: translate this string below -->
-	<string name="news_load_id_error"><![CDATA[Failed to open article from an invalid URL: %1$s. Check the URL or report this to us either via <a href="mailto:support@oxygenupdater.com">email</a> or on our <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
 	<!-- TODO: translate these 2 strings below -->
 	<string name="news_unread_count_1">You have %1$d unread news articles. Tap here to view them.</string>
 	<string name="news_unread_count_2">You have %1$d unread news articles. Tap to show all articles.</string>
@@ -316,13 +263,11 @@ Instructions:
 	<string name="error_app_outdated">¡Oh no!</string>
 	<string name="error_app_outdated_message">La versión de la app está desactualizada. ¡Es hora de actualizarla! Pulsa en \"Google Play\" abajo. Dentro de Google Play, presiona \"Actualizar\".</string>
 	<string name="error_app_requires_network_connection">Sin conexión</string>
-	<string name="error_app_requires_network_connection_message">Error al conectar con el servidor. Por favor, asegúrate de que tienes una conexión a internet. The app will now close.</string>
 	<string name="error_google_play_button_text">Google Play</string>
-	<string name="error_no_internet_connection">Sin conexión.</string>
 	<string name="error_maintenance">Servidor en mantenimiento</string>
 	<string name="error_maintenance_message">Por favor espera. El servidor estará disponible muy pronto.</string>
 	<!-- TODO: translate this string below -->
-	<string name="error_maintenance_retry">The server may be down for maintenance. Try again after some time, or report it to us either via <a href="mailto:support@oxygenupdater.com">email</a> or on our <a href="https://discord.gg/5TXdhKJ">Discord server</a>.</string>
+	<string name="error_maintenance_retry"><![CDATA[The server may be down for maintenance. Try again after some time, or report it to us either via <a href="mailto:support@oxygenupdater.com">email</a> or on our <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
 	<string name="error_reload">Recargar</string>
 
 	<string name="error_unable_to_rate_app">No puedes valorar la app ya que Google Play Store no está instalado en tu dispositivo.</string>
@@ -350,7 +295,6 @@ Instructions:
 	<string name="purchase_error_after_payment">La compra de la versión sin anuncios ha fallado a causa de un error interno. Por favor, inténtalo de nuevo en unos minutos. Si ya has hecho el pago, por favor, contacta con el soporte de Google Play para que lo resuelvan.</string>
 
 	<!-- Other strings-->
-	<string name="error">Error</string>
 	<string name="icon">Icono</string>
 	<string name="loading">Cargando…</string>
 	<string name="processing">Procesando…</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools" tools:keep="@string/install_guide_page_*_*">
-
-	<string name="device_chooser_error_title">Ei voitu hakea listaa tuetuista laitteista</string>
-
+<resources>
 	<!-- Update information strings -->
 	<string name="enable">Ota käyttöön</string>
 	<string name="update_information_file_name">"Tiedostonimi: %1$s"</string>
@@ -12,13 +9,12 @@
 	<string name="update_information_error_title">Ei voitu hakea uusia päivitystietoja</string>
 	<string name="update_information_banner_server">Paina tästä nähdäksesi tärkeät ilmoitukset</string>
 	<!-- TODO: translate these 2 strings below -->
-	<string name="update_information_banner_advanced_mode_tip">You\'ve selected the \"%1$s\" update track. Enable kehittynyt tila if you plan to switch to this update track.</string>
+	<string name="update_information_banner_advanced_mode_tip">You\'ve selected the \"%1$s\" update method. Enable kehittynyt tila if you plan to switch to this update method.</string>
 	<string name="update_information_header_advanced_mode_hint">Edistynyt tila on käytössä</string>
-	<string name="update_information_header_advanced_mode_helper">Edistynyt tila on käytössä, voit ladata viimeisimmän \"%1$s\" ZIP:in.\n\nEdistyneen tilan saat pois käytöstä asetuksista.</string>
-	<string name="update_information_different_version_changelog_notice">Katsot viimeisimmän \"%1$s\" päivityksen muutoslokia. Jos aiot asentaa tämän päivityksen, sinun täytyy ottaa käyttöön edistynyt tila asetuksista.\n\nJos haluat nähdä muutoslokin tällä hetkellä asennettuna olevasta versiosta, sinun täytyy vaihtaa takaisin oikeaan päivitystapaan.</string>
-	<string name="update_information_last_checked_on">"Viimeksi tarkistettu: %1$s"</string>
+	<string name="update_information_header_advanced_mode_helper">Edistynyt tila on käytössä, voit ladata viimeisimmän \"%1$s\" ZIP:in. Edistyneen tilan saat pois käytöstä asetuksista.</string>
+	<string name="update_information_different_version_changelog_notice_base">Huomautus: tämä muutosluettelo koskee uusinta saatavilla olevaa versiota (%1$s) \"%2$s\" päivitysmenetelmällä</string>
+	<string name="update_information_different_version_changelog_notice_advanced">. Jos aiot asentaa tämän päivityksen, sinun on otettava asetuksissa käyttöön \"Kehittynyt tila\".</string>
 	<string name="update_information_no_update_data_available">"Päivitystietoja ei saatavilla"</string>
-	<string name="update_information_oxygen_os_version">"OxygenOS %1$s"</string>
 	<string name="update_information_system_is_up_to_date">"Järjestelmäsi on ajan tasalla."</string>
 	<string name="update_information_unknown_update_name">"Versionumeroton päivitys laitteelle %1$s"</string>
 	<string name="update_information_view_update_information">"Katso päivityksen tiedot"</string>
@@ -90,9 +86,7 @@ Jos haluat tietää enemmän, voit ottaa yhtettä joko <a href="mailto:support@o
 	<string name="summary_please_wait">Ole hyvä ja odota…</string>
 	<string name="summary_update_method">Valitse laite ensin</string>
 	<!-- TODO: check the following translation -->
-	<string name="summary_important_notifications_disabled">Jotkin tärkeät ilmoitukset on poistettu käytöstä: \"%1$s\"</string>
-	<string name="summary_theme">Aseta teema</string>
-	<string name="summary_language">Aseta kieli</string>
+	<string name="summary_important_notifications_disabled">Jotkin tärkeät ilmoitukset on poistettu käytöstä:</string>
 	<string name="summary_privacy_policy">Katso verkkosivuilta</string>
 	<string name="summary_rate_app">Anna 5 tähden arvostelu</string>
 
@@ -123,113 +117,49 @@ Jos haluat tietää enemmän, voit ottaa yhtettä joko <a href="mailto:support@o
 
 	<string name="settings_device">"Laite"</string>
 	<string name="settings_entered_incorrectly">"Virhe tallennettaessa asetuksia. Ole hyvä mene takaisin ja valitse laite / päivitystapa uudelleen."</string>
-	<string name="settings_explanation_incremental_full_update">"Lisäävä päivitys voidaan asentaa vain jos käytössäsi on viimeisin järjestelmäversio ennen kuin tämä päivitys julkaistiin.
-
-Täydellinen päivitys voidaan asentaa aina - huolimatta nykyisestä järjestelmäversiosta joka on asennettuna.
-
-Beta päivitys voidaan asentaa vain jos sinulla on jo käytössäsi OxygenOS beta versio."</string>
 	<string name="settings_push_from_server">"Tiedotus- ja varoitusviestit"</string>
 	<string name="settings_saving">"Asetuksiasi tallennetaan edelleen. Jos tämä tuntuu vievän liian pitkään varmista verkkoyhteytesi, sulje sovellus ja käynnistä se uudelleen."</string>
 	<string name="settings_advanced_mode">"Kehittynyt tila"</string>
-	<string name="settings_advanced_mode_explanation">"Kehittynyt tila piilottaa viestin \"Järjestelmäsi on ajantasalla\", antaa sinun ladata ja asentaa kaikki päivitykset, vaikka ne eivät olisikaan yhteensopiva laitteesi kanssa.
+	<string name="settings_advanced_mode_explanation">"Normaalisti sovellus näyttää päivitykset nykyisen käyttöjärjestelmäversion mukaan. Edistyneessä tilassa näytetään aina uusin saatavilla oleva päivitys riippumatta laitteen/version yhteensopivuudesta.
 
-Tämä voi olla hyödyllista kun:
--Päivitetään tavallisesta versiosta beta versioon
--Palautetaan beta versiosta tavalliseen versioon (älä unohda tehdä tehdastilan palautusta laitteelle)
--Asennettaessa uudelleen nykyistä järjestelmäversiota"</string>
+Tästä voi olla hyötyä, jos haluat:"</string>
+	<string name="settings_advanced_mode_uses">"&#8226; Lataa uusin versio uudelleen, vaikka se olisi jo käytössäsi
+&#8226; Vaihtaa eri päivitysraidalle"</string>
+	<string name="settings_advanced_mode_caption">"Edistynyttä tilaa saatetaan tarvita vain edellä mainituissa tilanteissa. Sitä ei kannata ottaa käyttöön, ellet tiedä, mitä olet tekemässä."</string>
 	<string name="settings_update_method">"Päivitystapa"</string>
 	<string name="settings_upload_logs">Jaa käyttötiedot ja lokit</string>
+	<string name="settings_ad_privacy">GDPR-mainonnan suostumus</string>
+	<string name="settings_ad_privacy_subtitle">"ETA:n/UK:n käyttäjille"</string>
 
 	<!-- FAQ strings -->
 	<string name="faq">"UKK"</string>
 	<string name="faq_menu_item">"UKK"</string>
 
 	<!-- First-time setup strings -->
-	<string name="onboarding">"Tervetuloa"</string>
+	<string name="onboarding">"Setup"</string>
 	<string name="onboarding_finished_button">"Käynnistä sovellus"</string>
-	<string name="onboarding_page_1_title">"Tervetuloa Oxygen Updateriin!"</string>
-	<string name="onboarding_page_1_text">"Tämä sovellus mahdollistaa sinulle:
+	<string name="onboarding_app_uses">"Tämä sovellus mahdollistaa sinulle:
 
--Nopeamman pääsyn viimeisimpiin Android päivityksiin OxygenOS laitteellesi
-
--Rootatun laitteen päivittämisen helposti
-
--Katsoa mitkä ovat uudistukset käytössäsi olevassa järjestelmäversiossa
-
--Lukea viimeisimpiä uutisia koskien OnePlussaa ja OxygeOS:ää
-
-Pyyhkäise vasemmalle jatkaaksesi"</string>
-	<string name="onboarding_page_1_caption">"Tämä ei ole virallinen OnePlus sovellus. Tämän sovelluksen käyttö tapahtuu täysin omalla vastuullasi. OnePlus tai sovelluksen kehittäjä eivät ole vastuussa tekemistäsi toimenpiteistä, mukaanlukien mitkä tahansa vahingot joita sovelluksen käytöstä aiheutuu.
-
-Käyttämällä sovellusta hyväksyt yllä olevat käyttöehdot.
-
-Pyyhkäise vasemmalle jatkaaksesi"</string>
-	<string name="onboarding_page_2_title">"Valitse laitteesi:"</string>
-	<string name="onboarding_page_2_caption">"Laitteesi on normaalisti jo oletuksena valittuna yläpuolella. Mikäli näin ei ole, valitse laitteesi yläpuolelta.
-
-Pyyhkäise vasemmalle jatkaaksesi."</string>
-	<string name="onboarding_page_3_title">"Valitse päivitystapasi"</string>
-	<string name="onboarding_page_3_caption">"Yleensä lisäävä päivitys on oikea valinta tässä kohtaa, koska se tarjoaa nopeammat ja pienemmät latauskoot
-
-Kuitenkaan tämä ei ole yhteensopiva tapa rootatuille laitteille. Jos laitteesi on rootattu valitse Täydellinen päivitys.
-
-Jos sinulla on beta versio OxygenOS:stä, valitse jokin Open Beta päivitystavoista.
-
-Pyyhkäise vasemmalle jatkaaksesi."</string>
-	<string name="onboarding_page_4_title">"Olet valmis!"</string>
-	<string name="onboarding_page_4_text">"Nauti sovelluksesta!
-
-Voit aina muuttaa asetuksiasi myöhemmin napsauttamalla oikealta yläkulmasta kolmea pistettä ja napsauttamalla \"Asetukset\"."</string>
+&#8226; Nopeamman pääsyn viimeisimpiin Android päivityksiin OxygenOS laitteellesi
+&#8226; Rootatun laitteen päivittämisen helposti
+&#8226; Katsoa mitkä ovat uudistukset käytössäsi olevassa järjestelmäversiossa
+&#8226; Lukea viimeisimpiä uutisia koskien OnePlussaa ja OxygeOS"</string>
+	<string name="onboarding_disclaimer">"Tämä ei ole virallinen OnePlus sovellus. Tämän sovelluksen käyttö tapahtuu täysin omalla vastuullasi. OnePlus tai sovelluksen kehittäjä eivät ole vastuussa tekemistäsi toimenpiteistä, mukaanlukien mitkä tahansa vahingot joita sovelluksen käytöstä aiheutuu. Käyttämällä sovellusta hyväksyt yllä olevat käyttöehdot."</string>
+	<string name="onboarding_device_chooser_title">"Valitse laitteesi:"</string>
+	<string name="onboarding_device_chooser_caption">"Laitteesi on normaalisti jo oletuksena valittuna yläpuolella. Mikäli näin ei ole, valitse laitteesi yläpuolelta."</string>
+	<string name="onboarding_method_chooser_title">"Valitse päivitystapasi"</string>
+	<string name="onboarding_method_chooser_caption">"Yleensä lisäävä päivitys on oikea valinta tässä kohtaa, koska se tarjoaa nopeammat ja pienemmät latauskoot Kuitenkaan tämä ei ole yhteensopiva tapa rootatuille laitteille. Jos laitteesi on rootattu valitse Täydellinen päivitys. Jos sinulla on beta versio OxygenOS:stä, valitse jokin Open Beta päivitystavoista."</string>
+	<string name="onboarding_caption">"Nauti sovelluksesta! Voit aina muuttaa asetuksia myöhemmin."</string>
 
 	<!-- Automatic install strings -->
 	<string name="install">"Asenna"</string>
 
 	<!-- Install guide strings -->
-	<string name="install_guide_no_root">"Asenna päivitys asennusohjeen mukaisesti"</string>
 	<string name="install_guide">"Asennusohje"</string>
-	<string name="install_guide_subtitle">"Install guide - %1$d / %2$d"</string>
-	<string name="install_guide_tip">"&#8226; On suositeltavaa kirjoittaa kaikki vaiheet ylös, koska laitteen virta tulee katkaista päivitystä asennettaessa."</string>
-	<string name="install_guide_page_1_title">"Lataa päivitys"</string>
-	<string name="install_guide_page_1_text">"&#8226; Paina lataa painiketta käynnistääksesi päivityksen lataamisen.
-
-- Latauksen edistyminen tulee näkyviin sovelluksessa ja ilmoituksena ilmoituskeskuksessa.
-
-- Kun lataus on valmistunut näet ilmoituksen \"Lataus valmis\".
+	<string name="install_guide_download_instructions">"&#8226; Paina lataa painiketta käynnistääksesi päivityksen lataamisen.
+&#8226; Latauksen edistyminen tulee näkyviin sovelluksessa ja ilmoituksena ilmoituskeskuksessa.
+&#8226; Kun lataus on valmistunut näet ilmoituksen \"Lataus valmis\".
 Jos latauksessa ilmenee virhe, avaa sovellus ja yritä ladata päivitys uudelleen. Jos tämä ei toimi varmista, että sinulla on toimiva yhteys. Muutoin olen yhteydessä sovelluksen kehittäjään. Voit tehdä tämän myös vierailemalla \"Omat sovellukset\" osiossa Play Kaupassa."</string>
-
-	<string name="install_guide_page_2_title">Valmistaudu asennukseen</string>
-	<string name="install_guide_page_2_text">"Huomio: Päivityksen asentaminen tapahtuu Järjestelmäpäivitys kohdassa laitteellasi. Jos jostain syystä järjestelmäpäivitys löytyy, kun avaat Järjestelmäpäivitys kohdan, voit asentaa sen päivityksen ensin ja avata Oxygen Updater:in varmistaaksesi että olet viimeisimmässä versiossa.
-
-Ohje:
-&#8226; Sulje Oxygen Updater painamalla kotinappia.
-
-&#8226; Avaa Asetukset sovellus. Sen pitäisi löytyä sovellusvalikosta.
-
-&#8226; Vieritä kunnes näet Järjestelmäpäivitykset kohdan. Paina sitä."</string>
-
-	<string name="install_guide_page_3_title">Asenna päivitys</string>
-	<string name="install_guide_page_3_text">"Nyt kun olet Järjestelmäpäivitys-osiossa, on aika asentaa päivitys.
-
-&#8226; Järjestelmäpäivitykset-osiossa paina hammasratas-ikonia oikeassa yläkulmassa.
-
-&#8226; Valitse \"Paikallinen päivitys\". Tiedostonvalintaruutu pitäisi aueta.
-
-&#8226; Paina päivitystiedostoa, jonka latasit Oxygen Updaterin avulla. Sen nimi tulisi alkaa \"%1$sOxygen\".
-
-&#8226; Paina \"Päivitä Nyt\". Asennuksen pitäisi alkaa automaattisesti."</string>
-
-	<string name="install_guide_page_4_title">Odota kunnes asennus on valmis</string>
-	<string name="install_guide_page_4_text">"&#8226; Puhelin asentaa päivityksen ja näyttää sen edistymisen. Odota kunnes asennus on valmis. Asennus voi kestää jopa 15 minuuttia.
-
-&#8226; Sen jälkeen puhelin käynnistyy uudestaan päivityksen viimeistelemiseksi."</string>
-	<string name="install_guide_page_5_title">"Valmis. Nauti uudesta OxygenOS versiosta!"</string>
-	<string name="install_guide_page_5_text">"&#8226; Kun laitteesi on viimeistellyt sovellusten optimoinnin, asennus on onnistuneesti suoritettu.
-Varmistaaksesi tämän voit tarkistaa nykyisen järjestelmän version seuraavasti:
-
-- Mene asetuksiin, napsauta \"Tietoja puhelimesta\" ja tarkista OxygenOS versio.
-
-- Jos pidät tästä sovelluksesta, annathan sille 5 tähteä Play Kaupassa!"</string>
-	<string name="install_guide_close_button">"Sulje asennusohje"</string>
 
 	<!-- Device information strings -->
 	<string name="device_information_supported_oxygen_os">Laitteesi on tuettu</string>
@@ -244,7 +174,7 @@ Varmistaaksesi tämän voit tarkistaa nykyisen järjestelmän version seuraavast
 	<string name="device_information_image_description">"Laitteen kuva"</string>
 	<string name="device_information_incremental_os_version">"Lisäävän päivityksen versio:"</string>
 	<string name="device_information_os_version">"Android versio:"</string>
-	<string name="device_information_oxygen_os_version">"OxygenOS versio:"</string>
+	<string name="device_information_oxygen_os_version">"OS versio:"</string>
 	<string name="device_information_oxygen_os_ota_version">"OTA versio:"</string>
 	<string name="device_information_patch_level_version">"Tietoturvapäivitysten päiväys:"</string>
 	<string name="device_information_serial_number">"Sarjanumero:"</string>
@@ -264,6 +194,8 @@ Varmistaaksesi tämän voit tarkistaa nykyisen järjestelmän version seuraavast
 	<string name="about_email_button_text">Sähköposti</string>
 
 	<!-- LocalNotifications strings -->
+	<string name="notification_permission_title">"Pysy ilmoitettuna"</string>
+	<string name="notification_permission_text">"Anna sovelluksen ilmoittaa sinulle OTA-päivityksistä, uutisista, käynnissä olevasta lataustilanteesta ja muista tärkeistä asioista. Voit hienosäätää asetuksiasi myöhemmin sovelluksen asetuksissa."</string>
 	<string name="notification_new_device_text">"%1$s on nyt tuettu. Avaa sovellus valitaksesi tämä laite."</string>
 	<string name="notification_no_notification_support">"Asenna tai päivitä Google Play palvelut mahdollistaaksesi push ilmoitukset"</string>
 	<string name="notification_version">"%1$s on nyt saatavissa laitteelle %2$s!"</string>
@@ -290,41 +222,9 @@ Varmistaaksesi tämän voit tarkistaa nykyisen järjestelmän version seuraavast
 	<string name="general_notification_channel_description">General notifications that don\'t fit into other categories</string>
 	<string name="url_submitted_notification_channel_description">Saat ilmoituksen, kun olet lähettänyt OTA URL-osoitteet onnistuneesti tiimillemme.\nVoit kieltäytyä lähettämästä URL-osoitteita automaattisesti sovelluksen asetuksissa.</string>
 
-	<!-- Help strings -->
-	<string name="help">"Apua"</string>
-	<string name="help_updating_your_device_title">"Laitteesi päivittäminen"</string>
-	<string name="help_updating_your_device_text">"Avatessasi sovelluksen näet onko järjestelmään saatavilla päivityksiä. Jos uusi päivitys on saatavilla voit asentaa sen.
-
-Aloittaaksesi asennuksen napsauta \"Lataa\" painiketta (päivityksen kuvauksen alla) jotta päivityksen lataus käynnistyy. Kun lataus on valmistunut, asennusikkuna ponnahtaa näkyviin. Jos siirryit pois sovelluksesta tai ikkuna ei ponnahtanut auki, napsauta \"Asenna\" painiketta, joka on nyt tullut \"Lataa\" painikkeen viereen.
-
-Asennusikkuna varmistaa ensin onko laitteesi rootattu. Jos sinulla on rootattu laite, anna root oikeus kun niitä kysytään ja valitse kuinka haluat asentaa päivityksen. Muutoin seuraa manuaalisen asennuksen ohjeita.
-
-Automaattinen asennus:
-Sinun tarvitsee vain valita asennuksen vaihtoehdot. Oletusasetuksia suositellaan, mutta sinun tulee valita root paketti joka (uudelleen)asennetaan. Valitse root paketti (zip tiedosto) käyttämällä sinistä kansio painiketta ja napsauta sitten \"Aloita asennus\" aloittaaksesi asennuksen.
-
-Manuaalinen asennus:
-Näet asennusohjeen ruudullasi. Kirjoita ohjeet ylös ja suorita ne asentaaksesi päivitys."</string>
-	<string name="help_reading_news_title">"Viimeisimpien uutisten lukeminen"</string>
-	<string name="help_reading_news_text">"Uutiset löydät päivitysikkunasta vasemmalle yläpalkissa. Viimeisimmät uutiset näkyvät ylimpänä. Napsauta uutista lukeaksesi sen. Napsauta takaisin nuolta tai painiketta palataksesi uutislistaan."</string>
-	<string name="help_device_information_title">"Laitteen tietojen katsominen"</string>
-	<string name="help_device_information_text">"Voit nähdä joitakin määrittelyjä laitteestasi käyttämällä oikealla puolella olevaa Laite info näkymää. Tämä on kätevä, kun olet tekemässä tukipyyntöä, jonka aikana sinulta voidaan kysyä joitakin laitteen tarkempia tietoja."</string>
-	<string name="help_change_settings_title">"Asetusten muuttaminen"</string>
-	<string name="help_change_settings_text">"Voit muuttaa asetuksia napsauttamalla kolmea pistettä näytön oikeassa yläkulmassa ja valitsemalla asetukset.
-Voit muuttaa seuraavia asetuksia
-
-• Laite ja päivitystapa
-• Push ilmoitukset
-• Sovelluksen sisäiset ilmoitukset
-• Yksityisyysasetukset (lokitietojen lähetys).
-
-Käytä kytkimiä kääntääksesi ilmoitus ja yksityisyysasetuksia päälle ja pois. Valitse laite ja/tai päivitystapa käyttämällä pudotusvalikkoja kytkinten yläpuolella. Eikö pudotusvalikot ole näkyvissä? Tarkista internetyhteystesi ja avaa Asetukset ikkuna uudelleen."</string>
-
 	<!-- News strings -->
 	<string name="news">"Uutiset"</string>
-	<string name="news_date_published">"Viimeisin päivitys: %1$s"</string>
-	<string name="news_empty">"Tällä artikkelilla ei ole kommentteja"</string>
-	<string name="news_load_network_error">"Artikkelin avaus epäonnistui. Tarkista verkkoyhteys ja paina 'UUDELLEEN' painiketta avataksesi artikkeli."</string>
-	<string name="news_load_id_error"><![CDATA[Artikkelin avaaminen viallisesta URL epäonnistui: %1$s. Tarkista URL tai kerro tästä meille joko <a href="mailto:support@oxygenupdater.com">sähköpostilla</a> tai meidän <a href="https://discord.gg/5TXdhKJ">Discord serverillä</a>.]]></string>
+	<string name="news_load_network_error">"Artikkelin avaus epäonnistui. Tarkista verkkoyhteys ja paina 'Uudelleen' painiketta avataksesi artikkeli."</string>
 
 	<string name="news_unread_count_1">Sinulla on %1$d lukematonta artikkelia. Paina tästä nähdäksesi ne.</string>
 	<string name="news_unread_count_2">Sinulla on %1$d lukematonta artikkelia. Paina nähdäksesi kaikki artikkelit.</string>
@@ -351,11 +251,9 @@ Käytä kytkimiä kääntääksesi ilmoitus ja yksityisyysasetuksia päälle ja 
 	<string name="error_app_outdated">"Voi ei!"</string>
 	<string name="error_app_outdated_message">"Tämä versio sovelluksesta on vanhentunut. On aika päivittää se! Napsauta alhaalta \"Play Kauppa\". Play Kaupassa, napsauta \"Päivitä\"."</string>
 	<string name="error_app_requires_network_connection">"Ei yhteyttä"</string>
-	<string name="error_app_requires_network_connection_message">"Palvelimeeen yhdistäminen ei onnistunut. Ole hyvä ja varmista että sinulla on toimiva verkkoyhteys. Sovellus sulkeutuu nyt."</string>
-	<string name="error_no_internet_connection">"Ei yhteyttä"</string>
 	<string name="error_maintenance">"Palvelimella huoltokatko"</string>
 	<string name="error_maintenance_message">"Ole hyvä ja odota. Palvelin on hyvin pian taas käytettävissä."</string>
-	<string name="error_maintenance_retry">Palvelimella saattaa olla huoltokatko. Yritä uudestaan pian, tai ilmoita siitä meille joko <a href="mailto:support@oxygenupdater.com">sähköpostilla</a> tai meidän <a href="https://discord.gg/5TXdhKJ">Discord palvelimella</a>.</string>
+	<string name="error_maintenance_retry"><![CDATA[Palvelimella saattaa olla huoltokatko. Yritä uudestaan pian, tai ilmoita siitä meille joko <a href="mailto:support@oxygenupdater.com">sähköpostilla</a> tai meidän <a href="https://discord.gg/5TXdhKJ">Discord palvelimella</a>.]]></string>
 	<string name="error_reload">"Lataa uudelleen"</string>
 	<string name="error_unable_to_rate_app">"Ei voi arvostella sovellusta, sillä Play Kauppa puuttuu laitteeltasi."</string>
 
@@ -382,7 +280,6 @@ Muut laitteet, mukaan lukien OnePlus laitteet joille on asennettu kustomoitu kä
 	<string name="purchase_error_after_payment">"Mainosvapaan version ostaminen epäonnistui, koska sattui sisäinen virhe. Ole hyvä ja yritä uudelleen muutaman minuutin kuluttua. Jos olet jo maksanut, ole hyvä ja ota yhteyttä Play Kaupan tukeen saadaksesi apua."</string>
 
 	<!-- Other strings -->
-	<string name="error">Virhe</string>
 	<string name="icon">"Ikoni"</string>
 	<string name="loading">"Ladataan…"</string>
 	<string name="processing">"Prosessoidaan…"</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools" tools:keep="@string/install_guide_page_*_*">
-
-	<string name="device_chooser_error_title">Impossible de récupérer la liste des appareils supportés</string>
-
+<resources>
 	<!-- Update information strings -->
 	<string name="enable">Activer</string>
-	<string name="update_information_file_name">"Nom du fichier : %1$s"</string>
+	<string name="update_information_file_name">"Nom du fichier: %1$s"</string>
 	<string name="update_information_md5">MD5: %1$s</string>
 	<string name="update_information_download_link">Étant donné qu\'une errreur de téléchargement s\'est produite et que le téléchargement doit être recommencé, vous pouvez utiliser ce lien pour télécharger le fichier de mise à jour. Vous devrez cependant le déplacer du dossier "Téléchargements" à la racine du stockage interne de votre appareil. Ce lien est le même lien que l\'application utilise et provient des serveurs FOTA de OnePlus:\n%1$s</string>
 	<string name="update_information_header">"Mise à jour"</string>
@@ -13,13 +10,12 @@
 	<string name="update_information_banner_server">Appuyez ici afin de voir des informations importantes</string>
 	<string name="update_information_banner_advanced_mode_tip">Vous avez sélectionné la méthode de mise à jour \"%1$s\". Activez le mode avancé si vous souhaitez passer à cette méthode de mise à jour.</string>
 	<string name="update_information_header_advanced_mode_hint">Le mode avancé est activé</string>
-	<string name="update_information_header_advanced_mode_helper">Étant donné que vous avez activé le mode avancé, vous pouvez télécharger le dernier fichier d\'installation (.zip) pour la méthode de mise à jour \"%1$s\".\n\nVous pouvez désactiver le mode avancé depuis les réglages de l\'application.</string>
-	<string name="update_information_different_version_changelog_notice">Vous regardez un journal de modifications conçu pour la dernière mise à jour disponible dans la méthode de mise à jour \"%1$s\". Si vous souhaitez installer cette mise à jour, vous devez d\'abord activer le mode avancé dans les réglages de l\'application.\n\nSi vous souhaitez voir le journal de modifications pour la version actuelle de votre appareil, vous devez resélectionner la précédente méthode de mise à jour.</string>
-	<string name="update_information_last_checked_on">"Dernière vérification : %1$s"</string>
+	<string name="update_information_header_advanced_mode_helper">Étant donné que vous avez activé le mode avancé, vous pouvez télécharger le dernier fichier d\'installation (.zip) pour la méthode de mise à jour \"%1$s\". Vous pouvez désactiver le mode avancé depuis les réglages de l\'application.</string>
+	<string name="update_information_different_version_changelog_notice_base">Remarque : ce journal des modifications concerne la dernière version disponible (%1$s) dans la méthode de mise à jour \"%2$s\"</string>
+	<string name="update_information_different_version_changelog_notice_advanced">. Si vous avez l\'intention d\'installer cette mise à jour, vous devez activer le mode avancé dans les paramètres.</string>
 	<string name="update_information_no_update_data_available">"Aucune information de mise à jour n'est disponible."</string>
-	<string name="update_information_oxygen_os_version">"OxygenOS %1$s"</string>
 	<string name="update_information_system_is_up_to_date">"Votre système est à jour"</string>
-	<string name="update_information_unknown_update_name">"Mise à jour non nommée pour : %1$s"</string>
+	<string name="update_information_unknown_update_name">"Mise à jour non nommée pour: %1$s"</string>
 	<string name="update_information_view_update_information">"Voir les informations de mise à jour"</string>
 
 	<!-- Server status warning strings -->
@@ -30,7 +26,7 @@
 	<!-- New app version message strings -->
 	<string name="new_app_version">Une mise à jour de l\'application (%1$s) est disponible.\nAppuyez ici pour ouvrir le Play Store et mettre à jour l\'application.</string>
 	<string name="new_app_version_inapp_downloaded">La mise à jour de l\'application a été téléchargée</string>
-	<string name="new_app_version_inapp_failed">La mise à jour de l\'\application n\'a pas pu être installée. Appuyez ici pour ouvrir le Play Store et mettre à jour l\'application.</string>
+	<string name="new_app_version_inapp_failed">La mise à jour de l\'application n\'a pas pu être installée. Appuyez ici pour ouvrir le Play Store et mettre à jour l\'application.</string>
 
 	<!-- Downloader strings -->
 	<!-- TODO: translate this string below -->
@@ -45,9 +41,9 @@
 	<string name="download_error">"Erreur de téléchargement"</string>
 	<string name="download_error_close">"Fermer"</string>
 	<string name="download_error_corrupt">"Le fichier de mise à jour est endommagé ! Veuillez essayer de le télécharger à nouveau."</string>
-	    
+
 	<string name="download_error_server">Une erreur serveur s\'est produite pendant le téléchargement de la mise à jour. Veuillez réessayer de la télécharger.</string>
-	    
+
 	<string name="download_error_internal">Malheureusement, une erreur critique s\'est produite pendant le téléchargement de la mise à jour. Veuillez réessayer de la télécharger. Si le problème persiste, veuillez contacter le développeur pour obtenir de l\'assistance.</string>
 	<string name="download_error_unsuccessful_response"><![CDATA[Il semble que le lien de téléchargement soit invalide. L\'erreur provient soit de notre part lorsque nous avons ajouté les données de mise à jour, soit le fichier a été supprimé des serveurs de OnePlus. Une notification nous a été envoyée, nous vérifierons cela dès que possible.
 
@@ -58,10 +54,10 @@ Si vous souhaitez en savoir plus, n\'hésitez pas à nous contacter par <a href=
 	<string name="download_error_storage">"Espace de stockage insuffisant sur votre appareil pour télécharger la mise à jour. Veuillez libérer de l'espace et réessayer."</string>
 	<string name="download_failed">"Le téléchargement a échoué"</string>
 	<string name="download_pending">"Le téléchargement va bientôt commencer…"</string>
-	    
-	    
+
+
 	<string name="download_notification_error_server">Erreur serveur pendant le téléchargement. Veuillez le relancer.</string>
-	    
+
 	<string name="download_notification_error_internal">Erreur critique pendant le téléchargement. Veuillez le redémarrer ou contacter le développeur.</string>
 	<string name="download_notification_error_storage_full">"Espace de stockage insuffisant."</string>
 	<string name="download_notification_error_corrupt">"La vérification du fichier a échoué. Veuillez vérifier votre connexion et réessayer."</string>
@@ -73,7 +69,7 @@ Si vous souhaitez en savoir plus, n\'hésitez pas à nous contacter par <a href=
 	<string name="download_progress_text_one_minute_remaining">"Environ une minute restante"</string>
 	<string name="download_progress_text_seconds_remaining">"Quelques secondes restantes"</string>
 	<string name="download_progress_text_unknown_time_remaining">"Estimation du temps restant en cours…"</string>
-	<string name="download_progress_text_verifying">"100 %, Vérification du fichier en cours…"</string>
+	<string name="download_progress_text_verifying">"100%, Vérification du fichier en cours…"</string>
 	<string name="download_progress_text_paused">En pause</string>
 
 	<string name="download_verifying">"Vérification…"</string>
@@ -93,9 +89,7 @@ Si vous souhaitez en savoir plus, n\'hésitez pas à nous contacter par <a href=
 	<string name="summary_please_wait">Veuillez patienter…</string>
 	<string name="summary_update_method">Veuillez sélectionner un appareil</string>
 	<!-- TODO: check the following translation -->
-	<string name="summary_important_notifications_disabled">Certaines notifications importantes sont désactivées: \"%1$s\"</string>
-	<string name="summary_theme">Choisissez un thème</string>
-	<string name="summary_language">Définir la langue</string>
+	<string name="summary_important_notifications_disabled">Certaines notifications importantes sont désactivées:</string>
 	<string name="summary_privacy_policy">Voir en ligne</string>
 	<string name="summary_rate_app">Donner 5 étoiles</string>
 
@@ -114,10 +108,10 @@ Si vous souhaitez en savoir plus, n\'hésitez pas à nous contacter par <a href=
 	<string name="theme_dark_subtitle">Thème avec un fond noir et couleur d\'accentuation rouge. Utilisez ce thème si vous souhaitez économiser de la batterie, plus précisément sur les appareils avec un écran AMOLED.</string>
 	<string name="theme_system_subtitle">Utilise le thème système (vous pouvez le modifier dans les paramètres d\'affichage ou les options de développement). Dépend de l\'appareil.</string>
 	<string name="theme_auto_subtitle">Bascule entre les thèmes lumineux et sombres en fonction de l\'heure afin d\'empêcher la fatigue des yeux pendant la nuit</string>
-	<string name="theme_additional_note">Note : si le thème choisi est « Automatique » et l\'économiseur de batterie activé, le thème sombre sera automatiquement utilisé quelle que soit l\'heure afin d\'économiser de la batterie.</string>
+	<string name="theme_additional_note">Note: si le thème choisi est « Automatique » et l\'économiseur de batterie activé, le thème sombre sera automatiquement utilisé quelle que soit l\'heure afin d\'économiser de la batterie.</string>
 
 	<string name="settings">"Paramètres"</string>
-	<string name="settings_buy_button_buy">"%1$s"</string>
+	<string name="settings_buy_button_buy">"Achat (%1$s)"</string>
 	<string name="settings_buy_button_bought">"Acheté"</string>
 	<string name="settings_buy_button_not_possible">"Indisponible"</string>
 	<string name="settings_buy_ad_free_label">"Acheter la version sans publicité"</string>
@@ -126,110 +120,52 @@ Si vous souhaitez en savoir plus, n\'hésitez pas à nous contacter par <a href=
 
 	<string name="settings_device">"Appareil"</string>
 	<string name="settings_entered_incorrectly">"Une erreur s'est produite lors de la sauvegarde de vos réglages. Retournez en arrière et sélectionnez à nouveau votre appareil et méthode de mise à jour."</string>
-	<string name="settings_explanation_incremental_full_update">"Une mise à jour incrémentale peut être installée depuis n'importe quelle version (sauf si votre bootloader est déverouillé, auquel cas vous devriez toujours choisir la mise à jour entière en tant que méthode de mise à jour).\n\nLes versions bêta d'OxygenOS peuvent toujours être installées, même si vous exécutez actuellement une version stable. Pour passer de la version stable à la version bêta, vous devez activer le mode avancé dans les réglages. Les méthodes de mises à jour incrémentale et entières marchent de la même manière pour les versions bêta et stables."</string>
 	<string name="settings_push_from_server">"Un message critique est disponible"</string>
 	<string name="settings_saving">"Vos réglages sont en cours d'enregistrement. Si cela prend trop de temps vérifiez votre connexion à Internet, quittez l'application et réessayez."</string>
 	<string name="settings_advanced_mode">"Mode avancé"</string>
-	<string name="settings_advanced_mode_explanation">"Le mode avancé cache le message « Votre système est à jour », vous permettant ainsi de télécharger et installer des mises à jour quand bien même elles pourraient ne pas être compatibles avec votre appareil.
+	<string name="settings_advanced_mode_explanation">"Normalement, l'application affiche les mises à jour en fonction de la version actuelle de votre système d'exploitation. Avec le mode avancé, la dernière mise à jour disponible sera toujours affichée, quelle que soit la compatibilité appareil/version.
 
-Cela peut être utile quand vous :
-— Installez une version bêta depuis une version stable
-— Choisissez de revenir sur une version stable depuis une version bêta (n'oubliez pas de réinitialiser votre appareil)
-— Réinstallez la version actuelle du système"</string>
+Cela peut s'avérer utile si vous souhaitez:"</string>
+	<string name="settings_advanced_mode_uses">"&#8226; Retélécharger la dernière version, même si vous êtes déjà dessus
+&#8226; Passer à une autre piste de mise à jour"</string>
+	<string name="settings_advanced_mode_caption">"Le mode avancé peut s'avérer nécessaire uniquement dans les situations ci-dessus. Vous ne devez l'activer que si vous savez ce que vous faites."</string>
 	<string name="settings_update_method">"Méthode de mise à jour"</string>
 	<string name="settings_upload_logs">Envoyer les données d\'utilisation et de crash au développeur</string>
+	<string name="settings_ad_privacy">Consentement à la publicité GDPR</string>
+	<string name="settings_ad_privacy_subtitle">"Pour les utilisateurs de l'EEE/du Royaume-Uni"</string>
 
 	<!-- FAQ strings -->
 	<string name="faq">"Foire aux Questions"</string>
 	<string name="faq_menu_item">"FAQ"</string>
 
 	<!-- First-time setup strings -->
-	<string name="onboarding">"Bienvenue"</string>
+	<string name="onboarding">"Setup"</string>
 	<string name="onboarding_finished_button">"Démarrer l'application"</string>
-	<string name="onboarding_page_1_title">"Bienvenue dans Oxygen Updater !"</string>
-	<string name="onboarding_page_1_text">"Cette application vous permettra :
+	<string name="onboarding_app_uses">"Cette application vous permettra:
 
-— D'avoir un accès plus rapide aux dernières mises à jour Android pour votre appareil sous OxygenOS
-— De mettre à jour aisément un appareil rooté
-— De voir les nouveautés du système d'exploitation que vous utilisez
-— Lire les dernières informations à propos de OnePlus et OxygenOS
-
-Balayez vers la droite pour continuer."</string>
-	<string name="onboarding_page_1_caption">"Cette application n'est pas une application officielle de OnePlus. Son usage est à vos propres risques. Ni OnePlus ni le développeur de cette application ne peuvent être tenus pour responsable de vos actions, incluant celles causées par l'usage de cette application.
-
-En utilisant cette application vous acceptez les termes et conditions énoncées précédemment.
-
-Balayez vers la droite pour continuer."</string>
-	<string name="onboarding_page_2_title">"Choisissez votre appareil :"</string>
-	<string name="onboarding_page_2_caption">"Votre appareil est normalement déjà sélectionné. Si ce n'est pas le cas, sélectionnez-le au-dessus.
-
-Balayez vers la droite pour continuer."</string>
-	<string name="onboarding_page_3_title">"Choisissez votre méthode de mise à jour."</string>
-	<string name="onboarding_page_3_caption">"Habituellement, la méthode incrémentale de mise à jour est la meilleure car permettant un téléchargement plus rapide et plus petit.
-
-Cependant, elle n'est pas compatible avec les appareils rootés. Si vous possédez un appareil rooté, choisissez la méthode complète.
-
-Si vous utilisez une version bêta d'OxygenOS, choisissez une des méthodes de mise à jour pour les bêta ouvertes.
-
-Balayez vers la droite pour continuer."</string>
-	<string name="onboarding_page_4_title">"Tout est prêt !"</string>
-	<string name="onboarding_page_4_text">"Profitez de cette application !
-
-Vous pourrez changer vos réglages plus tard si vous le souhaitez. Pour cela, cliquez sur les trois petits points dans le coin supérieur droit de l'écran et appuyez sur « Réglages »."</string>
+&#8226; D'avoir un accès plus rapide aux dernières mises à jour Android pour votre appareil sous OxygenOS
+&#8226; De mettre à jour aisément un appareil rooté
+&#8226; De voir les nouveautés du système d'exploitation que vous utilisez
+&#8226; Lire les dernières informations à propos de OnePlus et OxygenOS"</string>
+	<string name="onboarding_disclaimer">"Cette application n'est pas une application officielle de OnePlus. Son usage est à vos propres risques. Ni OnePlus ni le développeur de cette application ne peuvent être tenus pour responsable de vos actions, incluant celles causées par l'usage de cette application. En utilisant cette application vous acceptez les termes et conditions énoncées précédemment."</string>
+	<string name="onboarding_device_chooser_title">"Choisissez votre appareil:"</string>
+	<string name="onboarding_device_chooser_caption">"Votre appareil est normalement déjà sélectionné. Si ce n'est pas le cas, sélectionnez-le au-dessus."</string>
+	<string name="onboarding_method_chooser_title">"Choisissez votre méthode de mise à jour."</string>
+	<string name="onboarding_method_chooser_caption">"Habituellement, la méthode incrémentale de mise à jour est la meilleure car permettant un téléchargement plus rapide et plus petit. Cependant, elle n'est pas compatible avec les appareils rootés. Si vous possédez un appareil rooté, choisissez la méthode complète. Si vous utilisez une version bêta d'OxygenOS, choisissez une des méthodes de mise à jour pour les bêta ouvertes."</string>
+	<string name="onboarding_caption">"Profitez de cette application ! Vous pourrez changer vos réglages plus tard si vous le souhaitez."</string>
 
 	<!-- Automatic install strings -->
 	<string name="install">"Installation"</string>
 
 	<!-- Install guide strings -->
-	<string name="install_guide_no_root">"Installez la mise à jour en suivant les instructions du guide d'installation."</string>
 	<string name="install_guide">"Guide d'installation"</string>
-	<string name="install_guide_subtitle">"Guide d'installation — %1$d de %2$d"</string>
-	<string name="install_guide_tip">"Il est recommandé d'écrire sur papier les étapes suivantes, étant donné que vous devrez éteindre votre appareil pendant l'installation de la mise à jour."</string>
-	<string name="install_guide_page_1_title">"Téléchargez la mise à jour"</string>
-	<string name="install_guide_page_1_text">"Appuyez sur le bouton « Téléchargement » pour commencer à télécharger la mise à jour.
-
-— La progression du téléchargement va s'afficher dans l'application et dans votre barre de notifications.
-
-— Quand le téléchargement sera fini, vous verrez une notification avec le texte « Téléchargement fini ».
+	<string name="install_guide_download_instructions">"&#8226; Appuyez sur le bouton « Téléchargement » pour commencer à télécharger la mise à jour.
+&#8226; La progression du téléchargement va s'afficher dans l'application et dans votre barre de notifications.
+&#8226; Quand le téléchargement sera fini, vous verrez une notification avec le texte « Téléchargement fini ».
 Si une erreur de téléchargement s'est produite, ouvrez l'application et réessayez de télécharger l'application. Si cela ne fonctionne pas, vérifiez que votre connexion Internet fonctionne. Autrement, contactez le développeur de l'application.
 Vous pouvez faire cela en visitant la section « Mes applications » dans le Play Store."</string>
 
-	<string name="install_guide_page_2_title">Préparation de l\'installation</string>
-	<string name="install_guide_page_2_text">"Note: L'installation de la mise à jour s'effectue à partir d'une page spéciale dans la section « Mises à jour du système » de votre appareil.  Si, pour quelque raison que ce soit, une mise à jour système apparaît lors de l'ouverture de cette section, vous pouvez également choisir d'installer cette mise à jour en premier. Ensuite, ouvrez à nouveau Oxygen Updater pour vérifier que votre appareil est bien à jour.
-
-Instructions:
-&#8226; Fermez Oxygen Updater en appuyant sur le bouton d'accueil.
-
-&#8226; Ouvrez l'application « Paramètres ». Elle devrait être localisée dans le tiroir d'applications.
-
-&#8226; Faites défiler vers le bas jusqu'à la section « Système ». Appuyez dessus et sélectionnez « Mise à jour du système »."</string>
-
-	<string name="install_guide_page_3_title">Installation de la mise à jour</string>
-	<string name="install_guide_page_3_text">"Maintenant que vous êtes dans l'application de mise à jour du système, vous pouvez installer la mise à jour.
-
-&#8226; Appuyez sur la roue dentée en haut à droite.
-
-&#8226; Maintenant, sélectionnez \"Mise à niveau locale\". Un écran de sélection de fichier devrait apparaître.
-
-&#8226; Dans cet écran, appuyez sur le fichier de mise à jour que vous avez téléchargé à l'aide d'Oxygen Updater. Son nom devrait commencer par \"%1$sOxygen\".
-
-&#8226; Appuyez sur \"Installer maintenant\". L'installation devrait alors démarrer automatiquement."</string>
-
-	<string name="install_guide_page_4_title">Patientez jusqu\'à la fin de l\'installation</string>
-	<string name="install_guide_page_4_text">"&#8226; Votre appareil va maintenant installer la mise à jour et afficher une barre de progression. Veuillez patienter jusqu'à la fin de l'installation, qui peut prendre jusqu'à quinze minutes.
-
-&#8226; Après cela, votre appareil va redémarrer."</string>
-
-	<string name="install_guide_page_5_title">"Fait. Profitez de la nouvelle version d'OxygenOS !"</string>
-	<string name="install_guide_page_5_text">"Une fois que votre appareil a fini d'optimiser les applications, la mise à jour s'est correctement installée.
-Afin de le vérifier, vous pouvez effectuer la manipulation suivante :
-
-— Allez dans « Réglages », «  À propos du téléphone » et regardez la version d'OxygenOS.
-
-— Si vous aimez l'application, donnez-lui 5 étoiles sur le Play Store !"</string>
-	<string name="install_guide_close_button">"Fermer le guide d'installation"</string>
-
-	<!-- Device information strings -->
+	<!-- Device information strings -->
 	<string name="device_information_supported_oxygen_os">Votre appareil est supporté</string>
 	<string name="device_information_carrier_exclusive_oxygen_os">Votre appareil n\'est pas supporté car vendu exclusivement par un opérateur</string>
 	<string name="device_information_unsupported_oxygen_os">Nous ne supportons pas actuellement votre appareil.</string>
@@ -238,22 +174,22 @@ Afin de le vérifier, vous pouvez effectuer la manipulation suivante :
 	<string name="device_information_hardware_header">Matériel</string>
 	<string name="device_information_software_header">Logiciel</string>
 
-	<string name="device_information_amount_of_memory">"Mémoire vive :"</string>
-	<string name="device_information_cpu_frequency">"Fréquence du processeur :"</string>
+	<string name="device_information_amount_of_memory">"Mémoire vive:"</string>
+	<string name="device_information_cpu_frequency">"Fréquence du processeur:"</string>
 	<string name="device_information_header">"Appareil"</string>
 	<string name="device_information_image_description">"Image de l'appareil"</string>
-	<string name="device_information_incremental_os_version">"Version incrémentale de l'OS :"</string>
-	<string name="device_information_os_version">"Version d'Android :"</string>
-	<string name="device_information_oxygen_os_version">"Version d'OxygenOS :"</string>
-	<string name="device_information_oxygen_os_ota_version">"Version OTA :"</string>
-	<string name="device_information_patch_level_version">"Niveau du correctif de sécurité :"</string>
-	<string name="device_information_serial_number">"Numéro de série :"</string>
-	<string name="device_information_system_on_a_chip">"Processeur mobile (SoC) :"</string>
+	<string name="device_information_incremental_os_version">"Version incrémentale de l'OS:"</string>
+	<string name="device_information_os_version">"Version d'Android:"</string>
+	<string name="device_information_oxygen_os_version">"Version d'OS:"</string>
+	<string name="device_information_oxygen_os_ota_version">"Version OTA:"</string>
+	<string name="device_information_patch_level_version">"Niveau du correctif de sécurité:"</string>
+	<string name="device_information_serial_number">"Numéro de série:"</string>
+	<string name="device_information_system_on_a_chip">"Processeur mobile (SoC):"</string>
 	<string name="device_information_unknown">"Inconnu"</string>
 
 	<!-- About screen strings -->
 	<string name="about">"À propos"</string>
-	<string name="about_description">Cette application télécharge les mises à jour officielles directement depuis les serveurs de OnePlus et vérifie l\'intégrité des fichiers ZIPs téléchargés avant de vous permettre de les installer. Ce faisant, vous n\'aurez pas à attendre le déploiement progressif afin d\'installer les mises à jour officielles dès que possible. Si vous rencontrez des erreurs dans le système d\'exploitation, veuillez les signalez directement à OnePlus : <a href="https://forums.oneplus.com/feedback">https://forums.oneplus.com/feedback</a>. Vous souhaiterez peut être joindre notre <a href="https://discord.gg/5TXdhKJ">serveur Discord</a> afin de pouvoir échanger avec les autres utilisateurs de l\'application à propos des dernières mises à jour. Autrement n\'hésitez pas à nous envoyer un email à <a href="mailto:support@oxygenupdater.com">support@oxygenupdater.com</a> si vous avez des suggestions ou des commentaires.</string>
+	<string name="about_description">Cette application télécharge les mises à jour officielles directement depuis les serveurs de OnePlus et vérifie l\'intégrité des fichiers ZIPs téléchargés avant de vous permettre de les installer. Ce faisant, vous n\'aurez pas à attendre le déploiement progressif afin d\'installer les mises à jour officielles dès que possible. Si vous rencontrez des erreurs dans le système d\'exploitation, veuillez les signalez directement à OnePlus: <a href="https://forums.oneplus.com/feedback">https://forums.oneplus.com/feedback</a>. Vous souhaiterez peut être joindre notre <a href="https://discord.gg/5TXdhKJ">serveur Discord</a> afin de pouvoir échanger avec les autres utilisateurs de l\'application à propos des dernières mises à jour. Autrement n\'hésitez pas à nous envoyer un email à <a href="mailto:support@oxygenupdater.com">support@oxygenupdater.com</a> si vous avez des suggestions ou des commentaires.</string>
 	<string name="about_support">Si vous souhaitez nous supporter, vous pouvez acheter la version sans publicités (à partir des réglages de l\'application) ou vous rendre sur notre <a href="https://patreon.com/oxygenupdater">page Patreon</a>.</string>
 	<string name="about_background_story_header">Histoire</string>
 	<string name="about_background_story">Cette application a été initialement développée par Arjan Vlek à la suite d\'une autre de ses applications appelée <a href="https://cyanogenupdatetracker.com/">Cyanogen Update Tracker</a> (qui fournit des fonctionnalités similaires pour les utilisateurs de Cyanogen OS).\n\nAprès 4 ans, en Juillet 2019, Arjan a décidé de se retirer des deux projets et a transféré les applications à une équipe de développeurs venant chacun de différents pays. Ils ont pris la responsabilité de continuer à rendre à la communauté le service d\'obtenir les mises à jour réalisées par OnePlus plus rapidement.\nVous pouvez trouver plus d\'informations à propos de l\'annonce <a href="https://oxygenupdater.com/article/81/">ici</a>.\n\nLe 14 Août 2019 a marqué la première publication d\'une nouvelle version de l\'application par la nouvelle équipe, qui a introduit de nouvelles fonctionnalités (thème sombre et redesign).\n\nPour plus d\'information à propos de l\'équipe, consultez <a href="https://oxygenupdater.com/team/">le site</a>.</string>
@@ -263,6 +199,8 @@ Afin de le vérifier, vous pouvez effectuer la manipulation suivante :
 	<string name="about_email_button_text">Email</string>
 
 	<!-- LocalNotifications strings -->
+	<string name="notification_permission_title">"Restez informé"</string>
+	<string name="notification_permission_text">"Autorisez l'application à vous informer des mises à jour OTA, des nouvelles, de l'état des téléchargements en cours et d'autres choses importantes. Vous pouvez affiner vos préférences ultérieurement dans les paramètres de l'application."</string>
 	<string name="notification_new_device_text">"Le %1$s est maintenant disponible. Ouvrez l'application pour choisir cet appareil."</string>
 	<string name="notification_no_notification_support">"Installez ou mettez à jour les services Google Play pour activer les notifications push."</string>
 	<string name="notification_version">"%1$s est maintenant disponible pour le %2$s !"</string>
@@ -281,52 +219,18 @@ Cela inclut les notifications de mises à jour systèmes et celles de nouveaux a
 	<string name="device_notification_channel_name">"Nouvel appareil supporté"</string>
 	<string name="general_notification_channel_name">Générales</string>
 	<string name="url_submitted_notification_channel_name">Transmission de l\'URL de l\'OTA</string>
-	<string name="download_status_notification_channel_description">Notifications qui reflètent le statut d\'un téléchargement : en pause, actif, complété, ou échoué</string>
+	<string name="download_status_notification_channel_description">Notifications qui reflètent le statut d\'un téléchargement: en pause, actif, complété, ou échoué</string>
 	<string name="verification_status_notification_channel_description">Notifications qui reflètent le statut de la vérification du fichier de mise à jour: en cours, complété, or échoué.\nLa somme de contrôle MD5 est utilisée pour s\'assurer que le fichier de mise à jour n\'a pas été modifié et est valide.</string>
 	<string name="installation_status_notification_channel_description">Soyez notifié afin de savoir si une mise à jour a été correctement installée ou pas</string>
 	<string name="update_notification_channel_description">Soyez notifié lorsqu\'une nouvelle mise à jour est disponible pour votre appareil &amp; méthode de mise à jour sélectionnée</string>
 	<string name="news_notification_channel_description">Soyez notifié lorsque nous publions un nouvel article</string>
 	<string name="device_notification_channel_description">Soyez notifié lorsque l\'application supporte un nouvel appareil</string>
 	<string name="general_notification_channel_description">Notifications générales ne rentrant pas dans le cadre des autres catégories</string>
-	<string name="url_submitted_notification_channel_description">Recevez une notification lorsque vous avez soumis avec succès des URL d\'OTA à notre équipe.\n
-Vous pouvez choisir de ne pas soumettre automatiquement les URL dans les paramètres de l\'application.</string>
-
-	<!-- Help strings -->
-	<string name="help">"Aide"</string>
-	<string name="help_updating_your_device_title">"Mettre à jour votre appareil"</string>
-	<string name="help_updating_your_device_text">"Quand vous ouvrez l'application vous pouvez voir si une mise à jour système est disponible et l'installer.
-
-Pour commencer l'installation, appuyez sur le bouton « Télécharger » (en dessous de la description de la mise à jour). Quand le téléchargement sera fini l'écran d'installation s'affichera. Si vous avez quitté l'application pendant le téléchargement ou que l'écran ne s'est pas affiché veuillez appuyer sur le bouton « Installer » qui sera présent à côté du bouton « Télécharger ».
-
-Le processus d'installation va d'abord vérifier si votre appareil est rooté. Si c'est le cas veuillez autorisez l'accès root quand il sera demandé et choisissez comment vous voulez installer la mise à jour. Autrement veuillez suivre les instructions pour l'installation manuelle.
-
-Installation automatique :
-Vous n'avez qu'à choisir vos paramètres d'installation. Les réglages par défaut sont recommandés à l'exception de la sélection du package root qui devra être (ré)installé. Sélectionnez un package root (possédant l'extension .zip) en cliquant sur l'icône bleue puis cliquez sur « Démarrer l'installation » afin de démarrer l'installation.
-
-Installation manuelle :
-Un guide d'installation va s'afficher sur votre écran. Ecrivez sur papier les instructions et suivez-les afin d'installer la mise à jour."</string>
-	<string name="help_reading_news_title">"Lire les derniers articles"</string>
-	<string name="help_reading_news_text">"Les articles sont affichés à gauche du panneau d'information des mises à jour. Les plus récents apparaissent en haut. Appuyez sur l'un d'entre eux pour le lire. Appuyez sur la flèche arrière ou sur le bouton Retour pour revenir à la liste des articles."</string>
-	<string name="help_device_information_title">"Voir des informations à propos de votre appareil"</string>
-	<string name="help_device_information_text">"Vous pouvez voir certaines spécifications de votre appareil en utilisant l'écran à droite des informations de mise à jour. Cela peut s'avérer utile lorsque vous faites une requête auprès du support ; durant laquelle pourront vous être demandées certaines spécifications de votre appareil."</string>
-	<string name="help_change_settings_title">"Changement des réglages"</string>
-	<string name="help_change_settings_text">"Vous pouvez changer vos réglages en appuyant sur les trois petits points en haut à droite de l'écran puis en sélectionnant Réglages.
-Vous pouvez changer les réglages suivants :
-
-• Appareil et méthode de mise à jour
-• Notifications push
-• Notifications dans l'application
-• Réglages relatifs à la vie privée (upload des fichiers log)
-
-Utilisez les switchs pour changer les réglages.
-Sélectionnez un appareil et/ou une méthode de mise à jour en utilisant les menus déroulants. S'ils ne sont pas visibles vérifiez votre connexion Internet et rouvrez l'écran des réglages."</string>
+	<string name="url_submitted_notification_channel_description">Recevez une notification lorsque vous avez soumis avec succès des URL d\'OTA à notre équipe.\nVous pouvez choisir de ne pas soumettre automatiquement les URL dans les paramètres de l\'application.</string>
 
 	<!-- News strings -->
 	<string name="news">"Articles"</string>
-	<string name="news_date_published">"Dernière mise à jour : %1$s"</string>
-	<string name="news_empty">"Cet article n'a pas de contenu."</string>
 	<string name="news_load_network_error">"Échec de l'ouverture de l'article. Vérifiez votre connexion et appuyez sur le bouton « Réessayer » pour ouvrir l'article."</string>
-	<string name="news_load_id_error"><![CDATA[Échec de l\'ouverture de l\'article à partir d\'une URL invalide: %1$s. Vérifiez l\'URL ou signalez-le nous par <a href="mailto:support@oxygenupdater.com">email</a> ou par <a href="https://discord.gg/5TXdhKJ">Discord</a>.]]></string>
 	<string name="news_unread_count_1">Vous avez %1$d articles non lus. Appuyez ici pour les voir.</string>
 	<string name="news_unread_count_2">Vous avez %1$d articles non lus. Appuyez ici pour voir tous les articles.</string>
 	<string name="news_mark_read">Marquer comme lu</string>
@@ -352,11 +256,9 @@ Sélectionnez un appareil et/ou une méthode de mise à jour en utilisant les me
 	<string name="error_app_outdated">"Oh non !"</string>
 	<string name="error_app_outdated_message">"Cette version de l'application est obsolète. Il est temps de la mettre à jour ! Cliquez sur le bouton « Play Store » en dessous, puis sélectionnez « Mettre à jour »."</string>
 	<string name="error_app_requires_network_connection">"Pas de connexion"</string>
-	<string name="error_app_requires_network_connection_message">"Erreur de connexion au serveur. Veuillez vous assurer que votre connexion Internet fonctionne. L'application va maintenant se fermer."</string>
-	<string name="error_no_internet_connection">"Pas de connexion."</string>
 	<string name="error_maintenance">"Maintenance du serveur"</string>
 	<string name="error_maintenance_message">"Veuillez patienter. Le serveur sera disponible bientôt."</string>
-	<string name="error_maintenance_retry">Le serveur est probablement en cours de maintenance. Veuillez réessayez dans quelques instants ou signalez-le nous par <a href="mailto:support@oxygenupdater.com">email</a> ou par  <a href="https://discord.gg/5TXdhKJ">Discord</a>.</string>
+	<string name="error_maintenance_retry"><![CDATA[Le serveur est probablement en cours de maintenance. Veuillez réessayez dans quelques instants ou signalez-le nous par <a href="mailto:support@oxygenupdater.com">email</a> ou par <a href="https://discord.gg/5TXdhKJ">Discord</a>.]]></string>
 	<string name="error_reload">"Recharger"</string>
 	<string name="error_unable_to_rate_app">"Vous ne pouvez pas évaluer cette application car le Play Store n'est pas installé sur votre appareil."</string>
 
@@ -383,7 +285,6 @@ Les autres appareils, incluant les appareils OnePlus fonctionnant sous des roms 
 	<string name="purchase_error_after_payment">"L'achat de la version sans publicités a échoué en raison d'une erreur interne. Veuillez réessayer dans quelques minutes. Si vous avez déjà payé, veuillez contacter le support du Play Store."</string>
 
 	<!-- Other strings -->
-	<string name="error">Erreur</string>
 	<string name="icon">"Icône"</string>
 	<string name="loading">"Chargement…"</string>
 	<string name="processing">"Achat en cours…"</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools" tools:keep="@string/install_guide_page_*_*">
-
-	<!-- TODO: translate this string below -->
-	<string name="device_chooser_error_title">Couldn\'t retrieve list of supported devices</string>
-
+<resources>
 	<!-- Update information strings -->
 	<!-- TODO: translate this string below -->
 	<string name="enable">Omogućiti</string>
@@ -16,13 +12,12 @@
 	<!-- TODO: translate these 6 strings below -->
 	<string name="update_information_error_title">Couldn\'t retrieve latest update data information</string>
 	<string name="update_information_banner_server">Tap here to view important notices</string>
-	<string name="update_information_banner_advanced_mode_tip">You\'ve selected the \"%1$s\" update track. Enable napredni način if you plan to switch to this update track.</string>
+	<string name="update_information_banner_advanced_mode_tip">You\'ve selected the \"%1$s\" update method. Enable napredni način if you plan to switch to this update method.</string>
 	<string name="update_information_header_advanced_mode_hint">Omogućen je napredni način rada</string>
-	<string name="update_information_header_advanced_mode_helper">Since you\'ve enabled napredni način, you can download the latest ZIP for \"%1$s\".\n\nYou can turn napredni način off from settings.</string>
-	<string name="update_information_different_version_changelog_notice">You\'re viewing a changelog for the latest update in the \"%1$s\" upgrade track. If you intend to install this update, you must turn napredni način on first (in settings).\n\nHowever, if you wish to see the changelog for the currently installed version instead, you\'ll need to switch back to the correct update method.</string>
-	<string name="update_information_last_checked_on">"Zadnja provjera: %1$s"</string>
+	<string name="update_information_header_advanced_mode_helper">Since you\'ve enabled napredni način, you can download the latest ZIP for \"%1$s\". You can turn napredni način off from settings.</string>
+	<string name="update_information_different_version_changelog_notice_base">Napomena: ovaj dnevnik promjena je za posljednju dostupnu verziju (%1$s) u metodi ažuriranja \"%2$s\"</string>
+	<string name="update_information_different_version_changelog_notice_advanced">. Ako namjeravate instalirati ovo ažuriranje, morate omogućiti \"Napredni način\" u postavkama.</string>
 	<string name="update_information_no_update_data_available">"Nema novosti o ažuriranju"</string>
-	<string name="update_information_oxygen_os_version">"OxygenOS %1$s"</string>
 	<string name="update_information_system_is_up_to_date">"Tvoj sistem koristi najnovija ažuriranja."</string>
 	<string name="update_information_unknown_update_name">"Neimenovano ažuriranje za %1$s"</string>
 	<string name="update_information_view_update_information">"Pogledaj podatke o ažuriranju"</string>
@@ -49,9 +44,9 @@
 	<string name="download_complete">"Preuzimanje je gotovo."</string>
 	<string name="download_complete_notification">"Pritisnite kako bi počeli sa instalacijom"</string>
 	<string name="download_error">"Greška pri preuzimanju"</string>
-	<string name="download_error_close">"ZATVORI"</string>
+	<string name="download_error_close">"Zatvori"</string>
 	<string name="download_error_corrupt">"Podatak koji je preuzet je oštećen. Molimo pokušajte preuzeti ponovo."</string>
-	<string name="download_error_retry">"PONOVI"</string>
+	<string name="download_error_retry">"Ponovi"</string>
 	<string name="download_error_storage">"Na vašem uređaju nema dovoljno mjesta za preuzimanje ažuriranje. Molimo vas da uklonite neke podatke i pokušate preuzeti ponovo"</string>
 	<string name="download_failed">"Preuzimanje nije uspjelo"</string>
 	<string name="download_pending">"Tvoje ažuriranje će početi uskoro…"</string>
@@ -86,9 +81,7 @@
 	<string name="summary_please_wait">Molim te pričekaj…</string>
 	<string name="summary_update_method">Select a device first</string>
 	<!-- TODO: check the following translation -->
-	<string name="summary_important_notifications_disabled">Neke važne obavijesti su onemogućene: \"%1$s\"</string>
-	<string name="summary_theme">Set theme</string>
-	<string name="summary_language">Postavite jezik</string>
+	<string name="summary_important_notifications_disabled">Neke važne obavijesti su onemogućene:</string>
 	<string name="summary_privacy_policy">Pogledajte na mreži</string>
 	<string name="summary_rate_app">Leave a 5 star review</string>
 
@@ -117,110 +110,55 @@
 	<string name="settings_buy_button_buy">"Kupi (%1$s)"</string>
 	<string name="settings_buy_button_bought">"Kupljeno"</string>
 	<string name="settings_buy_button_not_possible">"Nedostupno"</string>
-	<string name="settings_buy_ad_free_label">"Nadogradi na Ad-Free"</string>
+	<string name="settings_buy_ad_free_label">"Nadogradi na ad-free"</string>
 
 	<string name="settings_contribute_label">Pomozite poboljšati aplikaciju</string>
 
 	<string name="settings_device">"Uređaj"</string>
 	<string name="settings_entered_incorrectly">"Greška pri spremanju postavki. Molimo vas ponovno odaberite vaš uređaj / metodu ažuriranja."</string>
-	<string name="settings_explanation_incremental_full_update">"Djelomično ažurianje može biti insalirano s bilo koje verzije (ako nemate bootloader otključan; onda biste uvjek trebali izabrati metodu punog ažuriranja), dok god mi imamo to djelomično ažuriranje.\n\nA Cjeli ažuriranje će uvjek biti instalirano - nevezano sa sadašnjom verzijom softwera korištenog na uređaju\n\nA Beta verzije OxygenOSa može uvjek biti instalirano kao i stabilna verzija. Da napravite to morate uključiti "napredni mod" u postavkama. Naćin ažuriranja je isti kao i kad ste na stabilnoj verziji."</string>
 	<string name="settings_push_from_server">"Važna poruka je dostupna"</string>
 	<string name="settings_saving">"Vaše postavke se još uvijek spremaju. Ako ovo potraje predugo: Provjerite vašu internet vezu , izađite iz aplikacije i pokrenite je ponovno."</string>
 	<string name="settings_advanced_mode">"Napredni način"</string>
-	<string name="settings_advanced_mode_explanation">"Napredni način skriva poruku \"Vaš uređaj je na najnovijim ažuriranjima\" , dopušta vam preuzimanje i instalaciju svih ažuriranja, iako oni možda nisu kompatibilni sa vašim uređajem.
+	<string name="settings_advanced_mode_explanation">"Obično vam aplikacija prikazuje ažuriranja na temelju vaše trenutne verzije OS-a. Uz napredni način rada, najnovije dostupno ažuriranje uvijek će biti prikazano bez obzira na kompatibilnost uređaja/verzije.
 
-To može biti korisno:
-- Ažuriranje"</string>
+Ovo može biti korisno ako želite:"</string>
+	<string name="settings_advanced_mode_uses">"&#8226; Ponovno preuzmite najnoviju verziju čak i ako je već koristite
+&#8226; Prebacite se na drugu stazu ažuriranja"</string>
+	<string name="settings_advanced_mode_caption">"Napredni način rada može biti potreban samo u gore navedenim situacijama. Ne biste ga trebali omogućiti ako ne znate što radite."</string>
 	<string name="settings_update_method">"Metoda ažuriranja"</string>
 	<!-- TODO translate -->
 	<string name="settings_upload_logs">Share usage data and logs</string>
+	<string name="settings_ad_privacy">GDPR pristanak za oglašavanje</string>
+	<string name="settings_ad_privacy_subtitle">"Za korisnike EEA/UK"</string>
 
 	<!-- FAQ strings -->
 	<string name="faq">"FAQ"</string>
 	<string name="faq_menu_item">"FAQ"</string>
 
 	<!-- First-time setup strings -->
-	<string name="onboarding">"Dobrodošli"</string>
+	<string name="onboarding">"Postaviti"</string>
 	<string name="onboarding_finished_button">"Pokretanje aplikacije"</string>
-	<string name="onboarding_page_1_title">"Dobrodošli u Oxygen Updater!"</string>
-	<string name="onboarding_page_1_text">"Ova aplikacija vam omogućava:
+	<string name="onboarding_app_uses">"Ova aplikacija vam omogućava:
 
-- Dobivanje ažuriranje brže na vaše OxygenOS uređaje
-
-- Lakše ažuriranje root-anih uređaja
-
-- Pregled novih mogućnosti vašeg software-a
-
-- Najnovije vijesti o OnePlus-u i OxygenOs-u
-
-Povucite lijevo za nastavak."</string>
-	<string name="onboarding_page_1_caption">"Ovo nije službena aplikacija OnePlus-a. Koristite ovu aplikaciju na svoj rizik. OnePlus i developer ove aplikacije nisu dogovorni za vaše postupke, uključujući ikakvu štetu koristeči ovu aplikaciju."</string>
-	<string name="onboarding_page_2_title">"Izaberi svoj uređaj:"</string>
-	<string name="onboarding_page_2_caption">"Vaš uređaj je uobičajno već izabran. Ako nije izaberite svoj uređaj gore.
-
-Povuci lijevo da nastaviš."</string>
-	<string name="onboarding_page_3_title">"Izaberi svoju metodu ažuriranja:"</string>
-	<string name="onboarding_page_3_caption">"Uobičajno inkrementalno ažuriranje je pravi odabir ovdje zato što pruža puno brže i manje skidanja.
-
-Iako ono nije kompatibilno sa rootanim uređajima. Ako je vaš uređaj rootan izaberite puno ažuriranje.
-
-Ako imate beta verziju OxygenOS izaberite (jednu od) Open Beta metoda ažuriranje/a.
-
-Povuci lijevo da nastaviš."</string>
-	<string name="onboarding_page_4_title">"Spreman si da kreneš!"</string>
-	<string name="onboarding_page_4_text">"Uživajte u korištenju aplikacije!"</string>
+&#8226; Dobivanje ažuriranje brže na vaše OxygenOS uređaje
+&#8226; Lakše ažuriranje root-anih uređaja
+&#8226; Pregled novih mogućnosti vašeg software-a
+&#8226; Najnovije vijesti o OnePlus-u i OxygenOs-u"</string>
+	<string name="onboarding_disclaimer">"Ovo nije službena aplikacija OnePlus-a. Koristite ovu aplikaciju na svoj rizik. OnePlus i developer ove aplikacije nisu dogovorni za vaše postupke, uključujući ikakvu štetu koristeči ovu aplikaciju."</string>
+	<string name="onboarding_device_chooser_title">"Izaberi svoj uređaj:"</string>
+	<string name="onboarding_device_chooser_caption">"Vaš uređaj je uobičajno već izabran. Ako nije izaberite svoj uređaj gore."</string>
+	<string name="onboarding_method_chooser_title">"Izaberi svoju metodu ažuriranja:"</string>
+	<string name="onboarding_method_chooser_caption">"Uobičajno inkrementalno ažuriranje je pravi odabir ovdje zato što pruža puno brže i manje skidanja. Iako ono nije kompatibilno sa rootanim uređajima. Ako je vaš uređaj rootan izaberite puno ažuriranje. Ako imate beta verziju OxygenOS izaberite (jednu od) Open Beta metoda ažuriranje/a."</string>
+	<string name="onboarding_caption">"Uživajte u korištenju aplikacije!"</string>
 
 	<!-- Automatic install strings -->
 	<string name="install">"Instaliraj"</string>
 
 	<!-- Install guide strings -->
-	<string name="install_guide_no_root">"Instalirajte ažuriranje kao što je prikazano u instalacijskom priručniku."</string>
 	<string name="install_guide">"instalacijski priručnik"</string>
-	<string name="install_guide_subtitle">"Instalacijski priručnik - %1$d od %2$d "</string>
-	<string name="install_guide_tip">"&#8226; Preporučeno je zapisati sve korake jer čete trebati isključiti uređaj tijekom instalacije ažuriranja"</string>
-	<string name="install_guide_page_1_title">"Preuzmi ažuriranje"</string>
-	<string name="install_guide_page_1_text">"&#8226; Pritisnite dugme za preuzimanje kako bi započeli preuzimanje ažuriranja.
-
-- Status preuzimanja biti će prikazan u aplikaciji i kao notifikacija.
-
-- Nakon završetka preuzimanja dobiti čete notifikaciju sa tekstom \"Preuzimanje završeno\" , ako se dogodi greška pri preuzimanju otvorite aplikaciju i pokušajte ponovno , ako ni to ne djeluje provjerite jeli imate stabilnu vezu. U suprotnom kontaktirajte stvaratelja aplikacije. To možete učiniti preko \"My apps\" sekcije u Google Play Store-u."</string>
-
-	<!-- TODO: translate these 2 strings below -->
-	<string name="install_guide_page_2_title">Prepare for installation</string>
-	<string name="install_guide_page_2_text">"Note: The installation of the update takes place from a special page of the standard System Updates section of your device. If, for some reason, a system update appears when opening this section, you may also opt to install that update first. Afterwards, open Oxygen Updater again to see if you're completely up-to-date.
-
-Instructions:
-&#8226; Close Oxygen Updater by pressing the home button.
-
-&#8226; Open the Settings app. It should be located in your app drawer.
-
-&#8226; Scroll down until you see System updates. Tap on it."</string>
-
-	<!-- TODO: translate these 2 strings below -->
-	<string name="install_guide_page_3_title">Install the update</string>
-	<string name="install_guide_page_3_text">"Now that you're in the System Updates app, it's time to install the update.
-
-&#8226; Within the System Updates section, tap the gear icon in the top right
-
-&#8226; Now, select \"Local upgrade\". A file selection screen should appear.
-
-&#8226; In this screen, tap on the update file you downloaded using Oxygen Updater. Its name should start with \"%1$sOxygen\".
-
-&#8226; Tap on \"Upgrade Now\". The installation should start automatically."</string>
-
-	<!-- TODO: translate these 2 strings below -->
-	<string name="install_guide_page_4_title">Wait until the installation completes</string>
-	<string name="install_guide_page_4_text">"&#8226; The phone will now install the update and displays a progress bar. Please wait until the installation has finished. Installation may take anywhere from a few minutes up to 15 minutes.
-
-&#8226; Afterwards, your phone will restart to complete the update."</string>
-
-	<string name="install_guide_page_5_title">"Gotovo. Uživajte u novoj OxygenOS verziji!"</string>
-	<string name="install_guide_page_5_text">"&#8226; Nakon što je vaš uređaj završio optimizaciju aplikacija tada je proces instalacije uspješno gotov.
-
-- Možete provjeriti verziju pomoću \"O uređaju\" u vašim postavkama uređaja
-
-- Ako vam se aplikacija sviđa molimo vas ocijenite je s 5 zvjezdica na Google Play-u!"</string>
-	<string name="install_guide_close_button">"Zatvorite priručnik."</string>
+	<string name="install_guide_download_instructions">"&#8226; Pritisnite dugme za preuzimanje kako bi započeli preuzimanje ažuriranja.
+&#8226; Status preuzimanja biti će prikazan u aplikaciji i kao notifikacija.
+&#8226; Nakon završetka preuzimanja dobiti čete notifikaciju sa tekstom \"Preuzimanje završeno\" , ako se dogodi greška pri preuzimanju otvorite aplikaciju i pokušajte ponovno , ako ni to ne djeluje provjerite jeli imate stabilnu vezu. U suprotnom kontaktirajte stvaratelja aplikacije. To možete učiniti preko \"My apps\" sekcije u Google Play Store-u."</string>
 
 	<!-- Device information strings -->
 	<!-- TODO: translate these lines -->
@@ -239,7 +177,7 @@ Instructions:
 	<string name="device_information_image_description">"Slika uređaja"</string>
 	<string name="device_information_incremental_os_version">"Inkrementalna OS verzija:"</string>
 	<string name="device_information_os_version">"Android verzija"</string>
-	<string name="device_information_oxygen_os_version">"OxygenOS verzija:"</string>
+	<string name="device_information_oxygen_os_version">"OS verzija:"</string>
 	<string name="device_information_oxygen_os_ota_version">"OTA verzija:"</string>
 	<string name="device_information_patch_level_version">"Datum security patch-a:"</string>
 	<string name="device_information_serial_number">"Serial number:"</string>
@@ -260,6 +198,8 @@ Instructions:
 	<string name="about_email_button_text">Email</string>
 
 	<!-- LocalNotifications strings -->
+	<string name="notification_permission_title">"Ostanite obaviješteni"</string>
+	<string name="notification_permission_text">"Dopustite aplikaciji da vas obavještava o OTA ažuriranjima, novostima, statusu preuzimanja u tijeku i drugim važnim stvarima. Kasnije možete fino podesiti svoje postavke u postavkama aplikacije."</string>
 	<string name="notification_new_device_text">"%1$s je sada podržan. Otvorite aplikaciju da izaberete ovaj uređaj."</string>
 	<string name="notification_no_notification_support">"Instalirajte ili ažurirajte Googe Play usluge da omogućite push notifikacije."</string>
 	<string name="notification_version">"%1$s je sada dostupan za %2$s!"</string>
@@ -286,42 +226,10 @@ Instructions:
 	<string name="general_notification_channel_description">General notifications that don\'t fit into other categories</string>
 	<string name="url_submitted_notification_channel_description">Primite obavijest kada uspješno pošaljete OTA URL-ove našem timu.\nMožete isključiti automatsko slanje URL-ova u postavkama aplikacije.</string>
 
-	<!-- Help strings -->
-	<string name="help">"Pomoć"</string>
-	<string name="help_updating_your_device_title">"Ažuriranje vašeg uređaja"</string>
-	<string name="help_updating_your_device_text">"Kada otvorite aplikaciju vidjeti čete ako je ažuriranje dostupno. Ako je ažuriranje dostupno možete ga preuzeti.
-
-Da započnete instalaciju pritisnite \"Preuzmi\" (ispod opisa ažuriranja). Kada je preuzimanje gotovo prozor za instalaciju će se pojaviti. Ako ste izašli iz aplikacije ili se prozor nije pojavio stisnite \"Instaliraj\" dugme pokraj \"Preuzmi\" dugmeta.
-
-Prozor za instalaciju će prvo provjeriti jeli vaš uređaj root-an. Ako imate root-an uređaj dajte root dopuštenja kada su zatražena i izaberite kako želite instalirati ažuriranje. U suprotnom samo slijedite upute za ručnu instalaciju.
-
-Automatska instalacija:
-Jedino što čete biti zatraženi je da odaberete način instalacije. Zadane postavke su preporučene osim ako imate specifičan root paket koji mora biti (re)instaliran. Odaberite root paket (zip fajl) koristeći se plavim folder dugmetom i pritisnite \"Počni instalaciju\" da započnete instalaciju.
-
-Ručna instalacija:
-Vidjeti čete priručnik za instalaciju na vašem ekranu. Zapišite instrukcije na papir i pratite ih tijekom instalaciju ažuriranja."</string>
-	<string name="help_reading_news_title">"Čitanje najnovijih vijesti"</string>
-	<string name="help_reading_news_text">"Vijesti su prikazanje na lijevoj strani stranice sa podacima o ažuriranju. Najnovije vijesti su prikazanje na vrhu. Pritiskom na njih možete ih pročitati.
-Pritiskom na strelicu ili pritiskom tipke na uređaju za unatrag možete se vratiti na početni zaslon"</string>
-	<string name="help_device_information_title">"Pregled informacija o vašem uređaju"</string>
-	<string name="help_device_information_text">"Možete vidjeti neke od specifikacija vašeg uređaja koristeći ekran s desne strane od informacija za ažuriranje. To vam može poslužiti tijekom pisanja molbe za pomoć tijekom koje bi mogli biti pitani neke od specifikacija vašeg uređaja."</string>
-	<string name="help_change_settings_title">"Promjena postavki"</string>
-	<string name="help_change_settings_text">"Možete promijeniti postavke pritiskom na tri točke u gornjem desnom kutu. Pritiskom na tipku za postavke možete promijeniti sljedeće:
-
-• Uređaj i metodu ažuriranja
-• \"Push\" Notifikacije
-• Notifikacije u aplikaciji
-• Postavke o privatnosti (log ažuriranja)
-
-Koristite \"prekidač\" da upalite ili ugasite notifikacije / postavke o privatnosti. Odaberite svoj uređaj i metodu ažuriranja pomoću selektivnog menija. Ne vidite selektivni meni? Provjerite svoju internetsku vezu i otvorite postavke ponovno."</string>
-
 	<!-- News strings -->
 	<string name="news">"Vijesti"</string>
-	<string name="news_date_published">"Najnovije vijesti: %1$s"</string>
-	<string name="news_empty">"Ovaj članak nema komentara"</string>
 	<string name="news_load_network_error">"Došlo je do pogreške. Molimo provjerite vašu internet vezu i pritisnite \"Retry\" tipku da otvorite članak"</string>
 	<!-- TODO: translate this string below -->
-	<string name="news_load_id_error"><![CDATA[Failed to open article from an invalid URL: %1$s. Check the URL or report this to us either via <a href="mailto:support@oxygenupdater.com">email</a> or on our <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
 	<!-- TODO: translate these 2 strings below -->
 	<string name="news_unread_count_1">You have %1$d unread news articles. Tap here to view them.</string>
 	<string name="news_unread_count_2">You have %1$d unread news articles. Tap to show all articles.</string>
@@ -349,12 +257,10 @@ Koristite \"prekidač\" da upalite ili ugasite notifikacije / postavke o privatn
 	<string name="error_app_outdated">"O ne!"</string>
 	<string name="error_app_outdated_message">"Ova verzija aplikacije je zastarjela. Vrijeme je da je ažurirate! Pritisnite na \"Google Play\". U Google play-u pritisnite \"Ažuriraj\""</string>
 	<string name="error_app_requires_network_connection">"Nema internetske veze"</string>
-	<string name="error_app_requires_network_connection_message">"Neuspješno povezivanje na server. Molimo provjerite vašu vezu. Aplikacija će se sada zatvoriti."</string>
-	<string name="error_no_internet_connection">"Nema internetske veze"</string>
 	<string name="error_maintenance">"Održavanje servera"</string>
 	<string name="error_maintenance_message">"Molimo pričekajte. Serveri će uskoro biti dostupni."</string>
 	<!-- TODO: translate this string below -->
-	<string name="error_maintenance_retry">The server may be down for maintenance. Try again after some time, or report it to us either via <a href="mailto:support@oxygenupdater.com">email</a> or on our <a href="https://discord.gg/5TXdhKJ">Discord server</a>.</string>
+	<string name="error_maintenance_retry"><![CDATA[The server may be down for maintenance. Try again after some time, or report it to us either via <a href="mailto:support@oxygenupdater.com">email</a> or on our <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
 	<string name="error_reload">"Ponovno pokreni"</string>
 	<string name="error_unable_to_rate_app">"Nemožete ocijeniti ovu aplikaciju jer na vašem uređaju nema Google Play aplikacije"</string>
 
@@ -383,7 +289,6 @@ Ostali uređaji tako i uređaji koji koriste \"Custom\" ROM-ove nisu podržani."
 
 	<!-- Other strings -->
 	<!-- TODO: translate this string below -->
-	<string name="error">Pogreška</string>
 	<string name="icon">"Ikona"</string>
 	<string name="loading">"Učitavanje…"</string>
 	<string name="processing">"Procesiranje…"</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools" tools:keep="@string/install_guide_page_*_*">
-	<string name="device_chooser_error_title">Nem sikerült beolvasni a támogatott eszközök listáját</string>
-
+<resources>
 	<!-- Update information strings-->
 	<string name="enable">Engedélyezés</string>
 	<string name="update_information_description_not_available">A frissítés által nyújtott új funkciókról nincs hivatalos információ. Az ilyen frissítés rendszerint hibajavításokat, teljesítményjavításokat és / vagy kritikus biztonsági frissítéseket biztosít az eszközödhöz.</string>
@@ -13,11 +11,10 @@
 	<string name="update_information_banner_server">Koppints ide a fontos értesítések megtekintéséhez</string>
 	<string name="update_information_banner_advanced_mode_tip">A(z) \"%1$s\" frissítési módot választottad. Engedélyezd a haladó módot ha erre a frissítési módra szeretnél váltani.</string>
 	<string name="update_information_header_advanced_mode_hint">A Haladó mód engedélyezve van</string>
-	<string name="update_information_header_advanced_mode_helper">Mivel engedélyezted a haladó módot, letöltheted a legújabb ZIP fájlt a(z) \"%1$s\" számára.\n\nA haladó módot a beállításokban kapcsolhatod ki.</string>
-	<string name="update_information_different_version_changelog_notice">A legfrissebb frissítés módosítási naplóját nézi a \"%1$s\" frissítési sávon. Ha telepíteni szeretnéd ezt a frissítést, előbb be kell kapcsolnod a haladó módot (a beállításokban).\n\nHa azonban inkább az aktuálisan telepített verzió módosítási naplóját szeretnéd látni, akkor vissza kell váltanod a helyes frissítési módszerre.</string>
-	<string name="update_information_last_checked_on">Utoljára ellenőrizve: %1$s</string>
+	<string name="update_information_header_advanced_mode_helper">Mivel engedélyezted a haladó módot, letöltheted a legújabb ZIP fájlt a(z) \"%1$s\" számára. A haladó módot a beállításokban kapcsolhatod ki.</string>
+	<string name="update_information_different_version_changelog_notice_base">Megjegyzés: ez a változásjegyzék a legújabb elérhető verzióra (%1$s) vonatkozik a \"%2$s\" frissítési módszerrel</string>
+	<string name="update_information_different_version_changelog_notice_advanced">. Ha ezt a frissítést kívánja telepíteni, engedélyeznie kell a \"Haladó mód\" opciót a beállításokban.</string>
 	<string name="update_information_no_update_data_available">Nem állnak rendelkezésre frissítési információk</string>
-	<string name="update_information_oxygen_os_version">OxygenOS %1$s</string>
 	<string name="update_information_system_is_up_to_date">A rendszer naprakész</string>
 	<string name="update_information_unknown_update_name">Névtelen frissítés a következőhöz: %1$s</string>
 	<string name="update_information_view_update_information">frissítési információk megtekintése</string>
@@ -44,7 +41,7 @@
 	<string name="download_complete_notification">Érintsd meg a telepítés elindításához</string>
 
 	<string name="download_error">letöltési Hiba</string>
-	<string name="download_error_close">BEZÁRÁS</string>
+	<string name="download_error_close">Bezárás</string>
 	<string name="download_error_corrupt">A letöltött frissítés fájl sérült! Próbáld meg újra letölteni.</string>
 	<string name="download_error_server">Szerverhiba történt a frissítés letöltése közben. Próbáld újra letölteni a frissítést.</string>
 	<string name="download_error_internal">Sajnos technikai hiba történt a frissítés letöltése közben. Próbáld meg újra letölteni. Ha ez továbbra is fennáll, kérjük, fordulj segítségért az alkalmazás fejlesztőjéhez.</string>
@@ -53,8 +50,8 @@
 Ha többet szeretnél tudni, vedd fel velünk a kapcsolatot <a href="mailto:support@oxygenupdater.com">emailen</a> vagy a <a href="https://discord.gg/5TXdhKJ">Discord szerverünkön</a>.]]></string>
 	<string name="download_error_could_not_move_temp_file">A fájl letöltésre került, de nem sikerült áthelyezni a megfelelő könyvtárba. Nyiss meg egy fájlkezelőt, keresd meg a \"%1$s\" helyet, és kézzel helyezd át a fájlt a belső tárolóhely legfelső könyvtárába.</string>
 
-	<string name="download_error_retry">ÚJRA</string>
-	<string name="download_error_resume">FOLYTATÁS</string>
+	<string name="download_error_retry">Újra</string>
+	<string name="download_error_resume">Folytatás</string>
 	<string name="download_error_storage">Nincs elegendő tárhely a készüléken a frissítés letöltéséhez. Távolíts el néhány fájlt, és próbáld meg újra letölteni.</string>
 
 	<string name="download_failed">Sikertelen letöltés</string>
@@ -92,9 +89,7 @@ Ha többet szeretnél tudni, vedd fel velünk a kapcsolatot <a href="mailto:supp
 	<string name="summary_please_wait">Kérlek várj…</string>
 	<string name="summary_update_method">Először válassz ki egy eszközt</string>
 	<!-- TODO: check the following translation -->
-	<string name="summary_important_notifications_disabled">Néhány fontos értesítés le van tiltva: \"%1$s\"</string>
-	<string name="summary_theme">Téma beállítása</string>
-	<string name="summary_language">Állítsa be a nyelvet</string>
+	<string name="summary_important_notifications_disabled">Néhány fontos értesítés le van tiltva:</string>
 	<string name="summary_privacy_policy">Megtekintés interneten</string>
 	<string name="summary_rate_app">Hagyj 5 csillagos értékelést</string>
 
@@ -125,78 +120,46 @@ Ha többet szeretnél tudni, vedd fel velünk a kapcsolatot <a href="mailto:supp
 
 	<string name="settings_device">Eszköz</string>
 	<string name="settings_entered_incorrectly">Hiba a beállítások mentésekor. Kérjük, menj vissza, és válaszd ki újra eszközöd / frissítési módszered.</string>
-	<string name="settings_explanation_incremental_full_update">Az inkrementális frissítés bármilyen verzióból telepíthető (kivéve, ha nyitott bootloadered van; ilyenkor mindig a teljes frissítést kell frissítési módszerként választanod).\n\nAz OxygenOS bétafrissítése mindig telepíthető, és akkor is, ha stabil verzión vagy. A stabilról béta módra váltáshoz engedélyezned kell a haladó módot a beállításokban. A béta esetén a teljes és az inkrementális frissítési módszerek ugyanúgy működnek, mint a stabil verziók esetében.</string>
 
 	<string name="settings_push_from_server">Tájékoztató és figyelmeztető üzenetek</string>
 
 	<string name="settings_saving">A beállításokat még mindig mentimentődnek. Ha ez túl sokáig tart: Ellenőrizd a hálózati kapcsolatot, lépj ki az alkalmazásból, és indítsd újra.</string>
 
 	<string name="settings_advanced_mode">Haladó mód</string>
-	<string name="settings_advanced_mode_explanation">A haladó mód hides elrejti az \"A rendszer naprakész\" üzenetet, és lehetővé teszi az összes frissítés letöltését és telepítését, akkor is, hogy ha ezek nem lennének kompatibilisek az eszközöddel.\n\nEz hasznos lehet ha:\n&#8226; Normál verzióról béta verzióra frissítesz\n&#8226; Béta verzióról stabil verzióra frissítesz vissza (ne felejtsd el készülékd gyári állapotát visszaállítani)\n&#8226; Jelenlegi rendszerverzió újratelepítése.</string>
+	<string name="settings_advanced_mode_explanation">"Normális esetben az alkalmazás az aktuális operációs rendszer verziója alapján mutatja a frissítéseket. A speciális módban mindig a legújabb elérhető frissítés jelenik meg, függetlenül az eszköz/verzió kompatibilitástól.
+
+Ez hasznos lehet, ha szeretné:"</string>
+	<string name="settings_advanced_mode_uses">"&#8226; Újra letölteni a legújabb verziót, még akkor is, ha már rajta van.
+&#8226; Másik frissítési sávra váltani"</string>
+	<string name="settings_advanced_mode_caption">"A speciális módra csak a fenti helyzetekben lehet szükség. Nem szabad engedélyeznie, hacsak nem tudja, mit csinál."</string>
 
 	<string name="settings_update_method">Frissítési módszer</string>
 	<string name="settings_upload_logs">Használati adatok és a naplók megosztása</string>
+	<string name="settings_ad_privacy">GDPR hirdetési hozzájárulás</string>
+	<string name="settings_ad_privacy_subtitle">"EGT/UK felhasználói számára"</string>
 
 	<!-- FAQ strings -->
 	<string name="faq">GYIK</string>
 	<string name="faq_menu_item">GYIK</string>
 
 	<!-- First-time onboarding strings -->
-	<string name="onboarding">Üdvözölünk</string>
+	<string name="onboarding">Beállítás</string>
 	<string name="onboarding_finished_button">Alkalmazás elindítása</string>
 
-	<string name="onboarding_page_1_title">Üdvözlünk az Oxygen Updater-ben!</string>
-	<string name="onboarding_page_1_text">Ez az alkalmazás lehetővé teszi a:\n\n&#8226; Gyorsabb hozzáférést a legfrissebb Android-frissítésekhez az OxygenOS-szel működő eszközödön\n\n&#8226; Rootolt eszközök egyszerű frissítését\n\n&#8226; Újdonságokat megtekintését a jelenleg használt szoftveredben\n\n&#8226; Legújabb hírek elolvasását a OnePlus-szal és az OxygenOS-szel kapcsolatban\n\nHúzd balra a folytatáshoz.</string>
-	<string name="onboarding_page_1_caption">Ez nem egy hivatalos OnePlus alkalmazás. Az alkalmazás használata teljesen a saját felelősségre történik. Sem az OnePlus, sem az alkalmazás fejlesztője nem vállal felelősséget a tetteidért, ideértve az alkalmazás használatával okozott károkat is.\n\nAz alkalmazás használatával elfogadod a fentiekben meghatározott feltételeket.</string>
-	<string name="onboarding_page_2_title">Válaszd ki a készüléked</string>
-	<string name="onboarding_page_2_caption">A készüléked általában már feljebb ki van választva. Ha nem, válaszd ki a készüléket feljebb.</string>
-	<string name="onboarding_page_3_title">Válaszd ki a frissítési módszered</string>
-	<string name="onboarding_page_3_caption">Általában az inkrementális frissítés itt a megfelelő választás, mivel sokkal gyorsabb és kisebb letöltéseket kínál.\n\nAzonban nem kompatibilis rootolt eszközökkel. Ha az eszközöd rootolva van, válaszd a Teljes Frissítés lehetőséget.\n\nHa OxygenOS bétaverziód van, válaszd a Nyílt Béta frissítési módszer(ek) egyikét.</string>
-	<string name="onboarding_page_4_title">Készen állsz!</string>
-	<string name="onboarding_page_4_text">Reméljük élvezni fogod az alkalmazás használatát!\n\nA beállításokat később bármikor megváltoztathatod. Ehhez: érintd meg a három pontot a jobb felső sarokban, majd érintsd meg a \"Beállítások\" gombot.</string>
+	<string name="onboarding_app_uses">Ez az alkalmazás lehetővé teszi a:\n\n&#8226; Gyorsabb hozzáférést a legfrissebb Android-frissítésekhez az OxygenOS-szel működő eszközödön\n&#8226; Rootolt eszközök egyszerű frissítését\n&#8226; Újdonságokat megtekintését a jelenleg használt szoftveredben\n&#8226; Legújabb hírek elolvasását a OnePlus-szal és az OxygenOS-szel kapcsolatban</string>
+	<string name="onboarding_disclaimer">Ez nem egy hivatalos OnePlus alkalmazás. Az alkalmazás használata teljesen a saját felelősségre történik. Sem az OnePlus, sem az alkalmazás fejlesztője nem vállal felelősséget a tetteidért, ideértve az alkalmazás használatával okozott károkat is. Az alkalmazás használatával elfogadod a fentiekben meghatározott feltételeket.</string>
+	<string name="onboarding_device_chooser_title">Válaszd ki a készüléked</string>
+	<string name="onboarding_device_chooser_caption">A készüléked általában már feljebb ki van választva. Ha nem, válaszd ki a készüléket feljebb.</string>
+	<string name="onboarding_method_chooser_title">Válaszd ki a frissítési módszered</string>
+	<string name="onboarding_method_chooser_caption">Általában az inkrementális frissítés itt a megfelelő választás, mivel sokkal gyorsabb és kisebb letöltéseket kínál. Azonban nem kompatibilis rootolt eszközökkel. Ha az eszközöd rootolva van, válaszd a Teljes Frissítés lehetőséget. Ha OxygenOS bétaverziód van, válaszd a Nyílt Béta frissítési módszer(ek) egyikét.</string>
+	<string name="onboarding_caption">Reméljük élvezni fogod az alkalmazás használatát! A beállításokat később bármikor megváltoztathatod.</string>
 
 	<!-- Automatic install strings -->
 	<string name="install">Telepítés</string>
 
 	<!-- Install guide strings -->
-	<string name="install_guide_no_root">Telepítsd a frissítést a telepítési útmutatóban bemutatott utasítások szerint.</string>
 	<string name="install_guide">Telepítési útmutató</string>
-	<string name="install_guide_subtitle">Telepítési útmutató - %2$d -ből %1$d</string>
-	<string name="install_guide_tip">&#8226; Javasoljuk, hogy írj le minden lépést, mivel a frissítés telepítésekor ki kell majd kapcsolnod az eszközt.</string>
-
-	<string name="install_guide_page_1_title">Töltsd le a frissítést</string>
-	<string name="install_guide_page_1_text">&#8226; A frissítés letöltésének megkezdéséhez nyomd meg a Letöltés gombot.\n\n&#8226; A letöltési folyamat az alkalmazásban jelenik meg, és értesítésként az értesítési sávban.\n\n&#8226; Amikor a letöltés befejeződött, egy értesítést fogsz látni, amelynek szövege: \"Letöltés kész\" lesz.\nHa letöltési hiba történt, nyisd meg az alkalmazást, és próbáld meg újra letölteni a frissítést. Ha ez nem működik, ellenőrizd, hogy működőképes-e a kapcsolat. Ellenkező esetben vedd fel a kapcsolatot az alkalmazás fejlesztőjével. Ezt megteheted a Google Play Áruház \"Saját alkalmazások\" szekciójában.</string>
-
-	<string name="install_guide_page_2_title">Felkészülés a telepítésre</string>
-	<string name="install_guide_page_2_text">"Megjegyzés: A frissítés telepítésére a készülék szabványos rendszerfrissítések részének speciális oldaláról kerül sor. Ha valamilyen oknál fogva megjelenik egy rendszerfrissítés a szakasz megnyitásakor, akkor dönthet az első frissítés telepítéséről is. Ezután nyissa meg újra az Oxygen Updater készüléket, hogy megnézze, teljesen naprakész-e.
-
-Instrukciók:
-&#8226; Zárd be az Oxygen Updater-t a középső gomb megnyomásával.
-
-&#8226; Nyisd meg a Beállítások alkalmazást. Ennek az alkalmazástárban kell lennie.
-
-&#8226; Görgess lefelé, amíg meg nem jelenik a Rendszerfrissítések. Érintsd meg."</string>
-
-	<string name="install_guide_page_3_title">Telepítsd a frissítést</string>
-	<string name="install_guide_page_3_text">"Most, hogy a Rendszerfrissítések alkalmazásban vagy, ideje telepíteni a frissítést.
-
-&#8226; A Rendszerfrissítések részben érintse meg a fogaskerék ikont a jobb felső sarokban
-
-&#8226; Most válaszd ki a \"Helyi frissítés\" lehetőséget. Megjelenik egy fájlkiválasztási képernyő.
-
-&#8226; Ezen a képernyőn érintsd meg az Oxygen Updater használatával letöltött frissítési fájlt. A nevének \"%1$sOxygen\" -nel kell kezdődnie.
-
-&#8226; Érintsd meg a \"Frissítés most\" elemet. A telepítésnek automatikusan el kell indulnia."</string>
-
-	<string name="install_guide_page_4_title">Várj, amíg a telepítés befejeződik</string>
-	<string name="install_guide_page_4_text">"&#8226; A telefon most telepíti a frissítést, és megjelenik egy folyamatjelző sáv. Várj, amíg a telepítés befejeződik. A telepítés néhány perctől 15 percig is eltarthat.
-
-&#8226; Ezután a telefon újraindul a frissítés befejezéséhez."</string>
-
-	<string name="install_guide_page_5_title">Kész. Élvezd az új OxygenOS verziót!</string>
-	<string name="install_guide_page_5_text">&#8226; Miután az eszköz optimalizálta alkalmazásokat, a frissítés sikeresen telepítve lett.\nEnnek ellenőrzéséhez ellenőrizze a rendszer jelenlegi verzióját a következők szerint:\n\n&#8226; Lépj a Beállítások menübe, érintsd meg az \"A telefonról\" gombot, és ellenőrizd az OxygenOS verziót.\n\n&#8226; Ha tetszik ez az alkalmazás, adj neki 5 csillagot a Google Playen!</string>
-
-	<string name="install_guide_close_button">Telepítési útmutató bezárása</string>
+	<string name="install_guide_download_instructions">&#8226; A frissítés letöltésének megkezdéséhez nyomd meg a Letöltés gombot.\n&#8226; A letöltési folyamat az alkalmazásban jelenik meg, és értesítésként az értesítési sávban.\n&#8226; Amikor a letöltés befejeződött, egy értesítést fogsz látni, amelynek szövege: \"Letöltés kész\" lesz.\nHa letöltési hiba történt, nyisd meg az alkalmazást, és próbáld meg újra letölteni a frissítést. Ha ez nem működik, ellenőrizd, hogy működőképes-e a kapcsolat. Ellenkező esetben vedd fel a kapcsolatot az alkalmazás fejlesztőjével. Ezt megteheted a Google Play Áruház \"Saját alkalmazások\" szekciójában.</string>
 
 	<!-- Device information strings -->
 	<string name="device_information_supported_oxygen_os">A készüléked támogatott</string>
@@ -213,7 +176,7 @@ Instrukciók:
 	<string name="device_information_image_description">Eszköz kép</string>
 	<string name="device_information_incremental_os_version">Inkrementális OS verzió</string>
 	<string name="device_information_os_version">Android verzió</string>
-	<string name="device_information_oxygen_os_version">OxygenOS verzió</string>
+	<string name="device_information_oxygen_os_version">OS verzió</string>
 	<string name="device_information_oxygen_os_ota_version">OTA verzió</string>
 	<string name="device_information_patch_level_version">Biztonsági javítás dátuma</string>
 	<string name="device_information_serial_number">Sorozatszám</string>
@@ -232,6 +195,8 @@ Instrukciók:
 	<string name="about_email_button_text">Email</string>
 
 	<!-- LocalNotifications strings -->
+	<string name="notification_permission_title">"Maradjon értesítve"</string>
+	<string name="notification_permission_text">"Engedélyezze, hogy az alkalmazás értesítse Önt az OTA-frissítésekről, hírekről, a folyamatban lévő letöltés állapotáról és egyéb fontos dolgokról. A beállításokat később az alkalmazás beállításaiban finomhangolhatja."</string>
 	<string name="notification_new_device_text">A %1$s már támogatott. Nyisd meg az alkalmazást ahhoz hogy kiválaszd ezt az eszközt.</string>
 	<string name="notification_no_notification_support">Telepítsd vagy frissítsd a Google Play szolgáltatásokat a push értesítések engedélyezéséhez.</string>
 	<string name="notification_version">%1$s már elérhető a %2$s számára!</string>
@@ -257,23 +222,9 @@ Instrukciók:
 	<string name="general_notification_channel_description">Általános értesítések, amelyek nem illenek más kategóriákba</string>
 	<string name="url_submitted_notification_channel_description">Értesítést kap, ha sikeresen elküldte OTA URL-jét a csapatunknak.\nAz alkalmazás beállításaiban lemondhat az URL-ek automatikus elküldéséről.</string>
 
-	<!-- Help strings -->
-	<string name="help">Súgó</string>
-	<string name="help_updating_your_device_title">Az eszközöd frissítése</string>
-	<string name="help_updating_your_device_text">Az alkalmazás megnyitásakor megnézheted, hogy elérhető-e rendszerfrissítés. Ha elérhető frissítés, telepítheted azt.\n\nA telepítés megkezdéséhez érintsd meg a \"Letöltés\" gombot (a frissítés leírása alatt) a letöltés megkezdéséhez. Amikor a letöltés befejeződött, megjelenik a telepítési képernyő. Ha elhagytad az alkalmazást, vagy a képernyő nem jelenik meg, koppints a \"Telepítés\" gombra, amely a \"Letöltés\" gomb mellett látható.\n\nA telepítő először ellenőrzi, hogy rootolt-e az eszközöd. Ha rootolt eszközöd van, add meg a root engedélyt, amikor a rendszer kéri, és válaszd ki a frissítés telepítésének módját. Ellenkező esetben kövesd a Kézi telepítés utasításait.\n\nAutomatikus telepítés:\nCsak a telepítési lehetőségeket kell kiválasztanod. Az alapértelmezett beállítások ajánlottak, azzal a különbséggel, hogy meg kell adni a root csomagot, amelyet (újra) telepíteni kell. Válaszd ki a root csomagot (zip fájl) a kék mappa gombbal, és érintsd meg a \"Telepítés indítása\" gombot a telepítés megkezdéséhez.\n\nKézi telepítés:\nLátsz egy telepítési útmutatót a képernyőn. Írd le az utasításokat, és hajtsd végre azokat a frissítés telepítéséhez szükséges módon.</string>
-	<string name="help_reading_news_title">A legújabb hírek elolvasása</string>
-	<string name="help_reading_news_text">A hírek a Frissítés képernyőtől balra jelennek meg. A legújabb elemek a tetején jelennek meg. Csak érints meg egy elemet az elolvasáshoz.\nNyomj a vissza nyílra vagy nyomd meg a vissza gombot, hogy visszatérj a hírek képernyőjére.</string>
-	<string name="help_device_information_title">Eszközinformációk megtekintése</string>
-	<string name="help_device_information_text">A készülék néhány specifikációját a Frissítés képernyőtől jobbra található képernyő segítségével tekintheted meg. Ez hasznos lehet egy támogatási kérelem benyújtásakor, amely során esetleg kérhetik a készüléked egyes műszaki adatait.</string>
-	<string name="help_change_settings_title">Beállítások módosítása</string>
-	<string name="help_change_settings_text">A beállításokat módosíthatod a jobb felső sarokban lévő három pont megérintésével, majd a Beállítások megérintésével.\nA következő beállításokat módosíthatod:\n\n• Eszköz és frissítési módszer\n• Push értesítések\n• Alkalmazáson belüli értesítések\n• Adatvédelmi beállítások (naplófeltöltés).\n\nA kapcsolókkal kapcsolhatod ki és be az értesítési / adatvédelmi beállításokat. Válasssz egy eszközt és / vagy frissítési módszert a kapcsolók felett látható legördülő menük segítségével. A legördülő menük nem láthatók? Ellenőrizd az internetkapcsolatod, és nyisd meg újra a Beállítások képernyőt.</string>
-
 	<!-- News strings -->
 	<string name="news">Hírek</string>
-	<string name="news_date_published">Utolsó frissítés: %1$s</string>
-	<string name="news_empty">Ennek a cikknek nincs tartalma.</string>
-	<string name="news_load_network_error">A cikk megnyitása nem sikerült. Ellenőrizze a kapcsolatot, és nyomja meg az \"ÚJRA\" gombot a cikk megnyitásához.</string>
-	<string name="news_load_id_error"><![CDATA[Nem sikerült megnyitni a cikket érvénytelen URL-ről: %1$s. Ellenőrizd az URL-t, vagy jelentsd nekünk ezt <a href="mailto:support@oxygenupdater.com">emailen</a> vagy a <a href="https://discord.gg/5TXdhKJ">Discord szerverünkön</a>.]]></string>
+	<string name="news_load_network_error">A cikk megnyitása nem sikerült. Ellenőrizze a kapcsolatot, és nyomja meg az \"Újra\" gombot a cikk megnyitásához.</string>
 	<string name="news_unread_count_1">%1$d olvasatlan híred van. Érints meg a megtekintésükhöz.</string>
 	<string name="news_unread_count_2">%1$d olvasatlan híred van. Érints meg az összes megtekintéséhez.</string>
 	<string name="news_mark_read">Jelöld olvasottként</string>
@@ -299,12 +250,10 @@ Instrukciók:
 	<string name="error_app_outdated">Jajj ne!</string>
 	<string name="error_app_outdated_message">Az alkalmazás e verziója elavult. Ideje frissíteni! Érintsd meg az alábbi \"Google Play\" lehetőséget. A Google Playen belül érintsd meg a \"Frissítés\" elemet.</string>
 	<string name="error_app_requires_network_connection">Nincs kapcsolat</string>
-	<string name="error_app_requires_network_connection_message">Nem sikerült kapcsolódni a szerverhez. Kérjük, ellenőrizd, hogy működőképes-e a kapcsolat. Az alkalmazás bezárul.</string>
 	<string name="error_google_play_button_text">Google Play</string>
-	<string name="error_no_internet_connection">Nincs kapcsolat.</string>
 	<string name="error_maintenance">Szerver karbantartás</string>
 	<string name="error_maintenance_message">Kérlek várj. A szerver hamarosan elérhető lesz.</string>
-	<string name="error_maintenance_retry">Lehetséges, hogy a szerver nem működik karbantartás miatt. Próbáld újra egy idő után, vagy jelentsd nekünk <a href="mailto:support@oxygenupdater.com">emailen</a> vagy a <a href="https://discord.gg/5TXdhKJ">Discord szerverünkön</a>.</string>
+	<string name="error_maintenance_retry"><![CDATA[Lehetséges, hogy a szerver nem működik karbantartás miatt. Próbáld újra egy idő után, vagy jelentsd nekünk <a href="mailto:support@oxygenupdater.com">emailen</a> vagy a <a href="https://discord.gg/5TXdhKJ">Discord szerverünkön</a>.]]></string>
 	<string name="error_reload">Újratöltés</string>
 
 	<string name="error_unable_to_rate_app">Nem tudod értékelni az alkalmazást, mert a Google Play Áruház hiányzik az eszközödről.</string>
@@ -329,7 +278,6 @@ Instrukciók:
 	<string name="purchase_error_after_payment">A hirdetésmentes verzió megvásárlása sikertelen, mert belső hiba történt. Kérjük, próbáld újra néhány perc múlva. Ha már fizettél, vedd fel a kapcsolatot a Google Play ügyfélszolgálatával.</string>
 
 	<!-- Other strings-->
-	<string name="error">Hiba</string>
 	<string name="icon">Ikon</string>
 	<string name="loading">Betöltés…</string>
 	<string name="processing">Feldolgozás…</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools" tools:keep="@string/install_guide_page_*_*">
-
-	<string name="device_chooser_error_title">Errore nel recuperare la lista dei dispositivi supportati.</string>
-
+<resources>
 	<!-- Update information strings -->
 	<string name="enable">Attiva</string>
 	<string name="update_information_file_name">"Nome file: %1$s"</string>
@@ -13,11 +10,10 @@
 	<string name="update_information_banner_server">Premi qui per i messaggi importanti</string>
 	<string name="update_information_banner_advanced_mode_tip">Hai selezionato il canale di aggiornamenti \"%1$s\". Abilita la modalità avanzata se vuoi passare a questo canale di aggiornamenti.</string>
 	<string name="update_information_header_advanced_mode_hint">La modalità avanzata è abilitata</string>
-	<string name="update_information_header_advanced_mode_helper">Grazie alla modalità avanzata, puoi scaricare l\'ultima ZIP per \"%1$s\".\n\nPuoi disattivare la modalità avanzata nelle impostazioni.</string>
-	<string name="update_information_different_version_changelog_notice">Stai visualizzando il changelog dell\'ultimo aggiornamento sulla traccia \"%1$s\". Se intendi installare questo aggiornamento, devi abilitare la modalità avanzata (impostazioni).\n\nPer visualizzare il changelog attuale devi scegliere la modalità di aggiornamento corretta.</string>
-	<string name="update_information_last_checked_on">"Ultima verifica: %1$s"</string>
+	<string name="update_information_header_advanced_mode_helper">Grazie alla modalità avanzata, puoi scaricare l\'ultima ZIP per \"%1$s\". Puoi disattivare la modalità avanzata nelle impostazioni.</string>
+	<string name="update_information_different_version_changelog_notice_base">Nota: questo changelog riguarda l\'ultima versione disponibile (%1$s) nel metodo di aggiornamento \"%2$s\"</string>
+	<string name="update_information_different_version_changelog_notice_advanced">. Se si intende installare questo aggiornamento, è necessario attivare la modalità avanzata nelle impostazioni.</string>
 	<string name="update_information_no_update_data_available">"Non è disponibile alcuna informazione sull'aggiornamento."</string>
-	<string name="update_information_oxygen_os_version">"OxygenOS %1$s"</string>
 	<string name="update_information_system_is_up_to_date">"Il tuo sistema è aggiornato."</string>
 	<string name="update_information_unknown_update_name">"Aggiornamento sconosciuto per %1$s"</string>
 	<string name="update_information_view_update_information">"Vedi info aggiornamento"</string>
@@ -42,7 +38,7 @@
 	<string name="download_complete">"Download completato"</string>
 	<string name="download_complete_notification">"Premi su start per iniziare l'installazione"</string>
 	<string name="download_error">"Errore nel download"</string>
-	<string name="download_error_close">"CHIUDI"</string>
+	<string name="download_error_close">"Chiudi"</string>
 	<string name="download_error_corrupt">"Il file scaricato è danneggiato! Riprova."</string>
 
 	<string name="download_error_internal">"Errore interno."</string>
@@ -51,8 +47,8 @@
 Se desideri saperne di più, non esitare a contattarci tramite <a href="mailto:support@oxygenupdater.com">email</a> o sul nostro <a href="https://discord.gg/5TXdhKJ">server Discord</a>.]]></string>
 	<string name="download_error_could_not_move_temp_file">Il file è stato scaricato ma non è stato possibile spostarlo. Apri un file manager, naviga a \"%1$s\" e sposta il file nella cartella più\' in alto di internal storage.</string>
 	<string name="download_error_server">"Errore nel server."</string>
-	<string name="download_error_retry">"RIPROVA"</string>
-	<string name="download_error_resume">"RIPRENDI"</string>
+	<string name="download_error_retry">"Riprova"</string>
+	<string name="download_error_resume">"Riprendi"</string>
 	<string name="download_error_storage">"Spazio insufficiente. Liberane un po' e ritenta."</string>
 	<string name="download_failed">"Download fallito"</string>
 	<string name="download_pending">"Il tuo download inizierà subito…"</string>
@@ -87,9 +83,7 @@ Se desideri saperne di più, non esitare a contattarci tramite <a href="mailto:s
 	<string name="summary_off">Disattivato</string>
 	<string name="summary_please_wait">Attendi…</string>
 	<string name="summary_update_method">Seleziona un dispositivo</string>
-	<string name="summary_important_notifications_disabled">Alcune notifiche importanti sono disattivate: \"%1$s\"</string>
-	<string name="summary_theme">Scegli il tema</string>
-	<string name="summary_language">Imposta la lingua</string>
+	<string name="summary_important_notifications_disabled">Alcune notifiche importanti sono disattivate:</string>
 	<string name="summary_privacy_policy">Visualizza online</string>
 	<string name="summary_rate_app">Rilascia una recensione da 5 stelle</string>
 
@@ -111,7 +105,7 @@ Se desideri saperne di più, non esitare a contattarci tramite <a href="mailto:s
 	<string name="theme_additional_note">Nel caso il risparmio energetico fosse attivo, il tema dark sarà utilizzato per conservare la batteria.</string>
 
 	<string name="settings">"Impostazioni"</string>
-	<string name="settings_buy_button_buy">"Acquista(%1$s)"</string>
+	<string name="settings_buy_button_buy">"Acquista (%1$s)"</string>
 	<string name="settings_buy_button_bought">"Acquistato"</string>
 	<string name="settings_buy_button_not_possible">"Non disponibile"</string>
 	<string name="settings_buy_ad_free_label">"Passa a senza annunci"</string>
@@ -120,115 +114,49 @@ Se desideri saperne di più, non esitare a contattarci tramite <a href="mailto:s
 
 	<string name="settings_device">"Dispositivo"</string>
 	<string name="settings_entered_incorrectly">"Errore nel salvare le impostazioni. Seleziona il tuo dispositivo / il modo d'aggiornamento e ritenta."</string>
-	<string name="settings_explanation_incremental_full_update">"Un aggiornamento incrementale può essere installatato da qualsiasi versione, eccetto nel caso di bootloader sbloccato, nel quale sei consigliato ad usare l'update intero. Per attivarlo basta attivare la modalità avanzata nelle impostazioni.
-
-Un aggiornamento completo può essere installato sempre - indipendentemente dalla versione attuale presente sul tuo dispositivo.
-
-Un aggiornamento beta può essere installato solo se ti trovi già' sul branch delle beta."</string>
 	<string name="settings_push_from_server">"È disponibile un messaggio critico"</string>
 	<string name="settings_saving">"Le tue impostazioni si stanno ancora salvando. Se questo impiega troppo tempo controlla la tua connessione, riavvia l'applicazione e ritenta."</string>
 	<string name="settings_advanced_mode">"Modalità avanzata"</string>
-	<string name="settings_advanced_mode_explanation">"La modalità avanzata nasconde il messaggio \"Il tuo sistema è aggiornato\", consentendo l'installazione di qualsiasi aggiornamento, anche se non compatibili con il tuo dispositivo.
+	<string name="settings_advanced_mode_explanation">"Normalmente, l'applicazione mostra gli aggiornamenti in base alla versione corrente del sistema operativo. Con la modalità avanzata, verrà sempre mostrato l'ultimo aggiornamento disponibile, indipendentemente dalla compatibilità tra dispositivo e versione.
 
-Questo può essere utile quando:
-- Aggiorni da un branch regolare a una beta;
-- Ritorni a un branch regolare da una beta (Non ti dimenticare di effetuare il factory reset)
-- Reinstallare la versione attuale del tuo sistema."</string>
+Questo può essere utile se si desidera:"</string>
+	<string name="settings_advanced_mode_uses">"&#8226; Riscaricare l'ultima versione anche se è già disponibile
+&#8226; Passare a una traccia di aggiornamento diversa"</string>
+	<string name="settings_advanced_mode_caption">"La modalità avanzata può essere necessaria solo nelle situazioni sopra descritte. Non è consigliabile attivarla se non si sa cosa si sta facendo."</string>
 	<string name="settings_update_method">"Metodo d'aggiornamento"</string>
 	<string name="settings_upload_logs">Condividi uso e logs.</string>
+	<string name="settings_ad_privacy">Consenso agli annunci GDPR</string>
+	<string name="settings_ad_privacy_subtitle">"Per gli utenti nel SEE/UK"</string>
 
 	<!-- FAQ strings -->
 	<string name="faq">"FAQ"</string>
 	<string name="faq_menu_item">"FAQ"</string>
 
 	<!-- First-time setup strings -->
-	<string name="onboarding">"Benvenuto"</string>
+	<string name="onboarding">"Configurazione"</string>
 	<string name="onboarding_finished_button">"Avvia app"</string>
-	<string name="onboarding_page_1_title">"Benvenuto su Oxygen Updater!"</string>
-	<string name="onboarding_page_1_text">"Questa app ti permetterà di:
+	<string name="onboarding_app_uses">"Questa app ti permetterà di:
 
--Avere accesso più veloce agli ultimi aggiornamenti di Android per il tuo dispositivo OnePlus con OxygenOS
-
--Facilmente aggiornare un dispositivo rootato
-
--Visualizzare le notivate in aggiornamenti
-
--Leggere le novità su OnePlus e OxygenOS
-
-Trascina verso sinistra per continuare."</string>
-	<string name="onboarding_page_1_caption">"Questa non è un applicazione ufficiale. L'uso di questa app è completamente a rischio proprio. Né OnePlus né lo sviluppatore dell'app sono responsabili delle tue azioni, incluso qualsiasi danno causato dall'uso inappropriato di questa app.
-
-Usando l'app consenti ai termini e condizioni citati sopra.
-
-Trascina verso sinistra per continuare."</string>
-	<string name="onboarding_page_2_title">"Seleziona il tuo dispositivo:"</string>
-	<string name="onboarding_page_2_caption">"Il tuo dovrebbe già essere selezionato, se non lo è, selezionalo sopra.
-
-Trascina verso sinistra per continuare"</string>
-	<string name="onboarding_page_3_title">"Seleziona il tuo metodo d'aggiornamento."</string>
-	<string name="onboarding_page_3_caption">"Di solito, l'aggiornamento progressivo è la scelta corretta, perché offre download molto più facili e piccoli.
-
-Però, non completamente comnpatibili con dispositivi rootati. Se hai un dispositivo con root, seleziona l'aggiornamento completo.
-
-Se hai una versione beta, seleziona una delle opzioni Open Beta.
-
-Trascina verso sinistra per continuare."</string>
-	<string name="onboarding_page_4_title">"Sei pronto per continuare!"</string>
-	<string name="onboarding_page_4_text">"Goditi l'app!
-
-Puoi cambiare le tue impostazioni in qualsiasi momento. Puoi farlo cliccando i tre puntini in alto a destra e selezionando \"Impostazioni\"."</string>
+&#8226; Avere accesso più veloce agli ultimi aggiornamenti di Android per il tuo dispositivo OnePlus con OxygenOS
+&#8226; Facilmente aggiornare un dispositivo rootato
+&#8226; Visualizzare le notivate in aggiornamenti
+&#8226; Leggere le novità su OnePlus e OxygenOS"</string>
+	<string name="onboarding_disclaimer">"Questa non è un applicazione ufficiale. L'uso di questa app è completamente a rischio proprio. Né OnePlus né lo sviluppatore dell'app sono responsabili delle tue azioni, incluso qualsiasi danno causato dall'uso inappropriato di questa app. Usando l'app consenti ai termini e condizioni citati sopra."</string>
+	<string name="onboarding_device_chooser_title">"Seleziona il tuo dispositivo:"</string>
+	<string name="onboarding_device_chooser_caption">"Il tuo dovrebbe già essere selezionato, se non lo è, selezionalo sopra."</string>
+	<string name="onboarding_method_chooser_title">"Seleziona il tuo metodo d'aggiornamento."</string>
+	<string name="onboarding_method_chooser_caption">"Di solito, l'aggiornamento progressivo è la scelta corretta, perché offre download molto più facili e piccoli. Però, non completamente comnpatibili con dispositivi rootati. Se hai un dispositivo con root, seleziona l'aggiornamento completo. Se hai una versione beta, seleziona una delle opzioni Open Beta."</string>
+	<string name="onboarding_caption">"Goditi l'app! Puoi cambiare le tue impostazioni in qualsiasi momento."</string>
 
 	<!-- Automatic install strings -->
 	<string name="install">"Installa"</string>
 
 	<!-- Install guide strings -->
-	<string name="install_guide_no_root">"Installa secondo le istruzioni mostrate nella guida."</string>
 	<string name="install_guide">"Guida d'installazione"</string>
-	<string name="install_guide_subtitle">"Guida - %1$d of %2$d"</string>
-	<string name="install_guide_tip">"&#8226; È consigliato scriversi tutti i passaggi, giacché è necessario spegnere il dispositivo durante l'installazione."</string>
-	<string name="install_guide_page_1_title">"Scarica l'aggiornamento."</string>
-	<string name="install_guide_page_1_text">"&#8226; Premi il bottone Download per iniziare a scaricare.
-
-- Il progresso apparirà nell'app e come notifica.
-
-- Al termine del download, riceverai una notifica con il testo \"Download completato\".
+	<string name="install_guide_download_instructions">"&#8226; Premi il bottone Download per iniziare a scaricare.
+&#8226; Il progresso apparirà nell'app e come notifica.
+&#8226; Al termine del download, riceverai una notifica con il testo \"Download completato\".
 Se è stato riscontrato un errore, apri l'app e ritenta il download. Assicurati di avere una connessione internet funzionante."</string>
-
-	<string name="install_guide_page_2_title">"Preparati per l'installazione"</string>
-	<string name="install_guide_page_2_text">"Nota: l\'installazione dell\'aggiornamento avviene da una pagina speciale della sezione Aggiornamenti di sistema standard del dispositivo. Se, per qualche motivo, viene visualizzato un aggiornamento di sistema all\'apertura di questa sezione, puoi anche scegliere di installarlo prima. Successivamente, apri nuovamente Oxygen Updater per vedere se sei completamente aggiornato.
-
-Istruzioni:
-&#8226; Chiudi Oxygen Updater premendo il pulsante home.
-
-&#8226; Apri l\'app Impostazioni. Dovrebbe trovarsi nell\'app drawer.
-
-&#8226; Scorri verso il basso fino a visualizzare Aggiornamenti di sistema. Selezionalo."</string>
-
-	<string name="install_guide_page_3_title">"Installa l'aggiornamento"</string>
-	<string name="install_guide_page_3_text">"Ora che sei nell'app Aggiornamenti di sistema, è il momento di installare l'aggiornamento.
-
-&#8226; Nella sezione Aggiornamenti di sistema, tocca l'icona a forma di ingranaggio in alto a destra
-
-&#8226; Ora seleziona \"Aggiornamento locale\". Dovrebbe apparire una schermata di selezione dei file.
-
-&#8226; In questa schermata, seleziona il file di aggiornamento che hai scaricato utilizzando Oxygen Updater. Il suo nome dovrebbe iniziare con \"%1$sOxygen\".
-
-&#8226; Premi \"Aggiorna ora\". L'installazione dovrebbe iniziare automaticamente."</string>
-
-	<string name="install_guide_page_4_title">"Attendi il completamento dell'installazione"</string>
-	<string name="install_guide_page_4_text">"&#8226; Il telefono installerà ora l'aggiornamento e visualizzerà una barra di avanzamento. Attendi fino al termine dell'installazione. L'installazione può richiedere da pochi minuti a 15 minuti.
-
-&#8226; Successivamente, il telefono verrà riavviato per completare l'aggiornamento."</string>
-
-	<string name="install_guide_page_5_title">"Fine. Buon divertimento!"</string>
-	<string name="install_guide_page_5_text"><![CDATA["- Dopo l'ottimizzazione delle app, l'aggiornamento è stato installato.
-Per verificare, controlla la versione attuale del tuo sistema:
-
-- Impostazioni —> Info Telefono \"Versione OxygenOS\".
-
-- Se ti piace l'app, lascia 5 stelle!"]]></string>
-	<string name="install_guide_close_button">"Chiudi guida"</string>
-
 	<!-- Device information strings -->
 	<string name="device_information_supported_oxygen_os">Il tuo dispositivo è supportato.</string>
 	<string name="device_information_carrier_exclusive_oxygen_os">Dispositivo non supportato, in quanto esclusivo col gestore.</string>
@@ -244,7 +172,7 @@ Per verificare, controlla la versione attuale del tuo sistema:
 	<string name="device_information_image_description">"Immagine Dispositivo"</string>
 	<string name="device_information_incremental_os_version">"Versone di sistema incrementale:"</string>
 	<string name="device_information_os_version">"Versione Android"</string>
-	<string name="device_information_oxygen_os_version">"Versione OxygenOS:"</string>
+	<string name="device_information_oxygen_os_version">"Versione OS:"</string>
 	<string name="device_information_oxygen_os_ota_version">"Versione OTA:"</string>
 	<string name="device_information_patch_level_version">"Data security patch:"</string>
 	<string name="device_information_serial_number">"Numero seriale:"</string>
@@ -254,15 +182,17 @@ Per verificare, controlla la versione attuale del tuo sistema:
 	<!-- About screen strings -->
 	<string name="about">"Info app"</string>
 	<string name="about_description">Questa app scarica gli aggiornamenti ufficiali direttamente dai server di OnePlus e verifica anche l\'integrità dello ZIP scaricato prima di consentirti l\'installazione. In questo modo, l\'applicazione consente di saltare la coda di rollout e installare gli aggiornamenti ufficiali il prima possibile. Se riscontri bug nel SO, segnalali direttamente a OnePlus: <a href="https://forums.oneplus.com/feedback">https://forums.oneplus.com/feedback</a>. Potresti voler unirti al nostro <a href="https://discord.gg/5TXdhKJ">server Discord</a>, in modo da poter parlare con altri utenti degli ultimi aggiornamenti. Altrimenti, non esitare a inviarci un\'e-mail all\'indirizzo <a href="mailto:support@oxygenupdater.com">support@oxygenupdater.com</a> con i tuoi suggerimenti/feedback.</string>
-	<string name="about_support">Se desideri sostenerci, puoi acquistare lo sblocco Ad-free (impostazioni dell\'app), o consultare la nostra <a href="https://patreon.com/oxygenupdater">pagina Patreon</a>.</string>
+	<string name="about_support">Se desideri sostenerci, puoi acquistare lo sblocco ad-free (impostazioni dell\'app), o consultare la nostra <a href="https://patreon.com/oxygenupdater">pagina Patreon</a>.</string>
 	<string name="about_background_story_header">Storia di fondo</string>
-	<string name="about_background_story">Questa app è stata originariamente sviluppata da Arjan Vlek come supplemento di un\'altra app, chiamata <a href="https://cyanogenupdatetracker.com/">Cyanogen Update Tracker</a>\n\nDopo 4 anni, Luglio 2019, Arjan decise di abbandonare entrambi i suoi progetti e affidarli ad una squadra di sviluppatori da diverse nazioni. Presero la responsabilità di fornire la community con un servizio eccellente &amp; per fornire aggiornamenti OnePlus in modo veloce. \nUlteriori informazioni sull\'<a href="https://oxygenupdater.com/article/81/">annuncio</a>.\n\nIl 14 Agosto 2018 segnò il primo rilascio sotto nuove direttive, che portò un sacco di novità come dark mode e un redesign completo. \n\nPer ulteriori informazioni sul team, visualizza <a href="https://oxygenupdater.com/team/">il sito</a>.</string>
-	<string name="about_third_party_app_notice">Questa non è un\'applicazione ufficiale. \nIl nome OnePlus, il logo OnePlus e OxygenOS sono proprietà di OnePlus\nAndroid, Google, Google Play e il logo Google Play sono marchi registrati di Google Inc.\nQuesta app utilizza dati di OnePlus e l\'azienda genitore Oppo per visualizzare alcune informazioni.</string>
+	<string name="about_background_story">Questa app è stata originariamente sviluppata da Arjan Vlek come supplemento di un\'altra app, chiamata <a href="https://cyanogenupdatetracker.com/">Cyanogen Update Tracker</a>\n\nDopo 4 anni, Luglio 2019, Arjan decise di abbandonare entrambi i suoi progetti e affidarli ad una squadra di sviluppatori da diverse nazioni. Presero la responsabilità di fornire la community con un servizio eccellente &amp; per fornire aggiornamenti OnePlus in modo veloce.\nUlteriori informazioni sull\'<a href="https://oxygenupdater.com/article/81/">annuncio</a>.\n\nIl 14 Agosto 2018 segnò il primo rilascio sotto nuove direttive, che portò un sacco di novità come dark mode e un redesign completo.\n\nPer ulteriori informazioni sul team, visualizza <a href="https://oxygenupdater.com/team/">il sito</a>.</string>
+	<string name="about_third_party_app_notice">Questa non è un\'applicazione ufficiale.\nIl nome OnePlus, il logo OnePlus e OxygenOS sono proprietà di OnePlus\nAndroid, Google, Google Play e il logo Google Play sono marchi registrati di Google Inc.\nQuesta app utilizza dati di OnePlus e l\'azienda genitore Oppo per visualizzare alcune informazioni.</string>
 	<string name="about_rate_button_text">"Vota"</string>
 	<string name="about_website_button_text">Web</string>
 	<string name="about_email_button_text">Email</string>
 
 	<!-- LocalNotifications strings -->
+	<string name="notification_permission_title">"Rimani informato"</string>
+	<string name="notification_permission_text">"Consentite all'app di notificarvi gli aggiornamenti OTA, le novità, lo stato dei download in corso e altre cose importanti. È possibile regolare le proprie preferenze in un secondo momento nelle impostazioni dell'app."</string>
 	<string name="notification_new_device_text">"Il %1$s è ora supportato. Apri l'app o scegli il dispositivo."</string>
 	<string name="notification_no_notification_support">"Installa o aggiorna i servizi Google Play per abilitare le notifiche push."</string>
 	<string name="notification_version">"%1$s è ora disponibile per %2$s!"</string>
@@ -288,42 +218,9 @@ Per verificare, controlla la versione attuale del tuo sistema:
 	<string name="general_notification_channel_description">Notifiche generali che non fanno parte di altre categorie</string>
 	<string name="url_submitted_notification_channel_description">Riceverete una notifica quando avrete inviato con successo gli URL OTA al nostro team.\nÈ possibile disattivare l\'invio automatico degli URL nelle impostazioni dell\'applicazione.</string>
 
-	<!-- Help strings -->
-	<string name="help">"Aiuto"</string>
-	<string name="help_updating_your_device_title">"Aggiornando il tuo dispositivo"</string>
-	<string name="help_updating_your_device_text">"Quando apri l'app, potrai vedere se è disponibile un aggiornamento. Se lo è, puoi installarlo.
-
-Per avviare l'installazione, premi \"Download\". Al completamento del download, la schermata d'installazione si aprirà. Se hai chiuso l'app, premi su \"Installa\" che è ora visibile accanto al bottone \"Download\".
-
-La schermata d'installazione verificherà prima se hai un dispositivo con root. Se si', autorizza l'app quando richiesto e scegli come installare l'aggiornamento. Altrimenti, segui le istruzioni per l'installazione manuale.
-
-Installazione Automatica:
-Devi soltanto scegliere le opzioni d'installazione. Quelle predefinite sono consigliate, eccetto l'impostazione per il pacchetto root nel caso volessi mantenerlo, che va selezionato. Seleziona il paccheto (file zip) usando il bottone blu e premendo su \"Avvia Installazione\" per avviare la installazione.
-
-
-Installazione Manuale:
-Ti verrà mostrata una guida sul tuo schermo. È consigliato scriversi i passi necessari ed effettuarli come scritti per installare l'aggiornamento."</string>
-	<string name="help_reading_news_title">"Leggendo le ultime novità"</string>
-	<string name="help_reading_news_text">"Le novità sono a sinistra della schermata info aggiornamenti. Il più recente è mostrato in alto. Premi su uno di questi per leggerlo."</string>
-	<string name="help_device_information_title">"Visualizzando info dispositivo"</string>
-	<string name="help_device_information_text">"Puoi visualizzare alcune specifiche del tuo dispositivo usando la schermata alla destre di quella di info aggiornamenti. Questo può tornare utile durante un ticket di support, nei quali potresti essere interpellato su alcune specifiche."</string>
-	<string name="help_change_settings_title">"Cambiando impostazioni"</string>
-	<string name="help_change_settings_text">"Puoi cambiare le impostazioni premendo sui 3 puntini in alto a destra seguito dall'opzione Impostazioni.
-Puoi cambiare le seguenti impostazioni:
-
-• Dispositivo e modalità d'aggiornamento
-• Notifiche push
-• Notifiche in-app
-• Impostazioni privacy.
-
-Non riesci a visualizzare le opzioni per i dispositivo e i metodi d'aggiornamento? Verifica di avere una connessione ad internet e riprova."</string>
-
 	<!-- News strings -->
 	<string name="news">"Novità"</string>
-	<string name="news_date_published">"Ultimo aggiornamento: %1$s"</string>
-	<string name="news_empty">"Questo articolo non ha commenti."</string>
 	<string name="news_load_network_error">"Errore nell'aprire l'articolo. Controlla la tua connesisone e ritenta."</string>
-	<string name="news_load_id_error"><![CDATA[Impossibile aprire l\'articolo da un URL non valido:: %1$s. Controlla l\'URL o segnalacelo tramite <a href="mailto:support@oxygenupdater.com">email</a> o sul nostro <a href="https://discord.gg/5TXdhKJ">server Discord</a>.]]></string>
 	<string name="news_unread_count_1">Hai %1$d articoli non letti. Premi qui per visualizzarli.</string>
 	<string name="news_unread_count_2">Hai %1$d articoli non letti. Premi per mostrare tutti gli articoli.</string>
 	<string name="news_mark_read">Segna come letto</string>
@@ -348,11 +245,9 @@ Non riesci a visualizzare le opzioni per i dispositivo e i metodi d'aggiornament
 	<string name="error_app_outdated">"Oh no!"</string>
 	<string name="error_app_outdated_message">"Questa versione è obsoleta. Aggiorna!"</string>
 	<string name="error_app_requires_network_connection">"Nessuna connessione"</string>
-	<string name="error_app_requires_network_connection_message">"Errore nel connettere al server. Assicurati di avere una connessione stabile. L'app terminerà ora."</string>
-	<string name="error_no_internet_connection">"Nessuna connesione."</string>
 	<string name="error_maintenance">"Manutenzione"</string>
 	<string name="error_maintenance_message">"Attendi. Il server tornerà disponibile presto."</string>
-	<string name="error_maintenance_retry">Il server potrebbe essere sotto manutenzione. Riprova più tardi o facci sapere tramite <a href="mailto:support@oxygenupdater.com">email</a> o sul nostro <a href="https://discord.gg/5TXdhKJ">Discord</a>.</string>
+	<string name="error_maintenance_retry"><![CDATA[Il server potrebbe essere sotto manutenzione. Riprova più tardi o facci sapere tramite <a href="mailto:support@oxygenupdater.com">email</a> o sul nostro <a href="https://discord.gg/5TXdhKJ">Discord</a>.]]></string>
 	<string name="error_reload">"Ricarica"</string>
 	<string name="error_unable_to_rate_app">"Non puoi valutare l'app perché Google Play Store non è presente sul dispositivo."</string>
 
@@ -378,7 +273,6 @@ Altri dispositivi della OnePlus su custom ROM, non sono supportati."</string>
 	<string name="purchase_error_after_payment">"Il pagamento non è andato a buon fine a causa di un errore interno. Ritenta in alcuni minuti. Se hai già pagato, contatta Google Play Support per assistenza."</string>
 
 	<!-- Other strings -->
-	<string name="error">Errore</string>
 	<string name="icon">"Icona"</string>
 	<string name="loading">"Caricando…"</string>
 	<string name="processing">"Processando…"</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="device_chooser_error_title">לא ניתן להשיג רשימה של המכשירים הנתמכים</string>
-
 	<!-- Update information strings-->
 	<string name="enable">הפעל</string>
 	<string name="update_information_description_not_available">עדכון זה אינו מציג מידע רשמי עבור תכונות חדשות. לרוב, עדכונים אלו מציגים תיקוני באגים, שיפורי ביצועים ו/או עדכוני אבטחה קריטיים למכשיר שלך</string>
@@ -14,10 +12,9 @@
 	<string name="update_information_banner_advanced_mode_tip">את/ה בחרת את מסלול \"%1$s\" הפעל מצב מתקדם אם ברצונך לקבל עדכון ממסלול זה.</string>
 	<string name="update_information_header_advanced_mode_hint">מצב מתקדם מופעל</string>
 	<string name="update_information_header_advanced_mode_helper">בחרת במסלול \"%1$s\" הפעל מצב מתקדם אם ברצונך לקבל עדכון ממסלול זה.</string>
-	<string name="update_information_different_version_changelog_notice">הינך צופה ביומן השינויים עבור הגרסה האחרונה בשיטת \"%1$s\". אם ברצונך להתקין עדכון זה, עלייך להדליק מצב מתקדם (בהגדרות). אך אם ברצונך לצפות ביומן השינויים עבור הגרסה הנוכחית, חזור אל השיטה בה המכשיר כעת.</string>
-	<string name="update_information_last_checked_on">נבדק בפעם האחרונה %1$s</string>
+	<string name="update_information_different_version_changelog_notice_base">הערה: יומן שינויים זה מיועד לגרסה האחרונה הזמינה (%1$s) בשיטת העדכון \"%2$s\"</string>
+	<string name="update_information_different_version_changelog_notice_advanced">. אם בכוונתך להתקין עדכון זה, עליך להפעיל את \"מצב מתקדם\" בהגדרות.</string>
 	<string name="update_information_no_update_data_available">אין מידע זמין עבור עדכון זה</string>
-	<string name="update_information_oxygen_os_version">OxygenOS %1$s</string>
 	<string name="update_information_system_is_up_to_date">המערכת שלך מעודכנת</string>
 	<string name="update_information_unknown_update_name">שם חסר עדכון עבור: %1$s</string>
 	<string name="update_information_view_update_information">צפה במידע על העדכון</string>
@@ -90,9 +87,7 @@
 	<string name="summary_please_wait">אנא המתן…</string>
 	<string name="summary_update_method">אנא בחר ראשית מכשיר</string>
 	<!-- TODO: check the following translation -->
-	<string name="summary_important_notifications_disabled">כמה התראות חשובות מושבתות: \"%1$s\"</string>
-	<string name="summary_theme">בחר עיצוב</string>
-	<string name="summary_language">בחר שפה</string>
+	<string name="summary_important_notifications_disabled">כמה התראות חשובות מושבתות:</string>
 	<string name="summary_privacy_policy">צפה בדפדפן</string>
 	<string name="summary_rate_app">השאר דירוג 5 כוכבים</string>
 
@@ -124,78 +119,45 @@
 
 	<string name="settings_device">מכשיר</string>
 	<string name="settings_entered_incorrectly">שגיאה בשמירת ההגדרות. אנא חזור אחורה ובחר את המכשיר/ שיטת העדכון שנית</string>
-	<string name="settings_explanation_incremental_full_update">עדכון מצטבר יכול להיות מותקן בכל מקרה (חוץ ממקרה בו פתחת את ה-bootloader, אז עליך לקחת את שיטת העדכון המלא). \n\n עדכון בטא של OxygenOS יכול תמיד להיות מותקן גם על גרסת בטא וגם על גרסה יציבה. כדי להחליף מגרסה יציבה לגרסת בטא, עליך להפעיל את מצב מתקדם בהגדרות. שיטות העדכונים: Beta, Full, Incremental.</string>
 	<string name="settings_push_from_server">הודעות ואזהרות - כללי</string>
 
 	<string name="settings_saving">ההגדרות שלך עדיין בתהליך שמירה. אם תהליך זה לוקח זמן רב מדי, אנא בדוק את חיבור הרשת שלך, ונסה לסגור את האפליקציה ולהפעילה מחדש.</string>
 
 	<string name="settings_advanced_mode">מצב מתקדם</string>
-	<string name="settings_advanced_mode_explanation">מצב מתקדם מסתיר את ההודעה \"המערכת שלך מעודכנת\", ומאפשר לך להוריד ולהתקין את כל העדכונים, בעוד שהם לא בהכרח תואמים למכשיר שלך. \n\nדבר זה שימושי כאשר: \n&#8226; מעדכנים מגרסה יציבה לגרסת בטא\n&#8226; שחזור מגרסת בטא לגרסה יציבה (לא לשכוח לבצע שחזור הגדרות יצרן) \n&#8226; התקנה חדשה של גרסת המכשיר</string>
+	<string name="settings_advanced_mode_explanation">"בדרך כלל, האפליקציה מציגה לך עדכונים על סמך גרסת מערכת ההפעלה הנוכחית שלך. במצב מתקדם, העדכון האחרון הזמין תמיד יוצג ללא קשר לתאימות מכשיר/גרסה.
+
+זה יכול להיות שימושי אם אתה רוצה:"</string>
+	<string name="settings_advanced_mode_uses">"&#8226; הורד מחדש את הגרסה העדכנית ביותר גם אם אתה כבר משתמש בה
+&#8226; עבור למסלול עדכון אחר"</string>
+	<string name="settings_advanced_mode_caption">"ייתכן שיהיה צורך במצב מתקדם רק במצבים שלעיל. אתה לא צריך להפעיל את זה אלא אם כן אתה יודע מה אתה עושה."</string>
 
 	<string name="settings_update_method">שיטת עדכון</string>
 	<string name="settings_upload_logs">שתף נתוני שימוש</string>
+	<string name="settings_ad_privacy">הסכמה למודעות GDPR</string>
+	<string name="settings_ad_privacy_subtitle">"עבור משתמשי EEA/בריטניה"</string>
 
 	<!-- FAQ strings -->
 	<string name="faq">שאלות ותשובות</string>
 	<string name="faq_menu_item">שאלות ותשובות</string>
 
 	<!-- First-time onboarding strings -->
-	<string name="onboarding">ברוך הבא</string>
+	<string name="onboarding">להכין</string>
 	<string name="onboarding_finished_button">התחל אפליקציה</string>
 
-	<string name="onboarding_page_1_title">ברוך הבא ל־Oxygen Updater!</string>
-	<string name="onboarding_page_1_text">יישום זה ייאפשר לך לעשות: \n\n&#8226; לקבל גישה מהירה לעדכוני גרסת האנדרואיד האחרונה עבור מכשירי OnePlus המריצים את OxygenOS\n\n&#8226; לעדכן בקלות מכשירים עם גישת Root\n\n&#8226; לגלות מה חדש בעדכון המערכת שהינך משתמש בו \n\n&#8226; לקרוא את החדשות האחרונות על חברת OnePlus ומערכת ההפעלה OxygenOS\n\n החלק שמאלה כדי להמשיך</string>
-	<string name="onboarding_page_1_caption">אפליקציה זאת אינה אפליקציה רשמית מחברת OnePlus ואינה מתיימרת להיות אחת כזו. שימוש באפליקציה זאת היא על אחריותך בלבד. OnePlus או מפתחי האפליקציה אינם אחראים לפעולות שתעשה באפליקציה, המשמעות היא שכל נזק הנגרם עקב שימוש באפליקציה זאת על אחריותך בלבד. .\n\שימוש באפליקציה זאת משמעותה שהינך מסכים ומאשר את התנאים וההגבלות כאמור לעיל.</string>
-	<string name="onboarding_page_2_title">בחר את המכשיר שלך</string>
-	<string name="onboarding_page_2_caption">המכשיר שלך לרוב נבחר בצורה אוטומטית. אך אם לא בחר את המכשיר בצורה ידנית</string>
-	<string name="onboarding_page_3_title">בחר את שיטת העדכון</string>
-	<string name="onboarding_page_3_caption">בדרך כלל, שיטת Incremental update הוא הבחירה הנכונה, מכיוון שהוא מציע הורדה מהירה יותר, וקבצים קלי משקל לעומת שיטת ה־ Full\n\אם זאת, שיטת Incremental update איננה נתמכת במכשירים עם גישת Root. אם ברשותך מכשיר עם גישת Root, אנא בחר את שיטת Full update.\n\אם הינך מריץ גרסת בטא של מערכת ההפעלה OxygenOS, אנא בחר אחד משיטות העדכונים שמיועדים לבטא (Open Beta).</string>
-	<string name="onboarding_page_4_title">אתה מוכן!</string>
-	<string name="onboarding_page_4_text">מאחלים לך הנאה בזמן שימוש באפליקציה! \n\ברשותך תמיד האפשרות לשנות את ההגדרות שלך. כדי לגשת אל ההגדרות לחץ על גלגל השיניים בתפריט למטה.</string>
+	<string name="onboarding_app_uses">יישום זה ייאפשר לך לעשות:\n\n&#8226; לקבל גישה מהירה לעדכוני גרסת האנדרואיד האחרונה עבור מכשירי OnePlus המריצים את OxygenOS\n&#8226; לעדכן בקלות מכשירים עם גישת Root\n&#8226; לגלות מה חדש בעדכון המערכת שהינך משתמש בו\n&#8226; לקרוא את החדשות האחרונות על חברת OnePlus ומערכת ההפעלה OxygenOS</string>
+	<string name="onboarding_disclaimer">אפליקציה זאת אינה אפליקציה רשמית מחברת OnePlus ואינה מתיימרת להיות אחת כזו. שימוש באפליקציה זאת היא על אחריותך בלבד. OnePlus או מפתחי האפליקציה אינם אחראים לפעולות שתעשה באפליקציה, המשמעות היא שכל נזק הנגרם עקב שימוש באפליקציה זאת על אחריותך בלבד. שימוש באפליקציה זאת משמעותה שהינך מסכים ומאשר את התנאים וההגבלות כאמור לעיל.</string>
+	<string name="onboarding_device_chooser_title">בחר את המכשיר שלך</string>
+	<string name="onboarding_device_chooser_caption">המכשיר שלך לרוב נבחר בצורה אוטומטית. אך אם לא בחר את המכשיר בצורה ידנית</string>
+	<string name="onboarding_method_chooser_title">בחר את שיטת העדכון</string>
+	<string name="onboarding_method_chooser_caption">בדרך כלל, שיטת Incremental update הוא הבחירה הנכונה, מכיוון שהוא מציע הורדה מהירה יותר, וקבצים קלי משקל לעומת שיטת ה־ Full ם זאת, שיטת Incremental update איננה נתמכת במכשירים עם גישת Root. אם ברשותך מכשיר עם גישת Root, אנא בחר את שיטת Full update. ם הינך מריץ גרסת בטא של מערכת ההפעלה OxygenOS, אנא בחר אחד משיטות העדכונים שמיועדים לבטא (Open Beta).</string>
+	<string name="onboarding_caption">מאחלים לך הנאה בזמן שימוש באפליקציה! ברשותך תמיד האפשרות לשנות את ההגדרות שלך.</string>
 
 	<!-- Automatic install strings -->
 	<string name="install">התקן</string>
 
 	<!-- Install guide strings -->
-	<string name="install_guide_no_root">התקן את העדכון לפי ההוראות המוצגות במדריך ההתקנה.</string>
 	<string name="install_guide">מדריך התקנה</string>
-	<string name="install_guide_subtitle">מדריך התקנה - %1$d מתוך %2$d</string>
-	<string name="install_guide_tip">&#8226; מומלץ לרשום את כל השלבים מכיוון שכיבוי המכשיר הוא אחד משלבי ההדרכה של ההתקנה.</string>
-
-	<string name="install_guide_page_1_title">הורד את העדכון</string>
-	<string name="install_guide_page_1_text">לחצ/י על כפתור ההורדה כדי להתחיל בהורדת העדכון. \n\n&#8226;תהליך &#8226; ההורדה יופיע באפליקציה, וכהתראה במסך ההתראות. \n\n&#8226;כשההורדה תסתיים את/ה תראה התראה עם הטקסט \"ההורדה הושלמה\".\n אם שגיאת הורדה מופיעה, פתח/י את האפליקציה ונסה להוריד את העדכון שוב. אם זה לא עובד, וודא/י שיש לך חיבור אינטרנט יציב. אחרת צור/צרי קשר עם המפתחים של האפליקציה. את/ה יכולה לעשות זאת על ידי ביקור בחלון \"האפליקציות והמשחקים שלי\" בחנות הGoogle Play.</string>
-
-	<string name="install_guide_page_2_title">הכנות להתקנה</string>
-	<string name="install_guide_page_2_text">"הערה: התקנת העדכון מתבצעת בעמוד מיוחד בעדכוני המערכת הסטנדרטיים במכשיר שלך. אם מסיבה כלשהי מופיע עדכון מערכת בעמוד זה, באפשרותך לבחור להתקין את העדכון הזה תחילה. לאחר מכן, באפשרותך לבדוק באמצעות Oxygen Updater האם קיימים עדכוני מערכת נוספים.
-
-הוראות:
-&#8226; נא לסגור את Oxygen Updater על ידי לחיצה על כפתור הבית.
-
-&#8226; נא לפתוח את יישום ההגדרות של המכשיר. לרוב היישום מופיע במגירת האפליקציות
-
-&#8226; נא להחליק למטה עד מציאת סעיף בשם מערכת, נא לפתוח את סעיף 'מערכת' ובתוך סעיף 'מערכת' יש לפתוח את סעיף 'עדכוני מערכת'."
-</string>
-
-	<string name="install_guide_page_3_title">התקנת העדכון</string>
-	<string name="install_guide_page_3_text">"הגיע הזמן להתקין את העדכון.
-
-&#8226; בעמוד עדכוני המערכת, לחץ כעת על אייקון גלגל השיניים הנמצא בצד שמאל למעלה
-
-&#8226; כעת, בחר בסעיף \"שדרוג מקומי\". הגיע הזמן לבחור את הקובץ
-
-&#8226; בחר את קובץ העדכון שהורדת באמצעות אפליקציית Oxygen Updater. שם הקובת צפוי להתחיל עם \"%1$sOxygen\".
-
-&#8226; לחץ על \"שדרג עכשיו\". ההתקנה אמורה להתחיל באופן אוטומטי."</string>
-
-	<string name="install_guide_page_4_title">המתן עד שההתקנה תסתיים</string>
-	<string name="install_guide_page_4_text">"&#8226; מכשירך יתקין כעת את העדכון ויציג בר התקדמות. אנא היעזר בסבלנות עד שההתקנה תגיע לסופה. ההתקנה עלולה לקחת בין כמה דקות עד ל-15 דקות.
-
-&#8226; לאחר מכן, מכשירך יופעל מחדש כדי ליישם את העדכון."</string>
-
-	<string name="install_guide_page_5_title">העדכון הושלם!</string>
-	<string name="install_guide_page_5_text">&#8226; לאחר שמכשירך סיים לעשות מיטוב אפליקציות, משמעות הדבר הוא שהעדכון הותקן בהצלחה. \nבשביל לאמת זאת, הינך מוזמן לבדוק את הגרסה הנוכחית של המערכת שלך על ידי: \n\n&#8226;כניסה להגדרות המכשיר, ולחיצה על "מידע על הטלפון"  ומשם מוזמן לבדוק את גרסת הOxygenOS. \n\n&#8226;אם אהבת את האפליקציה, נשמח אם תדרג אותנו ב5 כוכבים ב־Google Play!</string>
-
-	<string name="install_guide_close_button">סגור מדריך התקנה</string>
+	<string name="install_guide_download_instructions">לחצ/י על כפתור ההורדה כדי להתחיל בהורדת העדכון.\n&#8226;תהליך &#8226; ההורדה יופיע באפליקציה, וכהתראה במסך ההתראות.\n&#8226;כשההורדה תסתיים את/ה תראה התראה עם הטקסט \"ההורדה הושלמה\".  אם שגיאת הורדה מופיעה, פתח/י את האפליקציה ונסה להוריד את העדכון שוב. אם זה לא עובד, וודא/י שיש לך חיבור אינטרנט יציב. אחרת צור/צרי קשר עם המפתחים של האפליקציה. את/ה יכולה לעשות זאת על ידי ביקור בחלון \"האפליקציות והמשחקים שלי\" בחנות הGoogle Play.</string>
 
 	<!-- Device information strings -->
 	<string name="device_information_supported_oxygen_os">המכשיר שלך נתמך</string>
@@ -212,7 +174,7 @@
 	<string name="device_information_image_description">תמונת המכשיר</string>
 	<string name="device_information_incremental_os_version">גרסת מערכת הפעלה מצטברת</string>
 	<string name="device_information_os_version">גרסת Android</string>
-	<string name="device_information_oxygen_os_version">גרסת OxygenOS</string>
+	<string name="device_information_oxygen_os_version">גרסת OS</string>
 	<string name="device_information_oxygen_os_ota_version">גרסת OTA</string>
 	<string name="device_information_patch_level_version">תאריך עדכון אבטחה</string>
 	<string name="device_information_serial_number">מספר Serial</string>
@@ -224,13 +186,15 @@
 	<string name="about_description">אפליקציה זו מורידה עדכונים רשמיים היישר מתוך השרתים של OnePlus, ואף מאשרת את שלמות קובץ העדכון לפני שהמשתמש יוכל להוריד אותו מהאפליקציה. על ידי כך, האפליקציה מאפשרת לך לדלג על ההמתנה של שחרור העדכונים ולהוריד עדכונים רשמיים במהירות האפשרית. אם אתם נתקלים בבאגים בתוכנה, דווחו זאת ל־OnePlus ישירות: <a href="https://forums.oneplus.com/feedback">https://forums.oneplus.com/feedback</a>. אתם מוזמנים להצטרף<a href="https://discord.gg/5TXdhKJ"> לשרת ה־Discord שלנו </a>בשביל שתוכלו לדבר עם משתמשים אחרים על העדכונים האחרונים. בנוסף תרגישו חופשי לשלוח לנו אימייל בכתובת <a href="mailto:support@oxygenupdater.com">support@oxygenupdater.com</a> עם הרעיונות/המשוב שלכם.</string>
 	<string name="about_support">אם ברצונך לתמוך בנו, באפשרותך לקנות תוספת המעניקה לך חופש מפרסומות (יישום/ הגדרות), או לתרום לנו בעמוד ה- <a href="https://patreon.com/oxygenupdater">Patreon page</a>.</string>
 	<string name="about_background_story_header">סיפור רקע</string>
-	<string name="about_background_story">אפליקציית Oxygen Updater פותחה במקור על ידי Arjan Vlek ככלי מעקב אחר תוכנה אחרת שלו, המכונה <a href="https://cyanogenupdatetracker.com/">Cyanogen Update Tracker</a> (היא מספקת פונקציונליות דומה עבור משתמשי Cyanogen OS). \n\nאחרי 4 שנים, ביולי 2019, Arjan החליט לפרוש משני הפרויקטים והעביר את הבעלות על האפליקציה לצוות מפתחים שמגיעים ממדינות שונות. הם לקחו על עצמם את האחריות לספק לקהילה שירות מצויין ומהיר; תמיכה לקבלת עדכונים למכשירי OnePlus מהר יותר. \nהינך מוזמן לקרוא את ההכרזה <a href="https://oxygenupdater.com/article/81/">כאן</a>.\n\n ב-14 לאוגוסט 2019 נרשמה המהדורה הראשונה תחת הבעלים החדשים, שהגיע עם תכונות חדשות כמו מצב חושך ועיצוב שונה לגמרי. \n\nעבור עוד מידע על הצוות בדוק את <a href="https://oxygenupdater.com/team/">האתר שלנו</a></string>
-	<string name="about_third_party_app_notice">שימו לב, זוהי אינה אפליקציה רשמית מ-OnePlus. \n שם ה-OnePlus, לוגו ה-OnePlus ו-OxygenOS הם רכוש של OnePlus. \n Android, Google, Google Play, Google Play Logo הם סימנים מסחריים רשומים של Google Inc. \nאפליקציה זאת משתמשת בנתונים מבית OnePlus ומחברת האם שלה Oppo כדי להראות מידע על עדכונים.</string>
+	<string name="about_background_story">אפליקציית Oxygen Updater פותחה במקור על ידי Arjan Vlek ככלי מעקב אחר תוכנה אחרת שלו, המכונה <a href="https://cyanogenupdatetracker.com/">Cyanogen Update Tracker</a> (היא מספקת פונקציונליות דומה עבור משתמשי Cyanogen OS).\n\nאחרי 4 שנים, ביולי 2019, Arjan החליט לפרוש משני הפרויקטים והעביר את הבעלות על האפליקציה לצוות מפתחים שמגיעים ממדינות שונות. הם לקחו על עצמם את האחריות לספק לקהילה שירות מצויין ומהיר; תמיכה לקבלת עדכונים למכשירי OnePlus מהר יותר.\nהינך מוזמן לקרוא את ההכרזה <a href="https://oxygenupdater.com/article/81/">כאן</a>.\n\nב-14 לאוגוסט 2019 נרשמה המהדורה הראשונה תחת הבעלים החדשים, שהגיע עם תכונות חדשות כמו מצב חושך ועיצוב שונה לגמרי.\n\nעבור עוד מידע על הצוות בדוק את <a href="https://oxygenupdater.com/team/">האתר שלנו</a></string>
+	<string name="about_third_party_app_notice">שימו לב, זוהי אינה אפליקציה רשמית מ-OnePlus.\nשם ה-OnePlus, לוגו ה-OnePlus ו-OxygenOS הם רכוש של OnePlus.\nAndroid, Google, Google Play, Google Play Logo הם סימנים מסחריים רשומים של Google Inc.\nאפליקציה זאת משתמשת בנתונים מבית OnePlus ומחברת האם שלה Oppo כדי להראות מידע על עדכונים.</string>
 	<string name="about_rate_button_text">דרג</string>
 	<string name="about_website_button_text">אתר</string>
 	<string name="about_email_button_text">מייל</string>
 
 	<!-- LocalNotifications strings -->
+	<string name="notification_permission_title">הישארו מעודכנים</string>
+	<string name="notification_permission_text">אנא אפשר לאפליקציה להודיע לך על עדכוני OTA, חדשות, סטטוס הורדה מתמשך ודברים חשובים אחרים. תוכל לכוונן את ההעדפות שלך מאוחר יותר בהגדרות האפליקציה.</string>
 	<string name="notification_new_device_text">%1$s נתמך כעת. פתח את היישום כדי לבחור מכשיר זה.</string>
 	<string name="notification_no_notification_support">התקן או עדכן את שירותי Google Play כדי לאפשר התראות דחיפה.</string>
 	<string name="notification_version">%1$s עכשיו זמין עבור %2$s!</string>
@@ -248,7 +212,7 @@
 	<string name="general_notification_channel_name">כללי</string>
 	<string name="url_submitted_notification_channel_name">כתובת ה-URL של OTA נשלחה</string>
 	<string name="download_status_notification_channel_description">התראות המשקפות את המצב הנוכחי של ההורדה: המתנה, פעיל, הושלם או נכשל</string>
-	<string name="verification_status_notification_channel_description">התראות המשקפות את המצב הנוכחי של מטלת אימות קובץ: בתהליך, הושלם או נכשל. \n בדיקות MD5 עבור קבצים שהורדו מאומתות כדי לוודא שהקובץ לא טופל, והוא קובץ עדכון תקף.</string>
+	<string name="verification_status_notification_channel_description">התראות המשקפות את המצב הנוכחי של מטלת אימות קובץ: בתהליך, הושלם או נכשל.\nבדיקות MD5 עבור קבצים שהורדו מאומתות כדי לוודא שהקובץ לא טופל, והוא קובץ עדכון תקף.</string>
 	<string name="installation_status_notification_channel_description">קבל הודעה אם העדכון הותקן בהצלחה או לא</string>
 	<string name="update_notification_channel_description">קבל התראה כאשר יש עדכון חדש למכשיר שבחרת &amp; ושיטת עדכון</string>
 	<string name="news_notification_channel_description">קבל הודעה כשאנחנו מפרסמים מאמר חדשות</string>
@@ -256,23 +220,9 @@
 	<string name="general_notification_channel_description">התראות כלליות שאינן משתלבות בקטגוריות אחרות</string>
 	<string name="url_submitted_notification_channel_description">קבל התראה כששלחת בהצלחה כתובות OTA לצוות שלנו.\nתוכל לבטל את ההסכמה לשליחת כתובות אתרים אוטומטית בהגדרות האפליקציה.</string>
 
-	<!-- Help strings -->
-	<string name="help">עזרה</string>
-	<string name="help_updating_your_device_title">עדכן את המכשיר שלך</string>
-	<string name="help_updating_your_device_text">בזמן שהאפליקציה פתוחה, יוצג לפניך אם קיים עדכון מערכת חדש. במידה וקיים עדכון מערכת חדש תהיה לך האפשרות להוריד את העדכון. \n\nכדי להתחיל בהתקנה, לחץ על כפתור \"הורד עדכון\" ולאחר מכן כשההורדה הסתיימה, מסך ההתקנה יופיע. אם עזבת את האפליקציה או שהמסך לא הופיע, לחץ על כפתור \"העדכון ירד בהצלחה\".\n\nראשית, מסך ההתקנה יבדוק אם יש לכם גישת Root. אם יש לכם גישת Root, הענק גישת Root כשתתבקש/י ולאחר מכן יהיה באפשרותך לבחור את שיטת ההתקנה הרצויה. במידה ואין לך גישת Root, עקוב אחר ההוראות בשביל התקנה ידנית. \n\nהתקנה אוטומטית: יהיה עליך לבחור את אפשרויות ההתקנה, אנו ממליצים להשתמש בהגדרות ברירת המחדל, יש לציין שיש צורך בחבילת ה-Root הרצויה שצריכה להיות מותקנת מחדש. בחר חבילת Root (קובץ zip) על ידי שימוש באייקון בצורת תיקייה כחולה ולחץ על \"התחל בהתקנה\" כדי להתחיל את ההתקנה. \n\nהתקנה ידנית: \nיוצג לך מדריך התקנה במסך שלך. אנו ממליצים לרשום את ההוראות במקור חיצוני: (דף, מחשב…) ולבצע אותם כאמור למדריך ההתקנה.</string>
-	<string name="help_reading_news_title">קרא את החדשות האחרונות</string>
-	<string name="help_reading_news_text">חדשות מוצגות משמאל למסך העדכון. הפריטים האחרונים מופיעים למעלה. הקש על כפתור ה-I כדי לקרוא אותם. \n לחץ על החץ חזור כדי לחזור למסך פריטי החדשות.</string>
-	<string name="help_device_information_title">צפה במידע על המכשיר שלך</string>
-	<string name="help_device_information_text">באפשרותך לצפות בחלק מהמפרט של המכשיר שלך באמצעות המסך שמשמאל למסך פריטי החדשות. דבר זה עלול להיות שימושי בעת הגשת בקשת תמיכה, במהלכה ייתכן שתתבקש לתת חלק מהמפרט של המכשיר שלך.</string>
-	<string name="help_change_settings_title">שינוי הגדרות</string>
-	<string name="help_change_settings_text">באפשרותך לשנות את ההגדרות שלך על ידי לחיצה על גלגל השיניים הנמצא בסרגל הניווט. \nבאפשרותך לשנות לשנות את ההגדרות הבאות: \n\n•דגם מכשיר ושיטת עדכון \n•התראות דחיפה \n•הגדרות פרטיות (העלאת לוג). \n\n השתמש במתגים כדי להפעיל ולכבות את ההתראות / הגדרות הפרטיות. בחר מכשיר ו/או שיטת עדכון באמצעות התפריטים הנפתחים המוצגים מעל המתגים. התפריטים הנפתחים אינם גלויים? בדוק את חיבור האינטרנט ופתח את מסך ההגדרות שנית.</string>
-
 	<!-- News strings -->
 	<string name="news">חדשות</string>
-	<string name="news_date_published">עדכון אחרון: %1$s</string>
-	<string name="news_empty">לכתבה זאת אין תוכן.</string>
-	<string name="news_load_network_error">Failed to open article. Check your connection and press the \"RETRY\" button to open the article.</string>
-	<string name="news_load_id_error"><![CDATA[אירעה שגיאה בעת פתיחת המאמר משום שהקישור לא תקין: %1$s. בדוק את קישור הURL ודווח לנו זאת דרך <a href="mailto:support@oxygenupdater.com">המייל</a> או דרך <a href="https://discord.gg/5TXdhKJ">שרת הDiscord שלנו </a>.]]></string>
+	<string name="news_load_network_error">Failed to open article. Check your connection and press the \"Retry\" button to open the article.</string>
 	<string name="news_unread_count_1">גילינו שלא קראת %1$d כתבות. לחץ כאן כדי לקרוא אותם.</string>
 	<string name="news_unread_count_2">יש לך %1$d כתבות שלא קראת. לחץ כאן כדי להציג את כל הכתבות.</string>
 	<string name="news_mark_read">סמן כנקרא</string>
@@ -281,7 +231,7 @@
 	<string name="news_empty_state_none_available_header">אין מאמרים עדיין</string>
 	<string name="news_empty_state_all_read_header">אין כתבה שלא קראת!</string>
 	<string name="news_empty_state_none_available_text">אין מאמרים זמינים ברגע זה, בדוק שוב מאוחר יותר.</string>
-	<string name="news_empty_state_all_read_text">קראת את כל הכתבות. עבודה טובה! \nאנחנו מקווים שנהנתה לקרוא את הכתבות שלנו, ולמדת משהו חדש מהם. \n\n הקש על הבאנר שנית כדי להציג את כל הכתבות.</string>
+	<string name="news_empty_state_all_read_text">קראת את כל הכתבות. עבודה טובה!\nאנחנו מקווים שנהנתה לקרוא את הכתבות שלנו, ולמדת משהו חדש מהם.\n\nהקש על הבאנר שנית כדי להציג את כל הכתבות.</string>
 
 	<!-- Contribute strings -->
 	<string name="contribute">עזור לנו לשפר את האפליקציה</string>
@@ -298,12 +248,10 @@
 	<string name="error_app_outdated">אוי לא!</string>
 	<string name="error_app_outdated_message">גרסה זו של האפליקציה מיושנת. הגיע הזמן לעדכן! הקש על \"Google Play\" מתחת. ובתוך Google Play, הקש על \"עדכן\".</string>
 	<string name="error_app_requires_network_connection">אין חיבור</string>
-	<string name="error_app_requires_network_connection_message">החיבור לשרת נכשל. אנא וודא שיש ברשותך חיבור יציב לרשת האינטרנט. אפליקציה זאת עכשיו תסגר.</string>
 	<string name="error_google_play_button_text">Google Play</string>
-	<string name="error_no_internet_connection">אין חיבור.</string>
 	<string name="error_maintenance">השרת תחת תחזוקה</string>
 	<string name="error_maintenance_message">אנא המתן. השרת יהיה זמין בקרוב מאוד.</string>
-	<string name="error_maintenance_retry">השרת עלול להיות סגור בגלל בעיות תחזוקה. אנא נסה שוב מאוחר יותר, או דווח זאת דרך ה-<a href="mailto:support@oxygenupdater.com">מייל</a> או באמצעות <a href="https://discord.gg/5TXdhKJ">שרת הDiscordשלנו </a>.</string>
+	<string name="error_maintenance_retry"><![CDATA[השרת עלול להיות סגור בגלל בעיות תחזוקה. אנא נסה שוב מאוחר יותר, או דווח זאת דרך ה-<a href="mailto:support@oxygenupdater.com">מייל</a> או באמצעות <a href="https://discord.gg/5TXdhKJ">שרת הDiscordשלנו </a>.]]></string>
 	<string name="error_reload">טען מחדש</string>
 	<string name="error_unable_to_rate_app">אינך יכול לדרג את האפליקציה מכיוון שחנות ה-Google Play חסרה במכשיר שלך.</string>
 
@@ -315,7 +263,7 @@
 	<string name="unsupported_device_warning_title">מכשיר זה זוהה כלא נתמך</string>
 	<string name="carrier_exclusive_device_warning_message">נראה שאתה משתמש במכשיר בלעדי של ספק. למרות שאתה משתמש כעת במערכת OxygenOS, לא תוכל להתקין עדכונים. ספקים בדרך כלל נועלים את המכשיר כך שמשתמשים לא יוכלו לעדכן או לשנות את הקושחה ללא אישור מהספק עצמו. דבר זה נהוג בארה"ב: אפשרות \"שדרוג מקומי\" מוסרת מגרסאות בלעדיות של ספקים של OxygenOS. אפשרות זו נחוצה להתקנת עדכונים באפליקציה זו, גם אם אינך משתמש באפליקציה זו. למרבה הצער, אנו לא יכולים לסייע בנושא מכיוון שאנו מוגבלים מבחינה טכנית, ואולי, מבחינה חוקית. פנה אלינו באמצעות דוא"ל או באמצעות ה-Discord בשביל הסבר ברור יותר.</string>
 	<string name="unsupported_device_warning_message">מזל טוב על מכשיר ה-OnePlus החדש שלך! למרבה הצער, טרם הוספנו תמיכה למכשיר זה. אל דאגה, אנו נוסיף אותו בהקדם האפשרי. אנו לא אוהבים לטעות ולכן תהליך זה הוא תהליך שלוקח זמן בשביל לאמת ולבדוק עבור תמיכה במכשירים חדשים, אז בבקשה הישאר סבלני. צור איתנו קשר במייל או תצטרף לשרת הDiscord שלנו אם אתה רוצה לעזור לנו, או כדי להיות מעודכן מתי אנחנו משיקים גרסה חדשה של האפליקציה שתכלול תמיכה במכשיר שלך.</string>
-	<string name="unsupported_os_warning_message">נראה שהמכשיר שלך אינו מריץ את מערכת ההפעלה OxygenOS. שים לב שאתה יכול להתקין עדכוני מערכת רק במכשירים המריצים את מערכת ההפעלה OxygenOS. \n\מכשירים אחרים, כולל מכשירי OnePlus שמריצים גרסאות ROM מותאמות אישית, אינם נתמכות.</string>
+	<string name="unsupported_os_warning_message">נראה שהמכשיר שלך אינו מריץ את מערכת ההפעלה OxygenOS. שים לב שאתה יכול להתקין עדכוני מערכת רק במכשירים המריצים את מערכת ההפעלה OxygenOS.\n\nכשירים אחרים, כולל מכשירי OnePlus שמריצים גרסאות ROM מותאמות אישית, אינם נתמכות.</string>
 
 	<string name="incorrect_device_warning_title">אי התאמה בין המכשירים שנבחרו</string>
 	<string name="incorrect_device_warning_message">נראה כי בחרת את המכשיר הלא נכון: \"%1$s\", במקום \"%2$s\". שנה את בחירתך בהגדרות האפליקציה כדי לוודא שהינך מקבל עדכונים והתראות המיועדים עבור המכשיר שלך.</string>
@@ -326,7 +274,6 @@
 	<string name="purchase_error_pending_payment">הרכישה שלך נמצאת במצב \"תשלום בהמתנה\". לאחר השלמת התשלום, תקבל את כל ההטבות שאתה זכאי להן.</string>
 	<string name="purchase_error_after_payment">רכישת הגרסה חסרת המודעות נכשלה, מכיוון שהתרחש שגיאה פנימית. נסה שוב בעוד מספר דקות. אם חוייבת בכרטיס האשראי, אנאא פנה לתמיכה של Google Play לקבלת סיוע.</string>
 
-	<string name="error">שגיאה</string>
 	<string name="icon">סמל</string>
 	<string name="loading">טוען…</string>
 	<string name="processing">מעבד…</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools" tools:keep="@string/install_guide_page_*_*">
-	<string name="device_chooser_error_title">サポートされているデバイスの取得ができませんでした</string>
-
+<resources>
 	<!-- Update information strings-->
 	<string name="enable">有効にする</string>
 	<string name="update_information_description_not_available">このアップデートが提供する新機能について公式情報はありません。通常、このようなアップデートはデバイスのバグフィックス、パフォーマンス向上、重大なセキュリティアップデートを提供します。</string>
@@ -13,11 +11,10 @@
 	<string name="update_information_banner_server">ここをタップして重要なお知らせを見る</string>
 	<string name="update_information_banner_advanced_mode_tip">\"%1$s\" アップデートトラックを選択しました。このアップデートトラックに切り替える場合は拡張モードを有効化してください。</string>
 	<string name="update_information_header_advanced_mode_hint">拡張モードが有効</string>
-	<string name="update_information_header_advanced_mode_helper">拡張モードが選択され、\"%1$s\" の最新の ZIP をダウンロードすることができます。\n\n設定から拡張モードをオフにすることができます。</string>
-	<string name="update_information_different_version_changelog_notice">あなたは \"%1$s\" アップグレードトラックの最新版の更新履歴を見ています。このアップデートをインストールしたい場合は、始めに拡張モードをオンにする (設定で) 必要があります。\n\n現在インストールされているバージョンの更新履歴を見たい場合は、正しいアップデート方法に切り替える必要があります。</string>
-	<string name="update_information_last_checked_on">最終チェック日時: %1$s</string>
+	<string name="update_information_header_advanced_mode_helper">拡張モードが選択され、\"%1$s\" の最新の ZIP をダウンロードすることができます。 設定から拡張モードをオフにすることができます。</string>
+	<string name="update_information_different_version_changelog_notice_base">注意: この変更履歴は、\"%2$s\"アップデート方法で利用可能な最新バージョン(%1$s)のものです</string>
+	<string name="update_information_different_version_changelog_notice_advanced">。このアップデートをインストールする場合は、設定で\"拡張モード\"を有効にしてください。</string>
 	<string name="update_information_no_update_data_available">アップデート情報が存在しません</string>
-	<string name="update_information_oxygen_os_version">OxygenOS %1$s</string>
 	<string name="update_information_system_is_up_to_date">あなたのシステムは最新です</string>
 	<string name="update_information_unknown_update_name">%1$s 向けの名前のないアップデート</string>
 	<string name="update_information_view_update_information">アップデート情報を表示</string>
@@ -91,9 +88,7 @@
 	<string name="summary_please_wait">お待ち下さい…</string>
 	<string name="summary_update_method">まずデバイスを選択して下さい</string>
 	<!-- TODO: check the following translation -->
-	<string name="summary_important_notifications_disabled">一部の重要な通知が無効になっています。\"%1$s\"</string>
-	<string name="summary_theme">テーマの設定</string>
-	<string name="summary_language">言語を設定する</string>
+	<string name="summary_important_notifications_disabled">一部の重要な通知が無効になっています。:</string>
 	<string name="summary_privacy_policy">オンラインで表示</string>
 	<string name="summary_rate_app">レビューに 5 つ星を残す</string>
 
@@ -124,80 +119,46 @@
 
 	<string name="settings_device">デバイス</string>
 	<string name="settings_entered_incorrectly">設定の保存に失敗しました。デバイス / 更新方法を再選択して下さい。</string>
-	<string name="settings_explanation_incremental_full_update">増分アップデートはどのバージョンからでもインストール可能です（ブートローダーをアンロックしていない場合; アンロック済みの場合はフルアップデートをアップデート方法から選択する必要があります）。\n\nOxygenOS のベータアップデートは安定バージョンを使用している場合でも常にインストールできます。安定版からベータ版に切り替えるには、設定で詳細モードを有効にする必要があります。ベータ版では、フル・増分アップデートは安定版と同じように機能します。</string>
 
 	<string name="settings_push_from_server">通知と警告メッセージ</string>
 
 	<string name="settings_saving">設定を保存中です。長時間この状態が続く場合、ネットワーク接続を確認し、アプリをいったん終了し再起動して下さい。</string>
 
 	<string name="settings_advanced_mode">拡張モード</string>
-	<string name="settings_advanced_mode_explanation">拡張モードでは \"お使いのシステムは最新です\"というメッセージが非表示となり、デバイスと互換性がない場合でも全てのアップデートをダウンロードしインストール可能となります。\n\n以下の場合に役立ちます:\n&#8226; 通常版からベータ版へのアップデート\n&#8226; ベータ版から通常版への復帰(デバイスの工場出荷時設定へのリセットをお忘れずに)\n&#8226; 現在のシステムバージョンの再インストール 。</string>
+	<string name="settings_advanced_mode_explanation">"通常、アプリは現在のOSバージョンに基づいてアップデートを表示します。アドバンスモードでは、デバイス/バージョンの互換性に関係なく、利用可能な最新のアップデートが常に表示されます。
+
+これは次のような場合に便利です："</string>
+	<string name="settings_advanced_mode_uses">"&#8226; すでに最新バージョンであっても再ダウンロードしたい場合
+&#8226; 別のアップデートトラックに切り替える"</string>
+	<string name="settings_advanced_mode_caption">"アドバンスモードが必要になるのは、上記のような場合のみです。自分が何をしているのか分かっていない限り、有効にすべきではありません。"</string>
 
 	<string name="settings_update_method">アップデート方法</string>
 	<string name="settings_upload_logs">利用データとログを共有</string>
+	<string name="settings_ad_privacy">GDPR広告の同意</string>
+	<string name="settings_ad_privacy_subtitle">"EEA/UKのユーザー"</string>
 
 	<!-- FAQ strings -->
 	<string name="faq">FAQ</string>
 	<string name="faq_menu_item">FAQ</string>
 
 	<!-- First-time setup strings -->
-	<string name="onboarding">ようこそ</string>
+	<string name="onboarding">セットアップ</string>
 	<string name="onboarding_finished_button">アプリの開始</string>
 
-	<string name="onboarding_page_1_title">Oxygen Updater にようこそ!</string>
-	<string name="onboarding_page_1_text">本アプリでは次のことができます：\n\n&#8226; OxygenOS 搭載デバイスの最新の Android アップデートを高速アクセスで取得\n\n&#8226; ルート化済デバイスを簡単に更新\n\n&#8226; 現在使用しているシステムソフトウェアの最新情報を表示\n\n&#8226; OnePlus と OxygenOS に関する最新ニュースを読む\n\n続行するには左にスワイプします。</string>
-	<string name="onboarding_page_1_caption">これは OnePlus の公式アプリケーションではありません。このアプリの使用は完全にあなた自身の責任です。 OnePlus もアプリの開発者も、本アプリの使用によって引き起こされた損害を含め、あなたの行動に責任を負いません。\n\nこのアプリを使用すると、上記の利用規約に同意したことになります。</string>
-	<string name="onboarding_page_2_title">あなたのデバイスを選択</string>
-	<string name="onboarding_page_2_caption">通常、デバイスは上記で選択済です。 そうでない場合は、上でデバイスを選択して下さい。</string>
-	<string name="onboarding_page_3_title">アップデート方法を選択</string>
-	<string name="onboarding_page_3_caption">通常、高速で小規模ダウンロードであるため、増分アップデートが正しい選択です。\n\nただし、ルート化済デバイスとの互換性はありません。ルート化済デバイスの場合は完全アップデートを選択します。\n\nOxygenOS のベータ版を使用している場合は、オープンベータアップベート（のいずれか）を選択します。</string>
-	<string name="onboarding_page_4_title">準備が出来ました!</string>
-	<string name="onboarding_page_4_text">アプリの使用をお楽しみください！\n\n後からいつでも設定を変更できます。そのためには、右上隅の3つのドットをタップし、\"設定\"をタップします。</string>
+	<string name="onboarding_app_uses">本アプリでは次のことができます：\n\n&#8226; OxygenOS 搭載デバイスの最新の Android アップデートを高速アクセスで取得\n&#8226; ルート化済デバイスを簡単に更新\n&#8226; 現在使用しているシステムソフトウェアの最新情報を表示\n&#8226; OnePlus と OxygenOS に関する最新ニュースを読む</string>
+	<string name="onboarding_disclaimer">これは OnePlus の公式アプリケーションではありません。このアプリの使用は完全にあなた自身の責任です。 OnePlus もアプリの開発者も、本アプリの使用によって引き起こされた損害を含め、あなたの行動に責任を負いません。 このアプリを使用すると、上記の利用規約に同意したことになります。</string>
+	<string name="onboarding_device_chooser_title">あなたのデバイスを選択</string>
+	<string name="onboarding_device_chooser_caption">通常、デバイスは上記で選択済です。 そうでない場合は、上でデバイスを選択して下さい。</string>
+	<string name="onboarding_method_chooser_title">アップデート方法を選択</string>
+	<string name="onboarding_method_chooser_caption">通常、高速で小規模ダウンロードであるため、増分アップデートが正しい選択です。 ただし、ルート化済デバイスとの互換性はありません。ルート化済デバイスの場合は完全アップデートを選択します。 OxygenOS のベータ版を使用している場合は、オープンベータアップベート（のいずれか）を選択します。</string>
+	<string name="onboarding_caption">アプリの使用をお楽しみください！後からいつでも設定を変更できます。</string>
 
 	<!-- Automatic install strings -->
 	<string name="install">インストール</string>
 
 	<!-- Install guide strings -->
-	<string name="install_guide_no_root">インストールガイドに示されている指示に従い、アップデートをインストールします。</string>
 	<string name="install_guide">インストールガイド</string>
-	<string name="install_guide_subtitle">インストールガイド - %1$d of %2$d</string>
-	<string name="install_guide_tip">&#8226; 更新プログラムのインストール中にデバイスの電源を切る必要があるため、すべての手順を書き留めておくことをお勧めします。</string>
-
-	<string name="install_guide_page_1_title">アップデートのダウンロード</string>
-	<string name="install_guide_page_1_text">&#8226; ダウンロードボタンを押して、更新プログラムのダウンロードを開始します。\n\n&#8226; ダウンロードの進行状況がアプリに表示され、通知画面に通知として表示されます。\n\n&#8226; ダウンロードが完了すると、\"ダウンロード完了\"というテキストの通知が表示されます。\nダウンロードエラーが発生した場合は、アプリを開き、更新プログラムのダウンロードを再試行してください。機能しない場合は、接続が機能していることを確認してください。それ以外の場合は、Google Play ストアの\"マイアプリ\"セクションにアクセスし、アプリの開発者に連絡してください。</string>
-
-	<string name="install_guide_page_2_title">イントールの準備</string>
-	<string name="install_guide_page_2_text">"注: アップデートのインストールはデバイスの標準の システム アップデート から行われます。何らかの理由で、それを開いた時にシステムアップデートが表示された場合は、始めにそれをインストールすることもできます。その後、Oxygen Updater を開き直して完全に最新の状態になっているか確認します。
-
-手順:
-&#8226; ホームボタンを押して Oxygen Updater を閉じます。
-
-&#8226; 設定アプリを開きます。ドロワーにあるはずです。
-
-&#8226; システム アップデート が表示されるまでスクロールし、それをタップします。"
-</string>
-
-	<string name="install_guide_page_3_title">アップデートのインストール</string>
-	<string name="install_guide_page_3_text">"システム アップデート アプリに入ったので、アップデートをインストールします。
-
-&#8226; システム アップデート で、右上にある歯車のアイコンをタップします
-
-&#8226; ここで、"ローカルアップグレード" を選択します。ファイルを開くダイアログが表示されるはずです。
-
-&#8226; この画面で、Oxygen Updater を使用してダウンロードしたアップデートファイルをタップします。\"%1$sOxygen\" から始まる名前になっています。
-
-&#8226; "今すぐアップグレード" をタップします。自動的にインストールが始まります。"
-</string>
-
-	<string name="install_guide_page_4_title">アップデートが完了するまで待つ</string>
-	<string name="install_guide_page_4_text">"&#8226; アップデートのインストールが開始され、プログレスバーが表示されます。インストールが完了するまで待ってください。インストールには数分から 15 分程度掛かります。
-
-&#8226; その後、アップデートを完了するために電話が再起動されます。"</string>
-
-	<string name="install_guide_page_5_title">完了。新しい OxygenOS バージョンを使用して下さい!</string>
-	<string name="install_guide_page_5_text">&#8226; デバイスのアプリ最適化が完了で、アップデートのインストールは成功です。\nインストールの成功を確認するには、以下の方法でシステムの現在バージョンをチェックして下さい。\n\n&#8226; 設定に移動し\"端末情報\"をタップしOxygenOS バージョンを確認します。\n\n&#8226; このアプリが気に入ったら、Google Play で ５ つ星をつけて下さい!</string>
-
-	<string name="install_guide_close_button">インストールガイドを閉じる</string>
+	<string name="install_guide_download_instructions">&#8226; ダウンロードボタンを押して、更新プログラムのダウンロードを開始します。\n&#8226; ダウンロードの進行状況がアプリに表示され、通知画面に通知として表示されます。\n&#8226; ダウンロードが完了すると、\"ダウンロード完了\"というテキストの通知が表示されます。\nダウンロードエラーが発生した場合は、アプリを開き、更新プログラムのダウンロードを再試行してください。機能しない場合は、接続が機能していることを確認してください。それ以外の場合は、Google Play ストアの\"マイアプリ\"セクションにアクセスし、アプリの開発者に連絡してください。</string>
 
 	<!-- Device information strings -->
 	<string name="device_information_supported_oxygen_os">サポートされているデバイス</string>
@@ -215,7 +176,7 @@
 	<string name="device_information_image_description">デバイスイメージ</string>
 	<string name="device_information_incremental_os_version">インクリメンタル OS バージョン</string>
 	<string name="device_information_os_version">Android バージョン</string>
-	<string name="device_information_oxygen_os_version">OxygenOS バージョン</string>
+	<string name="device_information_oxygen_os_version">OS バージョン</string>
 	<string name="device_information_oxygen_os_ota_version">OTA バージョン</string>
 	<string name="device_information_patch_level_version">セキュリティパッチ日時</string>
 	<string name="device_information_serial_number">シリアル番号</string>
@@ -227,13 +188,15 @@
 	<string name="about_description">このアプリは直接 OnePlus のサーバーから正式なアップデートをダウンロードし、インストールを許可する前にダウンロードされた ZIP の整合性を確認することができます。そうすることで、このアプリはロールアウトをスキップし、アップデートを即座にインストールすることができます。OS の不具合に遭遇した場合、OnePlus に直接報告してください: <a href="https://forums.oneplus.com/feedback">https://forums.oneplus.com/feedback</a>。私たちの <a href="https://discord.gg/5TXdhKJ">Discord サーバー</a>に参加し、最新のアップデートについて話してみませんか。また、提案やフィードバックは <a href="mailto:support@oxygenupdater.com">support@oxygenupdater.com</a> にお気軽にどうぞ。</string>
 	<string name="about_support">私たちを支援したい場合は、広告の除去を購入もしくは <a href="https://patreon.com/oxygenupdater">Patreon のページ</a>を確認してください。</string>
 	<string name="about_background_story_header">経緯</string>
-	<string name="about_background_story">本アプリは Arjan Vlek が彼の他のアプリ <a href="https://cyanogenupdatetracker.com/">Cyanogen Update Tracker</a>(Cyanogen OS ユーザ向けに同様の機能を提供する) のフォローアップとして開発したものです。\n\n4年後、2019年7月にArjan は双方のプロジェクトから辞任することを決定し、アプリの所有権をさまざまな国からの開発者チームに移しました。彼らは、OnePlusの更新を迅速に取得するための優れたサービスとサポートをコミュニティに提供する責任を負っています。\n\n発表の詳細については、<a href="https://oxygenupdater.com/article/81/">こちら</a>をご覧ください。\n\n 2019年8月14日 ダークモードや完全な再設計などの新機能を備えた新しい所有権の下での最初のリリース。\n\nチームの詳細については、<a href="https://oxygenupdater.com/team/">ウェブサイト</a>.</string>
+	<string name="about_background_story">本アプリは Arjan Vlek が彼の他のアプリ <a href="https://cyanogenupdatetracker.com/">Cyanogen Update Tracker</a>(Cyanogen OS ユーザ向けに同様の機能を提供する) のフォローアップとして開発したものです。\n\n4年後、2019年7月にArjan は双方のプロジェクトから辞任することを決定し、アプリの所有権をさまざまな国からの開発者チームに移しました。彼らは、OnePlusの更新を迅速に取得するための優れたサービスとサポートをコミュニティに提供する責任を負っています。\n\n発表の詳細については、<a href="https://oxygenupdater.com/article/81/">こちら</a>をご覧ください。\n\n2019年8月14日 ダークモードや完全な再設計などの新機能を備えた新しい所有権の下での最初のリリース。\n\nチームの詳細については、<a href="https://oxygenupdater.com/team/">ウェブサイト</a>.</string>
 	<string name="about_third_party_app_notice">注意、これは OnePlus 公式のアプリケーションではありません。\nOnePlus、OnePlus ロゴ、および OxygenOS は OnePlus の登録商標です。\nAndroid、Google、Google Play、および Google Play ロゴは Google Inc. の登録商標です。\nこのアプリは OnePlus およびその親会社 Oppo のデータを使用して更新情報を表示します。</string>
 	<string name="about_rate_button_text">評価</string>
 	<string name="about_website_button_text">ウェブサイト</string>
 	<string name="about_email_button_text">メール</string>
 
 	<!-- LocalNotifications strings -->
+	<string name="notification_permission_title">"通知を受け取る"</string>
+	<string name="notification_permission_text">"OTAアップデート、ニュース、進行中のダウンロード状況、その他重要なことをアプリが通知するようにしてください。設定はアプリの設定で変更できます。"</string>
 	<string name="notification_new_device_text">%1$s がサポートされました。 アプリを開き、このデバイスを選択。</string>
 	<string name="notification_no_notification_support">Google Play サービスをインストール/アップデートしプッシュ通知を有効化する</string>
 	<string name="notification_version">%2$s 向けの %1$s が利用可能です!</string>
@@ -259,23 +222,9 @@
 	<string name="general_notification_channel_description">どのカテゴリにも属さない一般的な通知</string>
 	<string name="url_submitted_notification_channel_description">OTA URLの提出が完了したら、通知を受け取ることができます。\nアプリの設定で、URLの自動送信を停止することができます。</string>
 
-	<!-- Help strings -->
-	<string name="help">ヘルプ</string>
-	<string name="help_updating_your_device_title">デバイスのアップデート</string>
-	<string name="help_updating_your_device_text">アプリを開くと、システムアップデートが利用可能かどうかがわかります。更新プログラムが利用可能な場合は、それをインストールできます。\n\nインストールを開始するには、（更新プログラムの説明の下にある）\"ダウンロード\"ボタンをタップしてダウンロードを開始します。ダウンロードが完了すると、インストール画面が表示されます。アプリを離れた場合、または画面がポップアップしなかった場合は、\"ダウンロード\"ボタンの横に表示される\"インストール\"ボタンをタップします。\n\nインストール画面では、root化済デバイスであるか最初に確認されます。ルート化済デバイスで場合は、確認画面でルート権限を付与し、アップデートのインストール方法を選択します。非ルート化済みデバイスの場合は、手動インストールの手順に従ってください。\n\n自動インストール：\nインストールオプションを選択するだけです。デフォルトの設定が推奨されますが、（再）インストールする必要があるルートパッケージを指定する必要があります。青いフォルダボタンを使用してルートパッケージ（zip ファイル）を選択し、\"インストールを開始\"をタップしてインストールを開始します。\n\n手動インストール：\n画面にインストールガイドが表示されます。指示を書き留め、記載されているとおりに実行して更新プログラムをインストールします。</string>
-	<string name="help_reading_news_title">最新ニュースの購読</string>
-	<string name="help_reading_news_text">ニュースはアップデートスクリーンの左側に表示されます。最新アイテムは最上部に表示されます。項目をタップして読むだけです。\n←矢印をタップするか、戻るキーを押してニュース項目画面に戻ります。</string>
-	<string name="help_device_information_title">デバイス情報の表示</string>
-	<string name="help_device_information_text">更新画面の右側の画面を使用して、デバイスの仕様の一部を表示できます。 これは、デバイスの仕様の一部を尋ねられる可能性のあるサポートリクエストを行うときに役立ちます。</string>
-	<string name="help_change_settings_title">設定の変更</string>
-	<string name="help_change_settings_text">設定を変更するには、右上の 3 つドットをタップし、\"設定\"をタップします。\n次の設定を変更できます。\ n\n•デバイスと更新方法\n•プッシュ通知\n•アプリ通知\n•プライバシー設定（ログのアップロード）。\n\nスイッチを使用して、通知/プライバシー設定をオンまたはオフにします。 スイッチの上に表示されるドロップダウンメニューを使用して、デバイスおよび/または更新方法を選択します。 ドロップダウンメニューは表示されませんか？ インターネット接続を確認し、設定画面を再度開きます。</string>
-
 	<!-- News strings -->
 	<string name="news">ニュース</string>
-	<string name="news_date_published">最終更新日: %1$s</string>
-	<string name="news_empty">この記事には内容がありません。</string>
 	<string name="news_load_network_error">記事を開けませんでした。 接続を確認し、\'再試行\'ボタンを押して記事を開きます。</string>
-	<string name="news_load_id_error"><![CDATA[無効な URL から記事を開くのに失敗しました: %1$s。URL を確認するか<a href="mailto:support@oxygenupdater.com">メール</a>または<a href="https://discord.gg/5TXdhKJ">Discord サーバー</a>からご報告ください。]]></string>
 	<string name="news_unread_count_1">%1$d 件未読のニュース記事。ここをタップして表示。</string>
 	<string name="news_unread_count_2">%1$d 件未読のニュース記事。ここをタップしてすべての記事を表示。</string>
 	<string name="news_mark_read">既読にする</string>
@@ -301,12 +250,10 @@
 	<string name="error_app_outdated">Oh no!</string>
 	<string name="error_app_outdated_message">このバージョンのアプリは古くなっています。 更新する時が来ました！ 下の\"Google Play\" をタップし、 Google Play 内で、\"更新\"をタップします。</string>
 	<string name="error_app_requires_network_connection">接続なし</string>
-	<string name="error_app_requires_network_connection_message">サーバへの接続に失敗しました。ネットワーク接続が正常であるか確認して下さい。アプリケーションを閉じます。</string>
 	<string name="error_google_play_button_text">Google Play</string>
-	<string name="error_no_internet_connection">接続なし</string>
 	<string name="error_maintenance">サーバメンテナンス</string>
 	<string name="error_maintenance_message">お待ちください。 サーバーはまもなく利用可能になります。</string>
-	<string name="error_maintenance_retry">サーバーはメンテナンスのためダウンしている可能性があります。時間をおいてもう一度やり直すか、<a href="mailto:support@oxygenupdater.com">メール</a>や<a href="https://discord.gg/5TXdhKJ">Discord サーバー</a>で報告してください。</string>
+	<string name="error_maintenance_retry"><![CDATA[サーバーはメンテナンスのためダウンしている可能性があります。時間をおいてもう一度やり直すか、<a href="mailto:support@oxygenupdater.com">メール</a>や<a href="https://discord.gg/5TXdhKJ">Discord サーバー</a>で報告してください。]]></string>
 	<string name="error_reload">再読込</string>
 
 	<string name="error_unable_to_rate_app">Google Play ストアがデバイスにないため、アプリを評価できません。</string>
@@ -331,7 +278,6 @@
 	<string name="purchase_error_after_payment">内部エラーが発生したため、広告なしバージョンの購入に失敗しました。 数分後にもう一度お試しください。 既に支払いを済ませている場合は、Google Play サポートにお問い合わせください。</string>
 
 	<!-- Other strings-->
-	<string name="error">エラー</string>
 	<string name="icon">アイコン</string>
 	<string name="loading">読み込中…</string>
 	<string name="processing">処理中…</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="device_chooser_error_title">Неможе да се врати листа од поддржани уреди</string>
-
 	<!-- Update information strings-->
 	<string name="enable">Овозможи</string>
 	<string name="update_information_description_not_available">Нема официјални информации за новите функции која ова ажурирање ги овозможува. Обично, вакво ажурирање се состои од поправки на грешки, подобрување на перформанси, и/или критични безбедносни закрпи за вашиот уред.</string>
@@ -13,11 +11,10 @@
 	<string name="update_information_banner_server">Притиснете овде за прикажување на важни известувања</string>
 	<string name="update_information_banner_advanced_mode_tip">Ја селектиравте \"%1$s\" ажурирачка трака. Овозможете напреден режим ако планирате да се префрлите на оваа ажурирачка трака.</string>
 	<string name="update_information_header_advanced_mode_hint">Напредниот режим е овозможен</string>
-	<string name="update_information_header_advanced_mode_helper">Бидејќи имате овозможено напреден режим, можете да ја превземете најновата ZIP датотека за \"%1$s\".\n\nМожете да го исклучите напредниот режим во поставките.</string>
-	<string name="update_information_different_version_changelog_notice">Ги гледате измените за најновото ажурирање во \"%1$s\" траката. Ако планирате да го инсталирате ова ажурирање, мора да го овозможите напредниот режим (во поставките).\n\nНо, ако сакате да ги видите промените за сегашното инсталирано ажурирање, ќе треба да се префрлите на точната ажурирачка метода.</string>
-	<string name="update_information_last_checked_on">Последно проверено на: %1$s</string>
+	<string name="update_information_header_advanced_mode_helper">Бидејќи имате овозможено напреден режим, можете да ја превземете најновата ZIP датотека за \"%1$s\". Можете да го исклучите напредниот режим во поставките.</string>
+	<string name="update_information_different_version_changelog_notice_base">Забелешка: овој дневник е за најновата достапна верзија (%1$s) во методот за ажурирање \"%2$s\"</string>
+	<string name="update_information_different_version_changelog_notice_advanced">. Ако имате намера да го инсталирате ова ажурирање, мора да овозможите \"Напреден режим\" во поставките.</string>
 	<string name="update_information_no_update_data_available">Не се достапни податоци за ажурирање</string>
-	<string name="update_information_oxygen_os_version">OxygenOS %1$s</string>
 	<string name="update_information_system_is_up_to_date">Вашиот систем е ажуриран</string>
 	<string name="update_information_unknown_update_name">Безимено ажурирање за %1$s</string>
 	<string name="update_information_view_update_information">Погледни ги информациите за ажурирањето</string>
@@ -43,7 +40,7 @@
 	<string name="download_complete_notification">Притиснете за да ја започнете инсталацијата</string>
 
 	<string name="download_error">Грешка при превземање</string>
-	<string name="download_error_close">ЗАТВОРИ</string>
+	<string name="download_error_close">Затвори</string>
 	<string name="download_error_corrupt">Преземениот фајл за ажурирање е оштетен! Ве молиме превземете го павторно.</string>
 	<string name="download_error_server">Настана серверска грешка при превземање на ажурирањето. Ве молиме обидете се да го превземете ажурирањето повторно.</string>
 	<string name="download_error_internal">За жал, настана техничка грешка при превземање на ажурирањето. Обидете се да го превземето повторно. Ако грешките продолжат, ве молиме исконтактирајте го развивачот на оваа апликација за помош.</string>
@@ -52,8 +49,8 @@
 Ако сакате да дознаете повеќе, слободно контактирајте не на <a href="mailto:support@oxygenupdater.com">е-пошта</a> или на нашиот <a href="https://discord.gg/5TXdhKJ">Discord сервер</a>.]]></string>
 	<string name="download_error_could_not_move_temp_file">Датотеката е превземена, но неможе да се премести до соодветниот директориум. Отворете го менаџерот на податоци, навигирајте до \"%1$s\" и мануелно преместета ја датотеката во најгорниот директориум на внатрешната меморија.</string>
 
-	<string name="download_error_retry">ОБИДИ СЕ ПОВТОРНО</string>
-	<string name="download_error_resume">ПРОДОЛЖИ</string>
+	<string name="download_error_retry">Обиди се повторно</string>
+	<string name="download_error_resume">Продолжи</string>
 	<string name="download_error_storage">Нема доволно меморија на вашиот уред за да се превземе ажурирањето. Ве молиме отстранете некои датотеки и обидете се повторно.</string>
 
 	<string name="download_failed">Превземањето е неуспешно</string>
@@ -89,9 +86,7 @@
 	<string name="summary_off">Оневозможено</string>
 	<string name="summary_please_wait">Ве молиме почекајте…</string>
 	<string name="summary_update_method">Најпрво изберете уред</string>
-	<string name="summary_important_notifications_disabled">Некои по важни нотификации се оневозможени: \"%1$s\"</string>
-	<string name="summary_theme">Избери тема</string>
-	<string name="summary_language">Избери јазик</string>
+	<string name="summary_important_notifications_disabled">Некои по важни нотификации се оневозможени:</string>
 	<string name="summary_privacy_policy">Погледнете онлајн</string>
 	<string name="summary_rate_app">Оставете преглед од 5 ѕвезди</string>
 
@@ -122,78 +117,46 @@
 
 	<string name="settings_device">Уред</string>
 	<string name="settings_entered_incorrectly">Грешка при зачувување на вашите поставки. Ве молиме вратете се назад и изберете го вашиот уред / метод на ажурирање повторно.</string>
-	<string name="settings_explanation_incremental_full_update">Инкрементално ажурирање може да биде инсталирано од било која верзија (освен ако имате отклучен bootloader; тогаш секогаш би требало да го избирате методот на целосно ажурирање).\n\nБета ажурирање за OxygenOS секогаш може да биде инсталирано, и кога сте на стабилна верзија. За да промените од стабилно на бета, мора да овозможите напреден режим од поставките. За бета ажурирањата, целосните и инкременталните методи работат на истиот начин како и кај стабилните верзии.</string>
 
 	<string name="settings_push_from_server">Информациони и предупредувачки пораки</string>
 
 	<string name="settings_saving">Вашите поставки сеуште се зачувуваат. Ако ова потрае долго време: Проверете ја интернет конекцијата, изгасете ја апликацијата и обидете се повторно.</string>
 
 	<string name="settings_advanced_mode">Напреден режим</string>
-	<string name="settings_advanced_mode_explanation">Напредниот режим ја крие пораката \"Your system is up to date\", овозможувајќи да ги превземете и инсталирате сите ажурирања, иако тие не се компатибилни со вашиот уред.\n\nОва може да биде корисно кога:\n&#8226; Ажурирање од стабилна кон бета верзија\n&#8226; Враќање од бета верзија кон стабилна верзија (не заборавајте да го вратите уредот на фабрички подесувања)\n&#8226; Преинсталација на сегашната системска верзија.</string>
+	<string name="settings_advanced_mode_explanation">"Вообичаено, апликацијата ви прикажува ажурирања врз основа на вашата тековна верзија на ОС. Со напредниот режим, последното достапно ажурирање секогаш ќе се прикажува без оглед на компатибилноста на уредот/верзијата.
+
+Ова може да биде корисно ако сакате:"</string>
+	<string name="settings_advanced_mode_uses">"&#8226; Преземете ја повторно најновата верзија дури и ако веќе сте на неа
+&#8226; Префрлете се на друга песна за ажурирање"</string>
+	<string name="settings_advanced_mode_caption">"Напредниот режим може да биде потребен само во горенаведените ситуации. Не треба да го овозможите освен ако не знаете што правите."</string>
 
 	<string name="settings_update_method">Метод на ажурирање</string>
 	<string name="settings_upload_logs">Споделете податоци за користење и дневници</string>
+	<string name="settings_ad_privacy">Согласност за реклама за GDPR</string>
+	<string name="settings_ad_privacy_subtitle">"За корисници на ЕЕА/Велика Британија"</string>
 
 	<!-- FAQ strings -->
 	<string name="faq">ЧПП</string>
 	<string name="faq_menu_item">ЧПП</string>
 
 	<!-- First-time onboarding strings -->
-	<string name="onboarding">Добредојдовте</string>
+	<string name="onboarding">Поставување</string>
 	<string name="onboarding_finished_button">Стартувај ја апликација</string>
 
-	<string name="onboarding_page_1_title">Добредојдовте во Oxygen Updater!</string>
-	<string name="onboarding_page_1_text">Оваа апликација ви овозможува:\n\n&#8226; Добивање побрз пристап до најновите Андроид ажурирања за вашиот OxygenOS уред\n\n&#8226; Лесно ажурирање на рутиран уред\n\n&#8226; Преглед на што е ново кај системскиот софтвер кој го користите\n\n&#8226; Читање на најновите вести за OnePlus и OxygenOS\n\nЛизгајте на лево за да продолжите.</string>
-	<string name="onboarding_page_1_caption">Ова не е официјална OnePlus апликација. Користењето на оваа апликација е на ваш ризик. Ниту OnePlus ниту развивачот на оваа апликација се одговорни за вашите постапки, вклучувајчи секаква штета настаната од користење на оваа апликација.\n\nСо користење на оваа апликација, се согласувате со условите како што е наведено погоре.</string>
-	<string name="onboarding_page_2_title">Изберете го вашиот уред</string>
-	<string name="onboarding_page_2_caption">Вашиот уред би требало да е избран. Доколку не е, изберете го погоре.</string>
-	<string name="onboarding_page_3_title">Изберете го вашиот метод на ажурирање</string>
-	<string name="onboarding_page_3_caption">Вообичаено, инкременталното ажурирање е вистинскиот избор овде, бидејќи овозможува побрзи и помали превземања.\n\nНо, не е компатибилно со рутирани уреди. Доколку имате рутиран уред, изберете метод на целосно ажурирање.\n\nДоколку имате бета верзија на OxygenOS, изберете (едно од) метод(ите) на ажурирање за отворена бета.</string>
-	<string name="onboarding_page_4_title">Спремни сте!</string>
-	<string name="onboarding_page_4_text">Уживајте во користењето на оваа апликација!\n\nСекогаш може да ги промените поставките подоцна. За да го направите тоа: Притиснете ги трите точки во горниот десен агол, и притиснете на \"Settings\".</string>
+	<string name="onboarding_app_uses">Оваа апликација ви овозможува:\n\n&#8226; Добивање побрз пристап до најновите Андроид ажурирања за вашиот OxygenOS уред\n&#8226; Лесно ажурирање на рутиран уред\n&#8226; Преглед на што е ново кај системскиот софтвер кој го користите\n&#8226; Читање на најновите вести за OnePlus и OxygenOS\n\nЛизгајте на лево за да продолжите.</string>
+	<string name="onboarding_disclaimer">Ова не е официјална OnePlus апликација. Користењето на оваа апликација е на ваш ризик. Ниту OnePlus ниту развивачот на оваа апликација се одговорни за вашите постапки, вклучувајчи секаква штета настаната од користење на оваа апликација. Со користење на оваа апликација, се согласувате со условите како што е наведено погоре.</string>
+	<string name="onboarding_device_chooser_title">Изберете го вашиот уред</string>
+	<string name="onboarding_device_chooser_caption">Вашиот уред би требало да е избран. Доколку не е, изберете го погоре.</string>
+	<string name="onboarding_method_chooser_title">Изберете го вашиот метод на ажурирање</string>
+	<string name="onboarding_method_chooser_caption">Вообичаено, инкременталното ажурирање е вистинскиот избор овде, бидејќи овозможува побрзи и помали превземања. Но, не е компатибилно со рутирани уреди. Доколку имате рутиран уред, изберете метод на целосно ажурирање. Доколку имате бета верзија на OxygenOS, изберете (едно од) метод(ите) на ажурирање за отворена бета.</string>
+	<string name="onboarding_caption">Уживајте во користењето на оваа апликација! Секогаш може да ги промените поставките подоцна.</string>
 
 	<!-- Automatic install strings -->
 	<string name="install">Инсталирај</string>
 
 	<!-- Install guide strings -->
-	<string name="install_guide_no_root">Инсталирајте го ажурирањето според инструкциите кои се прикажани во водичот за инсталација.</string>
 	<string name="install_guide">Водич за инсталација</string>
-	<string name="install_guide_subtitle">Водич за инсталација - %1$d од %2$d</string>
-	<string name="install_guide_tip">&#8226; Пожелно е да ги запишете сите чекори, бидејќи треба да го исклучите вашиот уред за време на инсталацијата.</string>
-
-	<string name="install_guide_page_1_title">Превземете го ажурирањето</string>
-	<string name="install_guide_page_1_text">&#8226; Притиснете го копчето за превземање за да го превземете ажурирањето.\n\n&#8226; Прогресот на превземање ќе се прикаже на апликацијата, и како нотификација на вашиот екран за нотификации.\n\n&#8226; Кога превземањето ќе заврши, ќе се прикаже нотификација со текст \"Download complete\".\nДоколку има грешка при превземање, отворете ја апликацијата и обидете се да го превземете ажурирањето повторно. Доколку и ова не функционира, осигурајте се дека имате стабилна конекција. Во спротивно, исконтактирајте го развивачот на апликацијата. Ова може да го направите со посета на \"My apps\" делот во Google Play Store.</string>
-
-	<string name="install_guide_page_2_title">Припремете се за инсталација</string>
-	<string name="install_guide_page_2_text">"Забелешка: Инсталацијата на ажурирањето се одвива во специјална страница во секцијата за Системски Ажурирања на вашиот уред. Доколку, за било каква причина, системското ажурирање се прикажува во оваа секција, можете прво да го инсталирате тоа ажурирање. Подоцна, отворете го Oxygen Updater повторно за да проверите дали сте на најновото ажурирање.
-
-Инструкции:
-&#8226; Исклучете го Oxygen Updater со притискање на копчето за почетен екран.
-
-&#8226; Отворете ја апликацијата за поставки. Би требало да се наоѓа во вашата листа на апликации.
-
-&#8226; Скролајте надоле додека не видите Системски ажурирања. Притиснете."</string>
-
-	<string name="install_guide_page_3_title">Инсталирајте го ажурирањето</string>
-	<string name="install_guide_page_3_text">"Сега, кога сте во апликацијата за Системски Ажурирања, време е да го инсталирате ажурирањето.
-
-&#8226; Во секцијата за Системски Ажурирања, притиснете ја иконата со запчаник во горниот десен агол.
-
-&#8226; Потоа, селектирајте \"Local upgrade\". Би требало да се појави екран за селектирање на датотеки.
-
-&#8226; На овој екран, притиснете на датотеката со ажурирањето која ја превземавте со Oxygen Updater. Нејзиното име треба да започнува со \"%1$sOxygen\".
-
-&#8226; Притиснете на \"Upgrade Now\". Инсталацијата треба да започне автоматски."</string>
-
-	<string name="install_guide_page_4_title">Почекајте да заврши инсталацијата</string>
-	<string name="install_guide_page_4_text">"&#8226; Уредот сега ќе го инсталира ажурирањети и ќе прикаже прогресна лента. Ве молиме почекајте инсталацијата да заврши. Инсталацијата може да потрае од неколку минути до 15 минути.
-
-&#8226; Потоа, вашиот уред ќе се рестартира за да заврши со ажурирањето."</string>
-
-	<string name="install_guide_page_5_title">Завршено. Уживајте во новата верзија на OxygenOS!</string>
-	<string name="install_guide_page_5_text">&#8226; Откако вашиот уред ќе заврши со оптимизација на апликациите, ажурирањето е успешно инсталирано.\nЗа да верификувате, можете да ја проверите тековната верзија на вашиот систем на следниот начин:\n\n&#8226; Одете во поставките на уредот, притиснете на \"About Phone\", и проверете ја верзијата на OxygenOS.\n\n&#8226; Ако ви се допаѓа оваа апликација, дадете и 5 ѕвезди на Google Play!</string>
-
-	<string name="install_guide_close_button">Затвори го инсталациониот водич</string>
+	<string name="install_guide_download_instructions">&#8226; Притиснете го копчето за превземање за да го превземете ажурирањето.\n&#8226; Прогресот на превземање ќе се прикаже на апликацијата, и како нотификација на вашиот екран за нотификации.\n&#8226; Кога превземањето ќе заврши, ќе се прикаже нотификација со текст \"Download complete\". Доколку има грешка при превземање, отворете ја апликацијата и обидете се да го превземете ажурирањето повторно. Доколку и ова не функционира, осигурајте се дека имате стабилна конекција. Во спротивно, исконтактирајте го развивачот на апликацијата. Ова може да го направите со посета на \"My apps\" делот во Google Play Store.</string>
 
 	<!-- Device information strings -->
 	<string name="device_information_supported_oxygen_os">Вашиот уред не е поддржан</string>
@@ -210,7 +173,7 @@
 	<string name="device_information_image_description">Слика од уредот</string>
 	<string name="device_information_incremental_os_version">Инкрементална верзија на ОС</string>
 	<string name="device_information_os_version">Андроид верзија</string>
-	<string name="device_information_oxygen_os_version">OxygenOS верзија</string>
+	<string name="device_information_oxygen_os_version">OS верзија</string>
 	<string name="device_information_oxygen_os_ota_version">OTA верзија</string>
 	<string name="device_information_patch_level_version">Датум на безбедносна закрпа</string>
 	<string name="device_information_serial_number">Сериски број</string>
@@ -229,6 +192,8 @@
 	<string name="about_email_button_text">Е-Пошта</string>
 
 	<!-- LocalNotifications strings -->
+	<string name="notification_permission_title">"Останете известени"</string>
+	<string name="notification_permission_text">"Дозволете апликацијата да ве известува за OTA ажурирања, новости, статус на тековно преземање и други важни работи. Подоцна можете да ги прилагодите вашите параметри во поставките на апликацијата."</string>
 	<string name="notification_new_device_text">%1$s сега е поддржан. Отворете ја апликацијата за да го изберете овој уред.</string>
 	<string name="notification_no_notification_support">Инсталирајте или ажурирајте ги сервисите на Google Play за да овозможите нотификации.</string>
 	<string name="notification_version">%1$s е сега достапна за %2$s!</string>
@@ -254,23 +219,9 @@
 	<string name="general_notification_channel_description">Општи нотификации кои не се дел од другите категории</string>
 	<string name="url_submitted_notification_channel_description">Добијте известување кога успешно сте ги испратиле OTA URL-адресите до нашиот тим.\nМоже да се откажете од автоматско испраќање URL-адреси во поставките на апликацијата.</string>
 
-	<!-- Help strings -->
-	<string name="help">Помош</string>
-	<string name="help_updating_your_device_title">Ажурирање на вашиот уред</string>
-	<string name="help_updating_your_device_text">При отварање на апликација, ќе се прикаже ако има достапно системско ажурирање. Доколку има достапно, можете да го инсталирате.\n\nЗа да ја започнете инсталацијата, притиснете го \"Превземи\" копчето (под описот за ажурирањето) за да го започнете превземањето. Кога ќе заврши превземањето, се пркажува екранот за инсталација. Ако сте ја напуштиле апликацијата или ако екранот не се појавил, притиснете на \"Инсталирај\" копчето, кое сега е прикажано до \"Преврземи\" копчето.\n\nЕкранот за инсталација ќе провери дали имате рутиран уред. Ако имате рутиран уред, дозволете рут пермиссии кога ќе бидете прашани и изберете го начинот на кој ќе го инсталирате ажурирањето. Во спротивно, следете ги инструкциите за мануелна инсталација.\n\nАвтоматска инсталација:\nПотребно е само да ги изберете поставките за инсталацијата. Првичните поставки се пожелни, освен тоа што треба да спесифицирате кон рут пакетот кој треба да биде (ре)инсталиран. Селектирајте рут пакет (zip датотека) користејќи го плавото копче со фолдер и притиснете на \"Започни инсталација\" за да ја започнете инсталацијата.\n\nМануелна инсталација:\nЌе се прикаже инсталациски водич на вашиот екран. Запишете ги инструкциите и извршете ги како што се запишани за да го инсталирате ажурирањето.</string>
-	<string name="help_reading_news_title">Читање на најновите статии</string>
-	<string name="help_reading_news_text">Новостите се прикажани на левата страна од екранот за ажурирање. Најновите статии се наоѓаат на врвот. Само притиснете на статија за да ја прочитате.\nПритиснете на стрелката за враќање или на копчето за враќање за се вратите на екранот со статиите.</string>
-	<string name="help_device_information_title">Прикажување на информации за вашиот уред</string>
-	<string name="help_device_information_text">Можете да погледнете дел од спесификациите на вашиот уред со користење на екранот десно од екранот за ажурирање. Ова е корисно кога правите кроисничко барање, во кое може да бидете прашани за дел од спесификациите на вашиот уред.</string>
-	<string name="help_change_settings_title">Промена на поставки</string>
-	<string name="help_change_settings_text">Можете да ги промените поставките со притискање на трите точки во горниот десен агол, проследено со притискање на Поставки.\nМожете да ги промените следните поставки:\n\n• Уред и метод на ажурирање\n• Нотификации\n• Внатрешни нотификации\n• Поставки за приватност (праќање на логови).\n\nКористете ги прекинувачите за да ги овозможите поставките за нотификациите / приватност. Изберете уред и / или метод на ажурирање користејќи ги паѓачките менија прикажани над прекинувачите. Не се видливи паѓачките менија? Проверете ја вашата интернет врска и отворете ги поставките повторно.</string>
-
 	<!-- News strings -->
 	<string name="news">Новости</string>
-	<string name="news_date_published">Последно ажурирање: %1$s</string>
-	<string name="news_empty">Оваа статија нема никаква содржина.</string>
 	<string name="news_load_network_error">Грешка при отварање на статија. Проверете ја вашата конекција и притиснете \"Обидете се повторно\" копчето за да ја отворите статијата.</string>
-	<string name="news_load_id_error"><![CDATA[Грешка при отварање на статија со неважечко URL: %1$s. Проверете го URL-то или пријавете го на <a href="mailto:support@oxygenupdater.com">е-пошта</a> или на нашиот <a href="https://discord.gg/5TXdhKJ">Discord сервер</a>.]]></string>
 	<string name="news_unread_count_1">Имате %1$d непрочитани статии. Притиснете овде за да ги видите.</string>
 	<string name="news_unread_count_2">Имате %1$d непрочитани статии. Притиснете за да се прикажат сите статии.</string>
 	<string name="news_mark_read">Означи како прочитани</string>
@@ -296,12 +247,10 @@
 	<string name="error_app_outdated">Ох не!</string>
 	<string name="error_app_outdated_message">Оваа верзија на апликацијата е застарена. Време е да ја ажурирате! Притиснете на \"Google Play\" подоле. Во Google Play, притиснете на \"Ажурирај\".</string>
 	<string name="error_app_requires_network_connection">Нема конекција</string>
-	<string name="error_app_requires_network_connection_message">Грешка при конектирање со серверот. Ве молиме проверете дали имате стабилна конекција. Апликацијата сега ке се исклучи.</string>
 	<string name="error_google_play_button_text">Google Play</string>
-	<string name="error_no_internet_connection">Нема конекција.</string>
 	<string name="error_maintenance">Одржување на серверот</string>
 	<string name="error_maintenance_message">Ве молиме почекајте. Серверот ќе биде достапен наскоро.</string>
-	<string name="error_maintenance_retry">Серверот најверојатно е под рутинска поправка. Обидете се повторно после некое време, или пријавете на нашата <a href="mailto:support@oxygenupdater.com">е-пошта</a> или на нашиот <a href="https://discord.gg/5TXdhKJ">Discord сервер</a>.</string>
+	<string name="error_maintenance_retry"><![CDATA[Серверот најверојатно е под рутинска поправка. Обидете се повторно после некое време, или пријавете на нашата <a href="mailto:support@oxygenupdater.com">е-пошта</a> или на нашиот <a href="https://discord.gg/5TXdhKJ">Discord сервер</a>.]]></string>
 	<string name="error_reload">Освежи</string>
 
 	<string name="error_unable_to_rate_app">Не можете да ја оцените апликацијата, бидејќи вашиот уред нема Google Play Store.</string>
@@ -326,7 +275,6 @@
 	<string name="purchase_error_after_payment">Купувањето на верзијата без реклами беше неуспешно, заради внатрешна грешка. Ве молиме обидете се повторно за неколку минути. Доколку веќе сте платиле, ве молиме исконтактирајте ја поддршката на Google Play за помош.</string>
 
 	<!-- Other strings-->
-	<string name="error">Грешка</string>
 	<string name="icon">Икона</string>
 	<string name="loading">Вчитување…</string>
 	<string name="processing">Процесирање…</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools" tools:keep="@string/install_guide_page_*_*">
-	<string name="device_chooser_error_title">Kon lijst van ondersteunde apparaten niet ophalen.</string>
-
+<resources>
 	<!-- Update information strings-->
 	<string name="enable">Inschakelen</string>
 	<string name="update_information_description_not_available">Er is geen officiële informatie beschikbaar over nieuwe functies die deze update toevoegt. Doorgaans bevatten deze updates oplossingen voor bugs, prestatie verbeteringen, en/of kritieke beveiligingsupdates voor jouw apparaat.</string>
@@ -13,11 +11,10 @@
 	<string name="update_information_banner_server">Tik hier om belangrijke mededelingen te bekijken</string>
 	<string name="update_information_banner_advanced_mode_tip">Je hebt het \"%1$s\" update pad geselecteerd. Zet geavanceerde modus aan als je van plan bent om naar dit update pad over te stappen.</string>
 	<string name="update_information_header_advanced_mode_hint">Geavanceerde modus is ingeschakeld</string>
-	<string name="update_information_header_advanced_mode_helper">Omdat je geavanceerde modus hebt ingeschakeld, kan je de laatste ZIP voor \"%1$s\" downloaden.\n\nJe kan geavanceerde modus uitzetten in de instellingen.</string>
-	<string name="update_information_different_version_changelog_notice">Je bekijkt een changelog van de laatste update in het \"%1$s\" update pad. Als je deze update wilde installeren, dan moet je geavanceerde modus aanzetten (in instellingen).\n\nEchter, als je wenst de changelog van de huidig-geïnstalleerde versie wil zien, zul je terug moeten gaan naar de correcte update methode.</string>
-	<string name="update_information_last_checked_on">Voor het laatst gecontroleerd om: %1$s</string>
+	<string name="update_information_header_advanced_mode_helper">Omdat je geavanceerde modus hebt ingeschakeld, kan je de laatste ZIP voor \"%1$s\" downloaden. Je kan geavanceerde modus uitzetten in de instellingen.</string>
+	<string name="update_information_different_version_changelog_notice_base">Let op: deze lijst met veranderingen is voor de laatst beschikbare versie (%1$s) in de \"%2$s\" update methode</string>
+	<string name="update_information_different_version_changelog_notice_advanced">. Als je van plan bent om deze update te installeren, moet je "Geavanceerde modus" aanzetten in de instellingen.</string>
 	<string name="update_information_no_update_data_available">Er is geen update-informatie beschikbaar</string>
-	<string name="update_information_oxygen_os_version">OxygenOS %1$s</string>
 	<string name="update_information_system_is_up_to_date">Je apparaat is volledig bijgewerkt</string>
 	<string name="update_information_unknown_update_name">Naamloze update voor %1$s</string>
 	<string name="update_information_view_update_information">Bekijk update-informatie</string>
@@ -44,7 +41,7 @@
 	<string name="download_complete_notification">Tik om te beginnen met de installatie</string>
 
 	<string name="download_error">Fout tijdens downloaden</string>
-	<string name="download_error_close">SLUITEN</string>
+	<string name="download_error_close">Sluiten</string>
 	<string name="download_error_corrupt">De gedownloade update is beschadigd! Probeer de update opnieuw te downloaden.</string>
 	<string name="download_error_server">Er deed zich tijdens het downloaden van de update een serverfout voor. Controleer je verbinding en probeer de update opnieuw te downloaden.</string>
 	<string name="download_error_internal">Er deed zich helaas een technische fout voor tijdens het downloaden van de update. Probeer hem opnieuw te downloaden. Als dit zich blijft voordoen, neem dan contact op met de ontwikkelaar van deze app.</string>
@@ -52,8 +49,8 @@
 
 Als je hier meer over wil weten, voel je dan vrij om ons te contacteren via <a href="mailto:support@oxygenupdater.com">email</a> of op onze <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
 	<string name="download_error_could_not_move_temp_file">Het bestand is gedownload, maar kon niet worden verplaatst naar de juiste map. Open een bestandsbeheerder, navigeer naar \"%1$s\" en verplaats handmatig het bestand naar de meest bovenliggende map van het interne geheugen.</string>
-	<string name="download_error_retry">OPNIEUW</string>
-	<string name="download_error_resume">HERVATTEN</string>
+	<string name="download_error_retry">Opnieuw</string>
+	<string name="download_error_resume">Hervatten</string>
 	<string name="download_error_storage">Er is onvoldoende opslagruimte op je apparaat beschikbaar om de update te downloaden. Verwijder één of meer bestanden en probeer het opnieuw te downloaden.</string>
 
 	<string name="download_failed">Downloaden mislukt</string>
@@ -90,9 +87,7 @@ Als je hier meer over wil weten, voel je dan vrij om ons te contacteren via <a h
 	<string name="summary_please_wait">Even geduld…</string>
 	<string name="summary_update_method">Selecteer eerst een apparaat</string>
 	<!-- TODO: check the following translation -->
-	<string name="summary_important_notifications_disabled">Sommige belangrijke meldingen zijn uitgeschakeld: \"%1$s\"</string>
-	<string name="summary_theme">Selecteer een thema</string>
-	<string name="summary_language">Taal instellen</string>
+	<string name="summary_important_notifications_disabled">Sommige belangrijke meldingen zijn uitgeschakeld:</string>
 	<string name="summary_privacy_policy">Bekijk online</string>
 	<string name="summary_rate_app">Geef een 5-sterren review</string>
 
@@ -121,17 +116,23 @@ Als je hier meer over wil weten, voel je dan vrij om ons te contacteren via <a h
 	<string name="settings_contribute_label">Verbeter de app voor anderen</string>
 	<string name="settings_device">Apparaat</string>
 	<string name="settings_entered_incorrectly">Fout tijdens opslaan van je instellingen. Ga terug en stel je instellingen opnieuw in.</string>
-	<string name="settings_explanation_incremental_full_update">"Een incrementele update kan worden geïnstalleerd vanaf elke versie (behalve als je een ontgrendelde bootloader hebt; dan moet je altijd voor de update-methode \"volledige update\" kiezen).\n\nEen bèta-versie kan te allen tijde geïnstalleerd worden. Ook als je een stabiele versie draait. Om te wisselen van de stabiele versies naar bèta's, moet je \"geavanceerde modus\" aanzetten in de instellingen. Bij bèta's werken incrementele en volledige updates op dezelfde manier als bij de stabiele versie."</string>
 
 	<string name="settings_push_from_server">Informatie- en waarschuwingsberichten</string>
 
 	<string name="settings_saving">Je instellingen zijn nog niet opgeslagen. Als dit te lang duurt, controleer je of je een werkende internetverbinding hebt en open je de app opnieuw.</string>
 
 	<string name="settings_advanced_mode">Geavanceerde modus</string>
-	<string name="settings_advanced_mode_explanation">De geavanceerde modus verbergt de melding \"Uw systeem is up-to-date\". Hierdoor kun je updates altijd downloaden en installeren, ook als ze mogelijk niet voor je apparaat geschikt zijn.\n\nDit kan handig zijn wanneer:\n&#8226; Je van een reguliere versie naar een bètaversie wil updaten\n&#8226; Je van een bètaversie terug wil naar een stabiele versie (vereist herstel naar fabrieksinstellingen)\n&#8226; Je dezelfde versie als die je nu hebt opnieuw wil installeren.</string>
+	<string name="settings_advanced_mode_explanation">"Normaal gesproken toont de app je updates op basis van je huidige OS-versie. Met de geavanceerde modus wordt altijd de laatste beschikbare update getoond, ongeacht de compatibiliteit van het apparaat of de versie.
+
+Dit kan handig zijn als je:"</string>
+	<string name="settings_advanced_mode_uses">"&#8226; De nieuwste versie opnieuw wilt downloaden, ook al draai je deze al
+&#8226; Overschakelen naar een andere update track"</string>
+	<string name="settings_advanced_mode_caption">"De geavanceerde modus kan alleen nodig zijn in de bovenstaande situaties. Je dient dit alleen in te schakelen als je weet wat je doet."</string>
 
 	<string name="settings_update_method">Update-methode</string>
 	<string name="settings_upload_logs">Deel gebruiksgegevens en logs</string>
+	<string name="settings_ad_privacy">GDPR-advertentie toestemming</string>
+	<string name="settings_ad_privacy_subtitle">"Voor gebruikers in EEA/UK"</string>
 
 	<!-- FAQ strings -->
 	<string name="faq">Veelgestelde vragen</string>
@@ -139,66 +140,27 @@ Als je hier meer over wil weten, voel je dan vrij om ons te contacteren via <a h
 
 
 	<!-- First-time setup screen strings -->
-	<string name="onboarding">Welkom</string>
+	<string name="onboarding">Instellingen</string>
 	<string name="onboarding_finished_button">Start de app</string>
 
-	<string name="onboarding_page_1_title">Welkom bij Oxygen Updater!</string>
-	<string name="onboarding_page_1_text">Met deze app kun je:\n\n&#8226; De nieuwste Android-updates voor jouw OxygenOS-apparaat als eerste downloaden\n\n&#8226; Een \"rooted\" apparaat eenvoudig bijwerken\n\n&#8226; Bekijken wat er nieuw is in de systeemsoftware die je momenteel gebruikt\n\n&#8226; Nieuwsberichten over OxygenOS en OnePlus lezen\n\nVeeg naar links om verder te gaan.</string>
+	<string name="onboarding_app_uses">Met deze app kun je:\n\n&#8226; De nieuwste Android-updates voor jouw OxygenOS-apparaat als eerste downloaden\n&#8226; Een \"rooted\" apparaat eenvoudig bijwerken\n&#8226; Bekijken wat er nieuw is in de systeemsoftware die je momenteel gebruikt\n&#8226; Nieuwsberichten over OxygenOS en OnePlus lezen</string>
 
-	<string name="onboarding_page_1_caption">Dit is geen officiële app van OnePlus. Het gebruik van deze app is volledig op eigen risico. Noch de ontwikkelaar, noch OnePlus zijn verantwoordelijk voor jouw acties, inclusief eventuele schade die is voortgekomen uit het gebruik van deze app.\n\nDoor deze app te gebruiken, ga je hiermee akkoord.</string>
+	<string name="onboarding_disclaimer">Dit is geen officiële app van OnePlus. Het gebruik van deze app is volledig op eigen risico. Noch de ontwikkelaar, noch OnePlus zijn verantwoordelijk voor jouw acties, inclusief eventuele schade die is voortgekomen uit het gebruik van deze app. Door deze app te gebruiken, ga je hiermee akkoord.</string>
 
-	<string name="onboarding_page_2_title">Kies je apparaat</string>
-	<string name="onboarding_page_2_caption">Meestal is jouw apparaat al in de lijst hierboven geselecteerd. Is dit niet zo? Kies dan hierboven je apparaat.</string>
+	<string name="onboarding_device_chooser_title">Kies je apparaat</string>
+	<string name="onboarding_device_chooser_caption">Meestal is jouw apparaat al in de lijst hierboven geselecteerd. Is dit niet zo? Kies dan hierboven je apparaat.</string>
 
-	<string name="onboarding_page_3_title">Kies je update-methode</string>
-	<string name="onboarding_page_3_caption">De incrementele update is meestal de juiste keuze, omdat deze snellere en kleinere downloads biedt.\n\nAls je een \"rooted\" apparaat gebruikt, kun je deze update-methode echter niet kiezen. Kies in dat geval voor "Volledige Update".\n\nGebruik je een bèta-versie van OxygenOS? Kies dan voor de Open Bèta.</string>
+	<string name="onboarding_method_chooser_title">Kies je update-methode</string>
+	<string name="onboarding_method_chooser_caption">De incrementele update is meestal de juiste keuze, omdat deze snellere en kleinere downloads biedt. Als je een \"rooted\" apparaat gebruikt, kun je deze update-methode echter niet kiezen. Kies in dat geval voor "Volledige Update". Gebruik je een bèta-versie van OxygenOS? Kies dan voor de Open Bèta.</string>
 
-	<string name="onboarding_page_4_title">Klaar!</string>
-	<string name="onboarding_page_4_text">Veel plezier met het gebruik van Oxygen Updater!\n\nJe kunt je instellingen altijd veranderen: tik op de drie puntjes rechtsbovenin, en tik vervolgens op \"Instellingen\".</string>
+	<string name="onboarding_caption">Veel plezier met het gebruik van Oxygen Updater!</string>
 
 	<!-- Automatic install strings -->
 	<string name="install">Installeren</string>
 
 	<!-- Install guide strings -->
-	<string name="install_guide_no_root">Installeer de update volgens de in de installatiehandleiding omschreven instructies.</string>
 	<string name="install_guide">Installatiehandleiding</string>
-	<string name="install_guide_subtitle">Installatie - %1$d van %2$d</string>
-	<string name="install_guide_close_button">Sluit de installatiehandleiding</string>
-	<string name="install_guide_tip">&#8226; Het is aanbevolen om alle stappen op te schrijven, omdat je apparaat tijdens de installatie van de update opnieuw moet worden opgestart.</string>
-
-	<string name="install_guide_page_1_title">Download de update</string>
-	<string name="install_guide_page_1_text">&#8226;Druk op de Download-knop om het downloaden te starten. De downloadvoortgang zal in de app verschijnen, en verschijnt ook als melding in je notificatiescherm.\n\n&#8226; Als het downloaden is voltooid, zie je een melding met de tekst \"Download voltooid\".\nAls er tijdens het downloaden een fout is opgetreden, probeer je de update opnieuw te downloaden. Indien dit niet werkt, controleer dan je internetverbinding, of neem contact op met de ontwikkelaar. Dit kun je via de Google Play Store doen onder het tabblad \"Mijn apps\".</string>
-
-	<string name="install_guide_page_2_title">Installatie voorbereiden</string>
-	<string name="install_guide_page_2_text">"Opmerking: de installatie van de update vindt plaats in een speciaal scherm in de standaard Systeemupdates-sectie van je apparaat. Als bij het openen van de Systeemupdates-sectie (toevallig) een systeemupdate in verschijnt, installeer deze dan eerst. Open vervolgens Oxygen Updater om te controleren of je écht up-to-date bent.
-
-Instructies:
-&#8226; Sluit Oxygen Updater af door op de home-knop te drukken.
-
-&#8226; Open de Instellingen-app. Deze staat als het goed is in je lijst met apps.
-
-&#8226; Scrol omlaag totdat je de Systeemupdates optie ziet. Tik daarop."</string>
-
-	<string name="install_guide_page_3_title">Installeer de update</string>
-	<string name="install_guide_page_3_text">"Nadat je de Systeemupdates-sectie hebt geopend, is het tijd om de update te gaan installeren.
-
-&#8226; In de Systeemupdates-sectie, tik je op het symbool met het tandwiel, wat rechtsboven staat.
-
-&#8226; Tik nu op \"Lokale upgrade\". Er verschijnt een bestandskeuze-scherm.
-
-&#8226; In dit scherm tik je op het updatebestand wat je zojuist met Oxygen Updater hebt gedownload. De naam hiervan begint meestal met \"%1$sOxygen\".
-
-&#8226; Tik op \"Nu bijwerken\"
-
-&#8226; De installatie verloopt hierna automatisch."</string>
-
-	<string name="install_guide_page_4_title">Wacht totdat de installatie is voltooid</string>
-	<string name="install_guide_page_4_text">"&#8226; Je apparaat gaat de update nu installeren en laat een voortgangsbalk zien. Wacht tot het installeren klaar is. Dit kan enkele minuten tot een kwartier duren.
-
-&#8226; Na de installatie start het apparaat opnieuw op om de update af te ronden."</string>
-
-	<string name="install_guide_page_5_title">Klaar. Geniet van je nieuwe OxygenOS-versie!</string>
-	<string name="install_guide_page_5_text">&#8226; Nadat het optimaliseren van je apps is voltooid, is de update succesvol geinstalleerd. Je kunt dit controleren door de nieuwe systeemversie te bekijken:\n\n&#8226; Ga naar Instellingen, tik op \"Over de telefoon\" en bekijk de OxygenOS-versie.\n\n&#8226; Als je deze app geweldig vindt, geef dan 5 sterren in de Google Play Store!</string>
+	<string name="install_guide_download_instructions">&#8226; Druk op de Download-knop om het downloaden te starten. De downloadvoortgang zal in de app verschijnen, en verschijnt ook als melding in je notificatiescherm.\n&#8226; Als het downloaden is voltooid, zie je een melding met de tekst \"Download voltooid\". Als er tijdens het downloaden een fout is opgetreden, probeer je de update opnieuw te downloaden. Indien dit niet werkt, controleer dan je internetverbinding, of neem contact op met de ontwikkelaar. Dit kun je via de Google Play Store doen onder het tabblad \"Mijn apps\".</string>
 
 	<!-- Device information strings -->
 	<string name="device_information_supported_oxygen_os">Je apparaat wordt ondersteund.</string>
@@ -215,7 +177,7 @@ Instructies:
 	<string name="device_information_image_description">Afbeelding van jouw apparaat</string>
 	<string name="device_information_incremental_os_version">Incrementele OS-versie</string>
 	<string name="device_information_os_version">Android-versie</string>
-	<string name="device_information_oxygen_os_version">OxygenOS-versie</string>
+	<string name="device_information_oxygen_os_version">OS-versie</string>
 	<string name="device_information_oxygen_os_ota_version">OTA-versie</string>
 	<string name="device_information_patch_level_version">Datum beveiligingsupdate</string>
 	<string name="device_information_serial_number">Serienummer</string>
@@ -234,6 +196,8 @@ Instructies:
 	<string name="about_email_button_text">Email</string>
 
 	<!-- LocalNotifications strings -->
+	<string name="notification_permission_title">"Blijf op de hoogte"</string>
+	<string name="notification_permission_text">"Sta de app toe om je op de hoogte te stellen van OTA-updates, nieuws, de downloadstatus en andere belangrijke zaken. Je kunt je voorkeuren later aanpassen in de instellingen van de app."</string>
 	<string name="notification_new_device_text">De %1$s wordt nu ondersteund. Open de app om dit apparaat te kiezen.</string>
 	<string name="notification_no_notification_support">Installeer Google Play Services of werk deze bij om pushnotificaties te kunnen ontvangen.</string>
 	<string name="notification_version">%1$s is nu beschikbaar voor de %2$s!</string>
@@ -259,23 +223,9 @@ Instructies:
 	<string name="general_notification_channel_description">Algemene notificaties welke niet passen in andere categorieën</string>
 	<string name="url_submitted_notification_channel_description">Ontvang een melding wanneer je succesvol OTA URL\'s hebt ingediend bij ons team.\nJe kunt je afmelden voor het automatisch indienen van URL\'s in de instellingen van de app.</string>
 
-	<!-- Help strings -->
-	<string name="help">Help</string>
-	<string name="help_updating_your_device_title">Je apparaat bijwerken</string>
-	<string name="help_updating_your_device_text">Als je de app opent, kun je zien of er een systeemupdate beschikbaar is. Als deze beschikbaar is, kun je hem installeren.\nOm de update te installeren, tik je als eerste op de \"Download\"-knop (onder de update-omschrijving).\n\nAls het downloaden klaar is, opent het installatiescherm. Heb je de app inmiddels verlaten of verschijnt het installatiescherm niet? Tik dan op de \"Installatie\"-knop, die nu naast de \"Download\"-knop staat.\n\nHet installatiescherm zal als eerste op root-toegang controleren. Als je root-toegang hebt, moet je de app hiervoor toestemming geven. Heb je geen root-toegang of weet je niet wat dit is? Volg dan de instructies voor Handmatige Installatie.\n\nAutomatische installatie:\nJe hoeft alleen de installatie-opties te bekijken en waar nodig aan te passen. Selecteer eventueel een root-bestand om te (her)installeren en je bent er helemaal klaar voor. Tik op \"Start installatie\" om de installatie te starten.\n\nHandmatige installatie:\nEr verschijnt een installatiehandleiding op het scherm. Deze bevat de instructies voor het handmatig installeren van de update. Omdat je je apparaat tijdens het installeren moet uitschakelen, is het aanbevolen om alle instructies eerst te noteren en ze vervolgens pas uit te voeren.</string>
-	<string name="help_reading_news_title">Nieuwsberichten lezen</string>
-	<string name="help_reading_news_text">Nieuwsberichten worden aan de linkerkant van het update-scherm getoond. De meest recente berichten staan bovenaan de lijst. Tik op een item om het te bekijken, en tik op het pijltje naar links (of de terug-toets) om terug te keren naar het nieuwsoverzicht.</string>
-	<string name="help_device_information_title">Specificaties apparaat bekijken</string>
-	<string name="help_device_information_text">Je kunt sommige specificaties van je apparaat bekijken, deze staan aan de rechterkant van het update-scherm. Dit is met name handig bij het doen van een support-aanvraag, omdat de ontwikkelaar deze gegevens meestal nodig heeft om je te helpen met het oplossen van je probleem.</string>
-	<string name="help_change_settings_title">Instellingen wijzigen</string>
-	<string name="help_change_settings_text">Je kunt een aantal instellingen wijzigen door op de drie puntjes rechtsboven te tikken, en vervolgens voor Instellingen te kiezen.\nJe kunt de volgende instellingen wijzigen:\n\n• Apparaat en update-methode\n• Pushnotificaties\n• Notificaties in de app\n• Privacy-instellingen (delen van logbestanden).\n\nOm notificatie-voorkeuren en privacy-instellignen te wijzigen, zet je de schuifjes aan of uit. Om een apparaat of update-methode te kiezen, gebruik je de dropdown-menu\'s. Zijn deze velden niet zichtbaar? Controleer dan eerst je verbinding en open het Instellingen-scherm opnieuw.</string>
-
 	<!-- News strings -->
 	<string name="news">Nieuws</string>
-	<string name="news_date_published">Laatste update: %1$s</string>
-	<string name="news_empty">Dit artikel bevat geen inhoud.</string>
-	<string name="news_load_network_error">Kan artikel niet laden. Controleer je verbinding en tik op \"OPNIEUW\" om het artikel opnieuw te laden.</string>
-	<string name="news_load_id_error"><![CDATA[Kan artikel niet openen vanaf een geldige URL: %1$s. Bekijk de URL of meld dit aan ons via <a href="mailto:support@oxygenupdater.com">email</a> of op onze <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
+	<string name="news_load_network_error">Kan artikel niet laden. Controleer je verbinding en tik op \"Opnieuw\" om het artikel opnieuw te laden.</string>
 	<string name="news_unread_count_1">Je hebt %1$d ongelezen nieuwsartikelen. Tik hier om ze te tonen.</string>
 	<string name="news_unread_count_2">Je hebt %1$d ongelezen nieuwsartikelen. Tik hier om alle artikelen te tonen.</string>
 	<string name="news_mark_read">Markeer als gelezen</string>
@@ -301,12 +251,10 @@ Instructies:
 	<string name="error_app_outdated">Oeps!</string>
 	<string name="error_app_outdated_message">Deze versie van de app is wel erg oud. Het is tijd om hem bij te werken! Dit kan door hieronder op \"Play Store\" te tikken. Tik vervolgens in de Google Play Store op \"Bijwerken\".</string>
 	<string name="error_app_requires_network_connection">Geen verbinding</string>
-	<string name="error_app_requires_network_connection_message">Kan geen verbinding met de server maken. Zorg ervoor dat je een werkende internetverbinding hebt. De app zal nu afsluiten.</string>
 	<string name="error_google_play_button_text">Google Play Store</string>
-	<string name="error_no_internet_connection">Geen verbinding.</string>
 	<string name="error_maintenance">Serveronderhoud</string>
 	<string name="error_maintenance_message">Een ogenblik geduld. De server zal zeer snel weer beschikbaar zijn.</string>
-	<string name="error_maintenance_retry">Het kan zijn dat de server niet beschikbaar is vanwege onderhoud. Probeer het later opnieuw, of meld het aan ons via <a href="mailto:support@oxygenupdater.com">email</a> dan wel via onze <a href="https://discord.gg/5TXdhKJ">Discord server</a></string>
+	<string name="error_maintenance_retry"><![CDATA[Het kan zijn dat de server niet beschikbaar is vanwege onderhoud. Probeer het later opnieuw, of meld het aan ons via <a href="mailto:support@oxygenupdater.com">email</a> dan wel via onze <a href="https://discord.gg/5TXdhKJ">Discord server</a>]]></string>
 	<string name="error_reload">Opnieuw laden</string>
 	<string name="error_unable_to_rate_app">Je kunt de app niet beoordelen, omdat je de Google Play Store niet hebt geïnstalleerd.</string>
 
@@ -330,7 +278,6 @@ Instructies:
 	<string name="purchase_error_after_payment">De aankoop van de reclamevrije versie is mislukt, omdat er een onverwachte fout is opgetreden. Probeer het over enkele ogenblikken opnieuw. Als je al hebt betaald, neem dan a.u.b. contact op met de Google Play Store helpdesk.</string>
 
 	<!-- Other strings -->
-	<string name="error">Fout</string>
 	<string name="icon">Icoon</string>
 	<string name="loading">Laden…</string>
 	<string name="processing">Verwerken…</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="device_chooser_error_title">Kunne ikke hente en liste over støttede enheter</string>
-
 	<!-- Update information strings-->
 	<string name="enable">Aktiver</string>
 	<string name="update_information_description_not_available">Det er ingen offisiell informasjon om de nye funksjonene denne oppdateringen gir. Vanligvis gir en slik oppdatering feilrettinger, ytelsesforbedringer og / eller kritiske sikkerhetsoppdateringer for enheten din.</string>
@@ -12,13 +10,12 @@
 	<string name="update_information_error_title">Kunne ikke hente den siste oppdateringsdatainformasjonen</string>
 	<string name="update_information_banner_server">Trykk her for å se viktige merknader</string>
 	<!-- TODO: translate these two strings below -->
-	<string name="update_information_banner_advanced_mode_tip">You\'ve selected the \"%1$s\" update track. Enable advanced mode if you plan to switch to this update track.</string>
+	<string name="update_information_banner_advanced_mode_tip">You\'ve selected the \"%1$s\" update method. Enable advanced mode if you plan to switch to this update method.</string>
 	<string name="update_information_header_advanced_mode_hint">Advanced mode is enabled</string>
-	<string name="update_information_header_advanced_mode_helper">Siden du har aktivert avansert modus, kan du laste ned den nyeste ZIP for \"%1$s\".\n\nDu kan slå avansert modus av fra innstillinger</string>
-	<string name="update_information_different_version_changelog_notice">Du ser på et endringslogg for den siste oppdateringen i oppdateringssporet \"%1$s\" Hvis du har tenkt å installere denne oppdateringen, må du aktivere avansert modus på første (i innstillingene). \n\nMen, hvis du ønsker å se endringsloggen for den installerte versjonen i stedet, du \'ll trenger å bytte tilbake til riktig oppdateringsmetode.</string>
-	<string name="update_information_last_checked_on">Sist sjekket: %1$s</string>
+	<string name="update_information_header_advanced_mode_helper">Siden du har aktivert avansert modus, kan du laste ned den nyeste ZIP for \"%1$s\". Du kan slå avansert modus av fra innstillinger</string>
+	<string name="update_information_different_version_changelog_notice_base">Merk: Denne endringsloggen gjelder den siste tilgjengelige versjonen (%1$s) i oppdateringsmetoden \"%2$s\"</string>
+	<string name="update_information_different_version_changelog_notice_advanced">. Hvis du vil installere denne oppdateringen, må du aktivere "Avansert modus" i innstillingene.</string>
 	<string name="update_information_no_update_data_available">Ingen oppdateringsinformasjon er tilgjengelig</string>
-	<string name="update_information_oxygen_os_version">OxygenOS %1$s</string>
 	<string name="update_information_system_is_up_to_date">Systemet ditt er oppdatert</string>
 	<string name="update_information_unknown_update_name">Ukjent oppdatering for %1$s</string>
 	<string name="update_information_view_update_information">Vis oppdateringsinformasjon</string>
@@ -45,7 +42,7 @@
 	<string name="download_complete_notification">Trykk for å starte installasjonen</string>
 
 	<string name="download_error">Nedlastingsfeil</string>
-	<string name="download_error_close">LUKK</string>
+	<string name="download_error_close">Lukk</string>
 	<string name="download_error_corrupt">Den nedlastede oppdateringsfilen er skadet! Prøv å laste ned den igjen.</string>
 	<string name="download_error_server">Det oppsto en serverfeil under nedlasting av oppdateringen. Prøv å laste ned oppdateringen igjen.</string>
 	<string name="download_error_internal">Dessverre skjedde det en teknisk feil under nedlasting av oppdateringen. Prøv å laste den ned igjen. Hvis dette fortsetter å skje, kan du kontakte utvikleren av denne appen for å få hjelp.</string>
@@ -54,8 +51,8 @@
 Hvis du ønsker å vite mer, ta gjerne kontakt med oss enten via <a href="mailto:support@oxygenupdater.com">e-post</a>eller på vår <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
 	<string name="download_error_could_not_move_temp_file">Filen er lastet ned, men kan ikke flyttes til riktig katalog. Åpne en filbehandling, naviger til \"%1$s\" og flytt filen manuelt til den øverste katalogen med intern lagring</string>
 
-	<string name="download_error_retry">PRØV IGJEN</string>
-	<string name="download_error_resume">GJENOPPTA</string>
+	<string name="download_error_retry">Prøv igjen</string>
+	<string name="download_error_resume">Gjenoppta</string>
 	<string name="download_error_storage">Det er ikke nok lagringsplass tilgjengelig på enheten din for å laste ned oppdateringen. Fjern noen filer og prøv å laste dem ned igjen.</string>
 
 	<string name="download_failed">Nedlasting mislyktes</string>
@@ -92,9 +89,7 @@ Hvis du ønsker å vite mer, ta gjerne kontakt med oss enten via <a href="mailto
 	<string name="summary_please_wait">Vennligst vent…</string>
 	<string name="summary_update_method">Velg en enhet først</string>
 	<!-- TODO: check the following translation -->
-	<string name="summary_important_notifications_disabled">Noen viktige varsler er deaktivert: \"%1$s\"</string>
-	<string name="summary_theme">Sett tema</string>
-	<string name="summary_language">Sett språk</string>
+	<string name="summary_important_notifications_disabled">Noen viktige varsler er deaktivert:</string>
 	<string name="summary_privacy_policy">Se på nettet</string>
 	<string name="summary_rate_app">Legg igjen en 5-stjerners anmeldelse</string>
 
@@ -120,84 +115,52 @@ spare batteri</string>
 	<string name="settings_buy_button_buy">Kjøp (%1$s)</string>
 	<string name="settings_buy_button_bought">Kjøpt</string>
 	<string name="settings_buy_button_not_possible">Utilgjengelig</string>
-	<string name="settings_buy_ad_free_label">Oppgrader til Ad-Free</string>
+	<string name="settings_buy_ad_free_label">Oppgrader til ad-free</string>
 
 	<string name="settings_contribute_label">Hjelp til å forbedre appen</string>
 
 	<string name="settings_device">Enhet</string>
 	<string name="settings_entered_incorrectly">Feil ved lagring av innstillingene. Gå tilbake og velg din enhet / oppdateringsmetode igjen.</string>
-	<string name="settings_explanation_incremental_full_update">En inkrementell oppdatering kan installeres fra hvilken som helst versjon (bortsett fra hvis du har en ulåst oppstartslaster; du bør alltid velge full oppdatering som oppdateringsmetode). \n\n En betaoppdatering av OxygenOS kan alltid installeres, også når du er på en stabil versjon. For å bytte fra stabil til beta, må du aktivere den avanserte modusen i innstillingene. For betas fungerer de fulle og trinnvise oppdateringsmetodene på samme måte som på stabile versjoner.</string>
 
 	<string name="settings_push_from_server">Informasjons- og advarselsmeldinger</string>
 
 	<string name="settings_saving">Innstillingene dine lagres fremdeles. Hvis dette tar for lang tid: Kontroller nettverkstilkoblingen din, avslutt appen og start den på nytt.</string>
 
 	<string name="settings_advanced_mode">Avansert modus</string>
-	<string name="settings_advanced_mode_explanation">Avansert modus skjuler meldingen \"Systemet ditt er oppdatert\", slik at du kan laste ned og installere alle oppdateringer, selv om de kanskje ikke er kompatible med enheten din. \n\ nDette kan være nyttig når: \n- Oppdatering fra en vanlig versjon til en betaversjon \n- Gjenoppretter fra en betaversjon til den vanlige versjonen (ikke glem å tilbakestille enheten til fabrikken) \n- Installere den nåværende systemversjonen på nytt.</string>
+	<string name="settings_advanced_mode_explanation">"Normalt viser appen deg oppdateringer basert på den aktuelle versjonen av operativsystemet. Med avansert modus vises alltid den siste tilgjengelige oppdateringen, uavhengig av enhetens/versjonens kompatibilitet.
+
+Dette kan være nyttig hvis du vil:"</string>
+	<string name="settings_advanced_mode_uses">"&#8226; Laste ned den nyeste versjonen på nytt selv om du allerede bruker den
+&#8226; Bytt til et annet oppdateringsspor"</string>
+	<string name="settings_advanced_mode_caption">"Avansert modus er kanskje bare nødvendig i de ovennevnte situasjonene. Du bør ikke aktivere den med mindre du vet hva du gjør."</string>
 
 	<string name="settings_update_method">Oppdateringsmetode</string>
 	<string name="settings_upload_logs">Del bruksdata og logger</string>
+	<string name="settings_ad_privacy">GDPR-samtykke til annonsering</string>
+	<string name="settings_ad_privacy_subtitle">"For brukere i EØS/Storbritannia"</string>
 
 	<!-- FAQ strings -->
 	<string name="faq">FAQ</string>
 	<string name="faq_menu_item">FAQ</string>
 
 	<!-- First-time onboarding strings -->
-	<string name="onboarding">Velkommen</string>
+	<string name="onboarding">Oppsett</string>
 	<string name="onboarding_finished_button">Start app</string>
 
-	<string name="onboarding_page_1_title">Velkommen til Oxygen Updater!</string>
-	<string name="onboarding_page_1_text">Denne appen lar deg få raskere tilgang til:\n\n&#8226; de siste Android-oppdateringene for din OxygenOS-drevne enhet \n\n&#8226; Oppdater enkelt en forankret enhet \n\n&#8226; Se hva som er nytt i systemprogramvaren du bruker for øyeblikket \n\n&#8226; Les de siste nyhetene om OnePlus og OxygenOS\n\nSveip til venstre for å fortsette.</string>
-	<string name="onboarding_page_1_caption">Dette er ikke en offisiell OnePlus-applikasjon. Bruk av denne appen er helt på egen risiko. Verken OnePlus eller utvikleren av appen er ansvarlig for handlingene dine, inkludert skader forårsaket av bruk av denne appen.\n\nGjennom å bruke denne appen, godtar du vilkårene og betingelsene som nevnt ovenfor.</string>
-	<string name="onboarding_page_2_title">Velg enheten din</string>
-	<string name="onboarding_page_2_caption">Enheten er vanligvis allerede valgt ovenfor. Hvis ikke, velg enheten ovenfor.</string>
-	<string name="onboarding_page_3_title">Velg din oppdateringsmetode</string>
-	<string name="onboarding_page_3_caption">Vanligvis er den inkrementelle oppdateringen det riktige valget her, fordi den tilbyr mye raskere og mindre nedlastinger.\n\nMen den er ikke kompatibel med forankrede enheter. Hvis du har en forankret enhet, velger du Full oppdatering.\n\nHvis du har en beta-versjon av OxygenOS, velger du (en av) Open Beta-oppdateringsmetoden (e).</string>
-	<string name="onboarding_page_4_title">Du er klar til å dra!</string>
-	<string name="onboarding_page_4_text">Gled deg over å bruke denne appen!\n\nDu kan alltid endre innstillingene senere. For å gjøre det: Trykk på de tre prikkene i øverste høyre hjørne, og trykk på \"Innstillinger\".</string>
+	<string name="onboarding_app_uses">Denne appen lar deg få raskere tilgang til:\n\n&#8226; de siste Android-oppdateringene for din OxygenOS-drevne enhet\n&#8226; Oppdater enkelt en forankret enhet\n&#8226; Se hva som er nytt i systemprogramvaren du bruker for øyeblikket\n&#8226; Les de siste nyhetene om OnePlus og OxygenOS</string>
+	<string name="onboarding_disclaimer">Dette er ikke en offisiell OnePlus-applikasjon. Bruk av denne appen er helt på egen risiko. Verken OnePlus eller utvikleren av appen er ansvarlig for handlingene dine, inkludert skader forårsaket av bruk av denne appen. Gjennom å bruke denne appen, godtar du vilkårene og betingelsene som nevnt ovenfor.</string>
+	<string name="onboarding_device_chooser_title">Velg enheten din</string>
+	<string name="onboarding_device_chooser_caption">Enheten er vanligvis allerede valgt ovenfor. Hvis ikke, velg enheten ovenfor.</string>
+	<string name="onboarding_method_chooser_title">Velg din oppdateringsmetode</string>
+	<string name="onboarding_method_chooser_caption">Vanligvis er den inkrementelle oppdateringen det riktige valget her, fordi den tilbyr mye raskere og mindre nedlastinger. Men den er ikke kompatibel med forankrede enheter. Hvis du har en forankret enhet, velger du Full oppdatering. Hvis du har en beta-versjon av OxygenOS, velger du (en av) Open Beta-oppdateringsmetoden (e).</string>
+	<string name="onboarding_caption">Gled deg over å bruke denne appen! Du kan alltid endre innstillingene senere.</string>
 
 	<!-- Automatic install strings -->
 	<string name="install">Installer</string>
 
 	<!-- Install guide strings -->
-	<string name="install_guide_no_root">Installer oppdateringen i henhold til instruksjonene som vises i installasjonsveiledningen.381</string>
 	<string name="install_guide">Installasjonsgveiledning</string>
-	<string name="install_guide_subtitle">Installasjonsveiledning - %1$d av %2$d</string>
-	<string name="install_guide_tip">&#8226; Det anbefales å skrive ned alle trinnene, ettersom du må slå av enheten din under installasjonen av oppdateringen.</string>
-
-	<string name="install_guide_page_1_title">Last ned oppdateringen</string>
-	<string name="install_guide_page_1_text">&#8226; Trykk på Last ned-knappen for å begynne å laste ned oppdateringen.\n\n&#8226; Nedlastingsfremdriften vises i appen, og som et varsel på varslingsskjermen.\n\n&#8226; Når nedlastingen er fullført, ser du et varsel med teksten \"Nedlasting ferdig\".\nHvis det oppstår en nedlastingsfeil, åpner du appen og prøver å laste ned oppdateringen på nytt. Hvis dette ikke fungerer, må du sørge for at du har en fungerende forbindelse. Kontakt ellers utvikleren av appen. Du kan gjøre dette ved å gå til \"Mine apper\" -delen i Google Play Butikk.</string>
-
-	<string name="install_guide_page_2_title">Forbered for installasjon</string>
-	<string name="install_guide_page_2_text">"Merk: Installasjonen av oppdateringen skjer fra en spesiell side i standard systemoppdateringer på enheten. Hvis det av en eller annen grunn vises en systemoppdatering når du åpner denne delen, kan du også velge å installere den oppdateringen først. Etterpå åpner du Oxygen Updater igjen for å se om du er helt oppdatert.
-
-Bruksanvisning:
-&#8226; Lukk Oxygen Updater ved å trykke på startknappen.
-
-&#8226; Åpne Innstillinger-appen. Den skal være plassert i appskuffen din.
-
-&#8226; Rull ned til du ser Systemoppdateringer. Trykk på den."</string>
-
-	<string name="install_guide_page_3_title">Installer oppdateringen</string>
-	<string name="install_guide_page_3_text">"Nå som du er i Systemoppdateringer-appen, er det på tide å installere oppdateringen.
-
-&#8226; Innenfor systemoppdateringer, klikker du på tannhjulikonet øverst til høyre
-
-&#8226; Velg nå \"Lokal oppgradering\". Et filvalgskjermbilde skal vises.
-
-&#8226; På denne skjermen trykker du på oppdateringsfilen du lastet ned ved hjelp av Oxygen Updater. Navnet skal begynne med \"%1$sOxygen\".
-
-&#8226; Trykk på \"Oppgrader nå\". Installasjonen skal starte automatisk."</string>
-
-	<string name="install_guide_page_4_title">Vent til installasjonen er fullført</string>
-	<string name="install_guide_page_4_text">"&#8226; Telefonen vil nå installere oppdateringen og viser en fremdriftslinje. Vent til installasjonen er ferdig. Installasjonen kan ta alt fra noen minutter til 15 minutter.
-
-&#8226; Etterpå starter telefonen på nytt for å fullføre oppdateringen."</string>
-
-	<string name="install_guide_page_5_title">Ferdig. Kos deg med den nye OxygenOS-versjonen!</string>
-	<string name="install_guide_page_5_text">&#8226; Etter at enheten din er ferdig med å optimalisere appene, har oppdateringen blitt installert. \nFor å bekrefte dette kan du sjekke den nåværende versjonen av systemet ditt som følgende:\n\n&#8226; Gå til Innstillinger, trykk på \"Om telefonen\", og sjekk OxygenOS-versjonen.\n\n&#8226; Hvis du liker denne appen, gi den 5 stjerner på Google Play!</string>
-
-	<string name="install_guide_close_button">Lukk installasjonsveiledningen</string>
+	<string name="install_guide_download_instructions">&#8226; Trykk på Last ned-knappen for å begynne å laste ned oppdateringen.\n&#8226; Nedlastingsfremdriften vises i appen, og som et varsel på varslingsskjermen.\n&#8226; Når nedlastingen er fullført, ser du et varsel med teksten \"Nedlasting ferdig\". Hvis det oppstår en nedlastingsfeil, åpner du appen og prøver å laste ned oppdateringen på nytt. Hvis dette ikke fungerer, må du sørge for at du har en fungerende forbindelse. Kontakt ellers utvikleren av appen. Du kan gjøre dette ved å gå til \"Mine apper\" -delen i Google Play Butikk.</string>
 
 	<!-- Device information strings -->
 	<string name="device_information_supported_oxygen_os">Enheten din støttes</string>
@@ -214,7 +177,7 @@ Bruksanvisning:
 	<string name="device_information_image_description">Enhetsbilde</string>
 	<string name="device_information_incremental_os_version">Inkrementell OS-versjon:</string>
 	<string name="device_information_os_version">Android-versjon:</string>
-	<string name="device_information_oxygen_os_version">OxygenOS-versjon:</string>
+	<string name="device_information_oxygen_os_version">OS-versjon:</string>
 	<string name="device_information_oxygen_os_ota_version">OTA-versjon:</string>
 	<string name="device_information_patch_level_version">Sikkerhetsoppdateringsdato:</string>
 	<string name="device_information_serial_number">Serienummer:</string>
@@ -234,6 +197,8 @@ Bruksanvisning:
 	<string name="about_email_button_text">E-post</string>
 
 	<!-- LocalNotifications strings -->
+	<string name="notification_permission_title">"Hold deg varslet"</string>
+	<string name="notification_permission_text">"Tillat at appen varsler deg om OTA-oppdateringer, nyheter, pågående nedlastingsstatus og andre viktige ting. Du kan finjustere innstillingene dine senere i appens innstillinger."</string>
 	<string name="notification_new_device_text">%1$s støttes nå. Åpne appen for å velge denne enheten.</string>
 	<string name="notification_no_notification_support">Installer eller oppdater Google Play-tjenester for å aktivere push-varsler.</string>
 	<string name="notification_version">%1$s er nå tilgjengelig for %2$s!</string>
@@ -260,23 +225,9 @@ Bruksanvisning:
 	<string name="general_notification_channel_description">General notifications that don\'t fit into other categories</string>
 	<string name="url_submitted_notification_channel_description">Bli varslet når du har sendt inn OTA-URL-er til teamet vårt.\nDu kan velge bort automatisk innsending av nettadresser i appens innstillinger.</string>
 
-	<!-- Help strings -->
-	<string name="help">Hjelp</string>
-	<string name="help_updating_your_device_title">Oppdaterer enheten</string>
-	<string name="help_updating_your_device_text">Når du åpner appen, ser du om en systemoppdatering er tilgjengelig. Hvis en oppdatering er tilgjengelig, kan du installere den.\n\nFor å starte installasjonen, trykk på \"Last ned\" -knappen (under oppdateringsbeskrivelsen) for å starte nedlastingen. Når nedlastingen er ferdig, vises installasjonsskjermen. Hvis du forlot appen eller skjermen ikke dukket opp, trykker du på \"Installer\" -knappen, som nå vises ved siden av \"Last ned\" -knappen.\n\nInstallasjonsskjermen vil først sjekke om du har en rotfestet enhet. Hvis du har en rotenhet, gi rottillatelse når du blir spurt, og velg hvordan du vil installere oppdateringen. Ellers følger du instruksjonene for manuell installasjon.\n\nAutomatisk installasjon:\nDu må bare velge installasjonsalternativer. Standardinnstillingene anbefales, bortsett fra at du må spesifisere rotpakken som må installeres. Velg en rotpakke (zip-fil) ved å bruke den blå mappeknappen og trykk på \"Start installasjon\" for å starte installasjonen.\n\nManuell installasjon:\nDu vil se en installasjonsveiledning på skjermen. Skriv instruksjonene ned og utfør dem som angitt for å installere oppdateringen.</string>
-	<string name="help_reading_news_title">Les siste nytt</string>
-	<string name="help_reading_news_text">Nyheter vises til venstre for oppdateringsskjermen. De siste elementene vises på toppen. Bare trykk på et element for å lese det.\nTrykk på bakpilen eller trykk på tilbake-tasten for å gå tilbake til nyhetsskjermen.</string>
-	<string name="help_device_information_title">Viser informasjon om enheten din</string>
-	<string name="help_device_information_text">Du kan vise noen av spesifikasjonene på enheten din ved hjelp av skjermen til høyre for oppdateringsskjermen. Dette er nyttig når du lager en støtteforespørsel, der du kan bli bedt om noen av spesifikasjonene til enheten din.</string>
-	<string name="help_change_settings_title">Endring av innstillinger</string>
-	<string name="help_change_settings_text">Du kan endre innstillingene dine ved å trykke på de tre punktene øverst til høyre, ved å trykke på Innstillinger.\nDu kan endre følgende innstillinger:\n\n• Enhets- og oppdateringsmetode\n• Push-varsler\n• I appvarsler\n• Personverninnstillinger (loggopplasting).\n\nBruk bryterne for å slå på og av varslings- / personverninnstillinger. Velg en enhet og / eller oppdateringsmetode ved hjelp av rullegardinmenyene som vises over bryterne. Rullegardinmenyer ikke synlige? Kontroller Internett-tilkoblingen din og åpne innstillingsskjermen igjen.</string>
-
 	<!-- News strings -->
 	<string name="news">Nyheter</string>
-	<string name="news_date_published">Siste oppdatering: %1$s</string>
-	<string name="news_empty">Denne artikkelen har ikke noe innhold.</string>
-	<string name="news_load_network_error">Kunne ikke åpne artikkelen. Sjekk forbindelsen din og trykk på \"PRØV PÅ NYTT\" -knappen for å åpne artikkelen.</string>
-	<string name="news_load_id_error"><![CDATA[Kunne ikke åpne artikkelen fra en ugyldig URL: %1$s. Sjekk URL-en eller rapporter dette til oss via <a href="mailto:support@oxygenupdater.com">e-post</a> eller på vår <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
+	<string name="news_load_network_error">Kunne ikke åpne artikkelen. Sjekk forbindelsen din og trykk på \"Prøv på nytt\" -knappen for å åpne artikkelen.</string>
 	<string name="news_unread_count_1">Du har %1$d uleste nyhetsartikler. Trykk her for å se dem.</string>
 	<string name="news_unread_count_2">Du har %1$d uleste nyhetsartikler. Trykk for å vise alle artiklene.</string>
 	<!-- TODO: translate these 2 strings below -->
@@ -303,12 +254,10 @@ Bruksanvisning:
 	<string name="error_app_outdated">Å nei!</string>
 	<string name="error_app_outdated_message">Denne versjonen av appen er utdatert. Det er på tide å oppdatere det! Trykk på \"Google Play\" nedenfor. Trykk på \"Oppdater\" i Google Play.</string>
 	<string name="error_app_requires_network_connection">Ingen forbindelse</string>
-	<string name="error_app_requires_network_connection_message">Kunne ikke koble til serveren. Forsikre deg om at du har en fungerende forbindelse. Appen lukkes nå.</string>
 	<string name="error_google_play_button_text">Google Play</string>
-	<string name="error_no_internet_connection">Ingen forbindelse.</string>
 	<string name="error_maintenance">Server vedlikehold</string>
 	<string name="error_maintenance_message">Vennligst vent. Serveren vil være tilgjengelig veldig snart.</string>
-	<string name="error_maintenance_retry">Serveren kan være nede for vedlikehold. Prøv igjen etter en stund, eller rapporter det til oss enten via <a href="mailto:support@oxygenupdater.com">e-post</a> eller på vår <a href="https://discord.gg/5TXdhKJ">Discord server</a>.</string>
+	<string name="error_maintenance_retry"><![CDATA[Serveren kan være nede for vedlikehold. Prøv igjen etter en stund, eller rapporter det til oss enten via <a href="mailto:support@oxygenupdater.com">e-post</a> eller på vår <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
 	<string name="error_reload">Last inn på nytt</string>
 
 	<string name="error_unable_to_rate_app">Du kan ikke rangere appen, fordi Google Play Store mangler på enheten din.</string>
@@ -334,7 +283,6 @@ Bruksanvisning:
 	<string name="purchase_error_after_payment">Kjøpet av den annonsefrie versjonen mislyktes fordi det oppstod en intern feil. Vennligst prøv igjen om noen minutter. Hvis du allerede har betalt, kan du kontakte brukerstøtten for Google Play for å få hjelp.</string>
 
 	<!-- Other strings-->
-	<string name="error">Feil</string>
 	<string name="icon">Ikon</string>
 	<string name="loading">Laster inn…</string>
 	<string name="processing">Behandler…</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools" tools:keep="@string/install_guide_page_*_*">
-	<!-- TODO: translate this string below -->
-	<string name="device_chooser_error_title">Couldn\'t retrieve list of supported devices</string>
-
+<resources>
 	<!-- Update information strings-->
 	<!-- TODO: translate this string below -->
 	<string name="enable">Włączyć</string>
@@ -16,13 +13,12 @@
 	<!-- TODO: translate these 6 strings below -->
 	<string name="update_information_error_title">Couldn\'t retrieve latest update data information</string>
 	<string name="update_information_banner_server">Tap here to view important notices</string>
-	<string name="update_information_banner_advanced_mode_tip">You\'ve selected the \"%1$s\" update track. Enable tryb zaawansowany if you plan to switch to this update track.</string>
+	<string name="update_information_banner_advanced_mode_tip">You\'ve selected the \"%1$s\" update method. Enable tryb zaawansowany if you plan to switch to this update method.</string>
 	<string name="update_information_header_advanced_mode_hint">Tryb zaawansowany jest włączony</string>
-	<string name="update_information_header_advanced_mode_helper">Since you\'ve enabled tryb zaawansowany, you can download the latest ZIP for \"%1$s\".\n\nYou can turn tryb zaawansowany off from settings.</string>
-	<string name="update_information_different_version_changelog_notice">You\'re viewing a changelog for the latest update in the \"%1$s\" upgrade track. If you intend to install this update, you must turn tryb zaawansowany on first (in settings).\n\nHowever, if you wish to see the changelog for the currently installed version instead, you\'ll need to switch back to the correct update method.</string>
-	<string name="update_information_last_checked_on">Ostatnio sprawdzono: %1$s</string>
+	<string name="update_information_header_advanced_mode_helper">Since you\'ve enabled tryb zaawansowany, you can download the latest ZIP for \"%1$s\". You can turn tryb zaawansowany off from settings.</string>
+	<string name="update_information_different_version_changelog_notice_base">Uwaga: ten dziennik zmian dotyczy najnowszej dostępnej wersji (%1$s) w metodzie aktualizacji \"%2$s\"</string>
+	<string name="update_information_different_version_changelog_notice_advanced">. Jeśli chcesz zainstalować tę aktualizację, musisz włączyć "Tryb zaawansowany" w ustawieniach.</string>
 	<string name="update_information_no_update_data_available">Brak dostępnych informacji o aktualizacjach</string>
-	<string name="update_information_oxygen_os_version">OxygenOS %1$s</string>
 	<string name="update_information_system_is_up_to_date">Twój system jest zaktualizowany do najnowszej wersji</string>
 	<string name="update_information_unknown_update_name">Nieznana aktualizacja dla %1$s</string>
 	<string name="update_information_view_update_information">Sprawdź informacje o aktualizacji</string>
@@ -50,7 +46,7 @@
 	<string name="download_complete_notification">Naciśnij, aby rozpocząć instalację</string>
 
 	<string name="download_error">Błąd pobierania</string>
-	<string name="download_error_close">ZAMKNIJ</string>
+	<string name="download_error_close">Zamknij</string>
 	<string name="download_error_corrupt">Pobrany plik jest uszkodzony ! Spróbuj pobrać go ponownie.</string>
 
 	<string name="download_error_server">Wystąpił bląd serwera podczas pobierania aktualizacji. Spróbuj pobrać aktualizację ponownie.</string>
@@ -61,8 +57,8 @@
 If you\'d like to know more, feel free to contact us either via <a href="mailto:support@oxygenupdater.com">email</a> or on our <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
 	<string name="download_error_could_not_move_temp_file">The file has been downloaded, but couldn\'t be moved to the correct directory. Open a file manager, navigate to \"%1$s\" and manually move the file to the topmost directory of internal storage.</string>
 
-	<string name="download_error_retry">PONÓW</string>
-	<string name="download_error_resume">WZNÓW</string>
+	<string name="download_error_retry">Ponów</string>
+	<string name="download_error_resume">Wznów</string>
 	<string name="download_error_storage">Na twoim urządzeniu nie jest wystarczająco wolnego miejsca na pobranie aktualizacji. Proszę usunąć jakieś pliki i spróbować pobrać ją ponownie.</string>
 
 	<string name="download_failed">Pobieranie nieudane</string>
@@ -99,9 +95,7 @@ If you\'d like to know more, feel free to contact us either via <a href="mailto:
 	<string name="summary_please_wait">Proszę czekać…</string>
 	<string name="summary_update_method">Wybierz najpierw urządzenie</string>
 	<!-- TODO: check the following translation -->
-	<string name="summary_important_notifications_disabled">Niektóre ważne powiadomienia są wyłączone: \"%1$s\"</string>
-	<string name="summary_theme">Wybierz motyw</string>
-	<string name="summary_language">Ustaw język</string>
+	<string name="summary_important_notifications_disabled">Niektóre ważne powiadomienia są wyłączone:</string>
 	<string name="summary_privacy_policy">Zobacz online</string>
 	<string name="summary_rate_app">Zostaw recenzję na 5 gwiazdek</string>
 
@@ -136,81 +130,46 @@ If you\'d like to know more, feel free to contact us either via <a href="mailto:
 
 	<string name="settings_device">Urządzenie</string>
 	<string name="settings_entered_incorrectly">Błąd podczas zapisywania twoich ustawień. Proszę cofnąć się i wybrać swoje urządzenie / metodą aktualizacji ponownie.</string>
-	<string name="settings_explanation_incremental_full_update">Częściowa aktualizacja może zostać zainstalowana z dowolnej wersji (chyba że masz odblokowany bootloader, wtedy musisz wybrać pełną aktualizację jako metodę aktualizacji). Wersja beta OxygenOS zawsze może zostać zainstalowana, nawet jeśli jesteś na stabilnej wersji. Aby przejść na wersję beta ze stabilnej, należy włączyć tryb zaawansowany w ustawieniach. Dla wersji beta, pełne i częściowe metody aktualizacji działają tak samo jak na wersjach stabilnych.</string>
 
 	<string name="settings_push_from_server">Informacje oraz ostrzeżenia</string>
 
 	<string name="settings_saving">Twoje ustawienia są nadal zapisywane. Jeśli to trwa zbyt długo: Sprawdź połączenie z internetem, wyjdź z aplikacji i spróbuj ponownie.</string>
 
 	<string name="settings_advanced_mode">Tryb zaawansowany</string>
-	<string name="settings_advanced_mode_explanation"> Tryb zaawansowany ukryje informację \"Twój system jest zaktualizowany\", pozwalając ci na pobieranie i instalowanie wszystkich aktualizacji, nawet jeśli nie są one kompatybilne z twoim urządzeniem.\n\nTo może być przydatne kiedy:\n&#8226; Aktualizowanie z wersji stabilnej na betę\n&#8226; Powracanie na wersję stabilną z wersji beta. (nie zapomnij o przywróceniu ustawień fabrycznych w urządzeniu)\n&#8226; Przeinstalowanie twojej aktualnej wersji systemu.</string>
+	<string name="settings_advanced_mode_explanation">"Zwykle aplikacja wyświetla aktualizacje na podstawie bieżącej wersji systemu operacyjnego. W trybie zaawansowanym najnowsza dostępna aktualizacja będzie zawsze wyświetlana niezależnie od zgodności urządzenia/wersji.
+
+Może to być przydatne, jeśli chcesz:"</string>
+	<string name="settings_advanced_mode_uses">"&#8226; Ponownie pobrać najnowszą wersję, nawet jeśli już na niej jesteś
+&#8226; Przełączyć się na inną ścieżkę aktualizacji"</string>
+	<string name="settings_advanced_mode_caption">"Tryb zaawansowany może być potrzebny tylko w powyższych sytuacjach. Nie powinieneś go włączać, jeśli nie wiesz, co robisz."</string>
 
 	<string name="settings_update_method">Metoda aktualizacji</string>
 	<string name="settings_upload_logs">Udostępnij dane użytkowania oraz logi</string>
+	<string name="settings_ad_privacy">Zgoda na reklamy RODO</string>
+	<string name="settings_ad_privacy_subtitle">"Dla użytkowników w EOG/Wielkiej Brytanii"</string>
 
 	<!-- FAQ strings -->
 	<string name="faq">FAQ</string>
 	<string name="faq_menu_item">FAQ</string>
 
 	<!-- First-time setup strings -->
-	<string name="onboarding">Witaj</string>
+	<string name="onboarding">Konfiguruj</string>
 	<string name="onboarding_finished_button">włącz aplikację</string>
 
-	<string name="onboarding_page_1_title">Witaj w Oxygen Updater!</string>
-	<string name="onboarding_page_1_text">Ta aplikacji pozwoli ci na:\n\n&#8226; Szybszy dostęp do aktualizacji na twoim urządzeniu z OxygenOS\n\n&#8226; Łatwa aktualizacja na urządzeniu z rootem\n\n&#8226; Zobaczyć nowości w systemie którego obecnie używasz\n\n&#8226; Przeczytać najnowsze wiadomości o OnePlus i aktualizacjach OxygenOS\n\nPrzesuń w lewo aby kontynuować.</string>
-	<string name="onboarding_page_1_caption">To nie jest oficjalna aplikacja OnePlusa. Ponosisz pełne ryzyko za używanie tej aplikacji.Ani OnePlus ani deweloper tej aplikacji nie są odpowiedzialni za twoje akcje, włączając wszelkie akcje mogące wyrządzić szkody przez tę aplikację.\n\nUżywając tej apliakcji, zgadzasz się na zasady i warunki opisane powyżej.</string>
-	<string name="onboarding_page_2_title">Wybierz swoje urządzenie</string>
-	<string name="onboarding_page_2_caption">Twoje urządzenie jest zazwyczaj wybrane powyżej. Jeśli nie, wybierz twoje urządzenie wyżej.</string>
-	<string name="onboarding_page_3_title">Wybierz metodę aktualizacji</string>
-	<string name="onboarding_page_3_caption">Zazwyczaj, częściowa aktualizacja jest tutaj właściwym wyborem, ponieważ umożliwia znacznie szybsze pobieranie oraz mniejszy rozmiar pliku.\n\nAczkolwiek, ta opcja nie jest kompatybilna ze zrootowanymi urządzeniami. Jeśli masz zrootowane urzadzenie, wybierz Pełną aktualizację.\n\nJeśli masz wersję beta OxygenOS, wybierz (jedną z) metod aktualizacji wersji Open Beta.</string>
-	<string name="onboarding_page_4_title">Jesteś gotowy do uruchomienia aplikacji!</string>
-	<string name="onboarding_page_4_text">Miłego korzystania z tej aplikacji !\n\nMożesz zawsze zmienić swoje ustawienia w dowolnym momencie. Aby to zrobić: Naciśnij trzy kropki w prawym górnym rogu oraz wybierz \"Ustawienia\".</string>
+	<string name="onboarding_app_uses">Ta aplikacji pozwoli ci na:\n\n&#8226; Szybszy dostęp do aktualizacji na twoim urządzeniu z OxygenOS\n&#8226; Łatwa aktualizacja na urządzeniu z rootem\n&#8226; Zobaczyć nowości w systemie którego obecnie używasz\n&#8226; Przeczytać najnowsze wiadomości o OnePlus i aktualizacjach OxygenOS</string>
+	<string name="onboarding_disclaimer">To nie jest oficjalna aplikacja OnePlusa. Ponosisz pełne ryzyko za używanie tej aplikacji.Ani OnePlus ani deweloper tej aplikacji nie są odpowiedzialni za twoje akcje, włączając wszelkie akcje mogące wyrządzić szkody przez tę aplikację. Używając tej apliakcji, zgadzasz się na zasady i warunki opisane powyżej.</string>
+	<string name="onboarding_device_chooser_title">Wybierz swoje urządzenie</string>
+	<string name="onboarding_device_chooser_caption">Twoje urządzenie jest zazwyczaj wybrane powyżej. Jeśli nie, wybierz twoje urządzenie wyżej.</string>
+	<string name="onboarding_method_chooser_title">Wybierz metodę aktualizacji</string>
+	<string name="onboarding_method_chooser_caption">Zazwyczaj, częściowa aktualizacja jest tutaj właściwym wyborem, ponieważ umożliwia znacznie szybsze pobieranie oraz mniejszy rozmiar pliku. Aczkolwiek, ta opcja nie jest kompatybilna ze zrootowanymi urządzeniami. Jeśli masz zrootowane urzadzenie, wybierz Pełną aktualizację. Jeśli masz wersję beta OxygenOS, wybierz (jedną z) metod aktualizacji wersji Open Beta.</string>
+	<string name="onboarding_caption">Miłego korzystania z tej aplikacji! Możesz zawsze zmienić swoje ustawienia w dowolnym momencie.</string>
 
 	<!-- Automatic install strings -->
 	<string name="install">Instaluj</string>
 
 	<!-- Install guide strings -->
-	<string name="install_guide_no_root">Install the update according to the instructions shown in the install guide.</string>
 	<string name="install_guide">Poradnik instalacji</string>
-	<string name="install_guide_subtitle">Poradnik instalacji - %1$d z %2$d</string>
-	<string name="install_guide_tip">&#8226; Rekomendowane jest napisanie tych wszystkich kroków, gdyż będziesz musiał wyłączyć urządzenie podczas instalacji aktualizacji.</string>
-
-	<string name="install_guide_page_1_title">Pobierz aktualizację</string>
-	<string name="install_guide_page_1_text">&#8226; Naciśnij przycisk Pobierz aby zacząć pobieranie aktualizacji.\n\n&#8226; Postęp pobierania pojawi się w aplikacji, jako powiadomienie na ekranie.\n\n&#8226; Kiedy pobieranie się zakończy, zobaczysz powiadomienie z komunikatem \"Pobieranie zakończone\".\nJeśli nastąpił błąd pobierania, otwórz aplikację i spróbuj pobrać aktualizację ponownie. Jeśli to nie zadziała, upewnij się że masz połączenie z internetem. W przeciwnym wypadku, skontaktuj się z deweloperem aplikacji. Możesz to zrobić odwiedzając sekcję \"Moje aplikacje\" w Sklepie Play.</string>
-
-	<!-- TODO: translate these 2 strings below -->
-	<string name="install_guide_page_2_title">Prepare for installation</string>
-	<string name="install_guide_page_2_text">"Note: The installation of the update takes place from a special page of the standard System Updates section of your device. If, for some reason, a system update appears when opening this section, you may also opt to install that update first. Afterwards, open Oxygen Updater again to see if you're completely up-to-date.
-
-Instructions:
-&#8226; Close Oxygen Updater by pressing the home button.
-
-&#8226; Open the Settings app. It should be located in your app drawer.
-
-&#8226; Scroll down until you see System updates. Tap on it."</string>
-
-	<!-- TODO: translate these 2 strings below -->
-	<string name="install_guide_page_3_title">Install the update</string>
-	<string name="install_guide_page_3_text">"Now that you're in the System Updates app, it's time to install the update.
-
-&#8226; Within the System Updates section, tap the gear icon in the top right
-
-&#8226; Now, select \"Local upgrade\". A file selection screen should appear.
-
-&#8226; In this screen, tap on the update file you downloaded using Oxygen Updater. Its name should start with \"%1$sOxygen\".
-
-&#8226; Tap on \"Upgrade Now\". The installation should start automatically."</string>
-
-	<!-- TODO: translate these 2 strings below -->
-	<string name="install_guide_page_4_title">Wait until the installation completes</string>
-	<string name="install_guide_page_4_text">"&#8226; The phone will now install the update and displays a progress bar. Please wait until the installation has finished. Installation may take anywhere from a few minutes up to 15 minutes.
-
-&#8226; Afterwards, your phone will restart to complete the update."</string>
-
-	<string name="install_guide_page_5_title">Zrobione. Ciesz się z nowej wersji OxygenOS !</string>
-	<string name="install_guide_page_5_text">&#8226; Gdy twoje urządzenie zakończy optymalizację aplikacji, aktualizacja zostanie pomyślnie zainstalowana.\nAby to zweryfikować, możesz sprawdzić obecną wersję systemu następująco:\n\n&#8226; Idź do Ustawień, naciśnij na \"Informacje o telefonie\" oraz sprawdź wersję OxygenOS.\n\n&#8226; Jeśli lubisz tę aplikację, daj jej 5 gwiazdek w Sklepie Play !</string>
-
-	<string name="install_guide_close_button">Zamknij poradnik instalacji</string>
+	<string name="install_guide_download_instructions">&#8226; Naciśnij przycisk Pobierz aby zacząć pobieranie aktualizacji.\n&#8226; Postęp pobierania pojawi się w aplikacji, jako powiadomienie na ekranie.\n&#8226; Kiedy pobieranie się zakończy, zobaczysz powiadomienie z komunikatem \"Pobieranie zakończone\". Jeśli nastąpił błąd pobierania, otwórz aplikację i spróbuj pobrać aktualizację ponownie. Jeśli to nie zadziała, upewnij się że masz połączenie z internetem. W przeciwnym wypadku, skontaktuj się z deweloperem aplikacji. Możesz to zrobić odwiedzając sekcję \"Moje aplikacje\" w Sklepie Play.</string>
 
 	<!-- Device information strings -->
 	<!-- TODO: translate these 4 strings below -->
@@ -228,7 +187,7 @@ Instructions:
 	<string name="device_information_image_description">Obraz urządzenia</string>
 	<string name="device_information_incremental_os_version">Częściowa wersja systemu operacyjnego</string>
 	<string name="device_information_os_version">Wersja Androida</string>
-	<string name="device_information_oxygen_os_version">Wersja OxygenOS</string>
+	<string name="device_information_oxygen_os_version">Wersja OS</string>
 	<string name="device_information_oxygen_os_ota_version">Wersja OTA</string>
 	<string name="device_information_patch_level_version">Poziom poprawek zabezpieczeń Android</string>
 	<string name="device_information_serial_number">Numer seryjny</string>
@@ -242,13 +201,15 @@ Instructions:
 	<string name="about_support">If you\'d like to support us, you can either buy the ad-free unlock (app\'s settings), or check our <a href="https://patreon.com/oxygenupdater">Patreon page</a>.</string>
 	<string name="about_background_story_header">Background story</string>
 	<string name="about_background_story">Ta aplikacja została oryginalnie napisana przez Arjana Vleka jako kontynuacja innej z jego aplikacji, <a href="https://cyanogenupdatetracker.com/">Cyanogen Update Tracker</a> (Ma ona podobną funkcjonalność dla urządzeń z CyanogenOS).\n\nPo upływie 4 lat, w czerwcu 2019, Arjan zdecydował się odejść od swoich obu projektów i przekazał własność aplikacji dla drużyny deweloperów pochodzących z róznych krajów Podjęli się oni rozwijania aplikacji i ponoszenia odpowiedzialności, dostarczając społeczności niesamowitą pomoc w szybszym uzyskiwaniu aktualizacji OnePlus.\nMożesz znaleźć więcej informacji o ogłoszeniu <a href="https://oxygenupdater.com/article/81/">here</a>.\n\n14 sierpnia 2019 roku została wydana nowa aktualizacja od nowych właścicieli, wprowadzając wiele nowości chociażby takie jak ciemny motyw oraz kompletne przeprojektowanie wyglądu.\n\nAby uzyskać więcej informacji o zespole, sprawdź <a href="https://oxygenupdater.com/team/">tę stronę</a>.</string>
-	<string name="about_third_party_app_notice">Proszę pamiętaj, to nie jest oficjalna aplikacja OnePlusa.\nNazwa OnePlus, logo OnePlus oraz OxygenOS są własnością OnePlusa.\n Logo Android, Google oraz Google Play są zarejestrowanymi znakami towarowymi Google Inc.\nTa aplikacja używa danych od OnePlusa oraz ich firmy-matki Oppo aby pokazuwać informacje o aktualizacjach.</string>
+	<string name="about_third_party_app_notice">Proszę pamiętaj, to nie jest oficjalna aplikacja OnePlusa.\nNazwa OnePlus, logo OnePlus oraz OxygenOS są własnością OnePlusa.\nLogo Android, Google oraz Google Play są zarejestrowanymi znakami towarowymi Google Inc.\nTa aplikacja używa danych od OnePlusa oraz ich firmy-matki Oppo aby pokazuwać informacje o aktualizacjach.</string>
 	<string name="about_rate_button_text">Oceń</string>
 	<!-- TODO: translate this string below -->
 	<string name="about_website_button_text">Stronie internetowej</string>
 	<string name="about_email_button_text">Email</string>
 
 	<!-- LocalNotifications strings -->
+	<string name="notification_permission_title">"Otrzymywanie powiadomień"</string>
+	<string name="notification_permission_text">"Zezwól aplikacji na powiadamianie Cię o aktualizacjach OTA, nowościach, bieżącym stanie pobierania i innych ważnych rzeczach. Możesz dostosować swoje preferencje później w ustawieniach aplikacji."</string>
 	<string name="notification_new_device_text">%1$s jest teraz wspierany . Otwórz aplikację aby wybrać to urządzenie.</string>
 	<string name="notification_no_notification_support">Zainstaluj albo zaktualizuj Usługi Google Play aby odblokować powiadomienia push.</string>
 	<string name="notification_version">%1$s jest teraz dostępne dla %2$s!</string>
@@ -275,24 +236,10 @@ Instructions:
 	<string name="general_notification_channel_description">General notifications that don\'t fit into other categories</string>
 	<string name="url_submitted_notification_channel_description">Otrzymuj powiadomienia o pomyślnym przesłaniu adresów URL OTA do naszego zespołu.\nMożesz zrezygnować z automatycznego przesyłania adresów URL w ustawieniach aplikacji.</string>
 
-	<!-- Help strings -->
-	<string name="help">Pomoc</string>
-	<string name="help_updating_your_device_title">Aktualizowanie twoje urządzenia</string>
-	<string name="help_updating_your_device_text">Podczas otwierania aplikacji, zobaczysz czy jest dostępna aktualizacja systemu. Jeśli aktualizacja jest dostępna, możesz ją zainstalować.\n\nAby rozpocząć instalację, naciśnij przycisk \"Download\" (pod opisem aktualizacji) aby rozpocząć pobieranie. Kiedy pobieranie zakończyło się, powinien się pojawić ekran instalacji. Jeśli wyszedłeś z aplikacji albo ekran nie wyskoczył, naciśnij przycisk \"Instaluj\", który jest pokazany obok przycisku \"Pobierz\".\n\nEkran instalacji najpierw sprawdzi, czy twoje urządzenie jest zrootowane. Jeśli posiadasz zrootowane urządzenie, przyznaj uprawnienia roota kiedy zostaniesz o nie poproszony oraz wybierz jak zamierasz zainstalować aktualizację. W przeciwnym wypadku, podążaj za instrukcją dla Manualnej instalacji.\n\nAutomatyczna instalacja:\nMusisz tylko wybrać opcje instalacji. Ustawienia domyślne są rekomendowane, chyba że musisz wybrać paczkę z rootem która musi być (prze)instalowana.Wybierz paczkę z rootem (plik ZIP) używając przycisku niebieskiego folderu i naciśnij na \"Rozpocznij instalację\" aby rozpocząć instalację.\n\nManualna instalacja:\nZobaczysz poradnik instalacji na ekranie. Zapisz instrukcje oraz wykonaj je tak jak powinieneś aby zainstalować aktualizację.</string>
-	<string name="help_reading_news_title">Czytanie najnowszych wiadomości</string>
-	<string name="help_reading_news_text">Wiadomości są wyświetlane na lewo od ekranu Aktualizacji. Najnowsze pozycje są pokazane na górze. Po prostu naciśnij na pozycję aby ją przeczytać.\nNaciśnij strzałkę do tyłu albo naciśnij klawisz powrotu aby powrócić do ekranu pozycji wiadomości.</string>
-	<string name="help_device_information_title">Wyświetlanie informacji o twoim urządzeniu</string>
-	<string name="help_device_information_text">Możesz zobaczyć nieco specyfikacji twojego urządzenia używając ekranu na prawo od ekranu Aktualizacji. To jest pomocne, kiedy tworzysz prośbę o pomoc, podczas której możesz zostać poproszony o niektóre elementy specyfikacji urządzenia.</string>
-	<string name="help_change_settings_title">Zmienianie ustawień</string>
-	<string name="help_change_settings_text">Możesz zmienić ustawienia naciskając na trzy kropki w prawym górnym rogu, a następnie na Ustawienia.\nMożesz zmienić następujące ustawienia:\n\n• Urządzenie i metody aktualizacji\n• Powiadomienia push\n• Powiadomienia w aplikacji\n• Ustawienia prywatności (wysyłanie logów).\n\nUżyj przełączników aby włączyć lub wyłączyć powiadomienia/ustawienia prywatności. Wybierz urządzenie i/oraz metodę aktualizacji używając rozwijanego menu pokazanego nad przełącznikami. Rozwijane menu niewidoczne ? Sprawdź połączenie z internetem i otwórz ekran Ustawień ponownie.</string>
-
 	<!-- News strings -->
 	<string name="news">Wiadomości</string>
-	<string name="news_date_published">Ostatnia aktualizacja: %1$s</string>
-	<string name="news_empty">Ten artykuł nie ma treści.</string>
-	<string name="news_load_network_error">Niepowodzenie otwierania artykułu. Sprawdź połączenie z internetem i naciśnij przycisk \'PONÓW PRÓBĘ\' aby otworzyć artykuł.</string>
+	<string name="news_load_network_error">Niepowodzenie otwierania artykułu. Sprawdź połączenie z internetem i naciśnij przycisk \'Ponów próbę\' aby otworzyć artykuł.</string>
 	<!-- TODO: translate this string below -->
-	<string name="news_load_id_error"><![CDATA[Failed to open article from an invalid URL: %1$s. Check the URL or report this to us either via <a href="mailto:support@oxygenupdater.com">email</a> or on our <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
 	<!-- TODO: translate these 2 strings below -->
 	<string name="news_unread_count_1">You have %1$d unread news articles. Tap here to view them.</string>
 	<string name="news_unread_count_2">You have %1$d unread news articles. Tap to show all articles.</string>
@@ -320,13 +267,11 @@ Instructions:
 	<string name="error_app_outdated">O nie !</string>
 	<string name="error_app_outdated_message">Ta wersja aplikacji jest przestarzała. To czas na aktualizację ! Naciśnij na \"Sklep Play\" poniżej. W Sklepie Play, naciśnij na \"Aktualizuj\".</string>
 	<string name="error_app_requires_network_connection">Brak połączenia</string>
-	<string name="error_app_requires_network_connection_message">Niepowodzenia połączenia z serwerem. Proszę upewnij się że masz działające połączenie z internetem. Please make sure you have a working connection. Aplikacja teraz wyjdzie.</string>
 	<string name="error_google_play_button_text">Sklep Play</string>
-	<string name="error_no_internet_connection">Brak połączenia.</string>
 	<string name="error_maintenance">Prace serwerowe</string>
 	<string name="error_maintenance_message">Proszę czekać. Serwer będzie dostępny niedługo.</string>
 	<!-- TODO: translate this string below -->
-	<string name="error_maintenance_retry">The server may be down for maintenance. Try again after some time, or report it to us either via <a href="mailto:support@oxygenupdater.com">email</a> or on our <a href="https://discord.gg/5TXdhKJ">Discord server</a>.</string>
+	<string name="error_maintenance_retry"><![CDATA[The server may be down for maintenance. Try again after some time, or report it to us either via <a href="mailto:support@oxygenupdater.com">email</a> or on our <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
 	<string name="error_reload">Przeładuj</string>
 
 	<string name="error_unable_to_rate_app">Nie możesz ocenić aplikacji, ponieważ nie posiadasz Sklepu Play na swoim urządzeniu.</string>
@@ -355,7 +300,6 @@ Instructions:
 
 	<!-- Other strings-->
 	<!-- TODO: translate this string below -->
-	<string name="error">Błąd</string>
 	<string name="icon">Ikona</string>
 	<string name="loading">Ładowanie…</string>
 	<string name="processing">Przetwarzanie…</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1,23 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="device_chooser_error_title">Não foi possível obter a lista de dispositivos</string>
-
 	<!-- Update information strings-->
 	<string name="enable">Ativar</string>
 	<string name="update_information_description_not_available">Não há informações oficiais sobre os novos recursos que esta atualização oferece. Normalmente, essa atualização fornece correções de bugs, melhorias de desempenho e/ou atualizações críticas de segurança para o seu dispositivo.</string>
 	<string name="update_information_file_name">Nome do arquivo: %1$s</string>
 	<string name="update_information_md5">MD5: %1$s</string>
-	<string name="update_information_download_link">Ocorreu um erro ao fazer o download, você pode usar esse link para realizar o download pelo navegador. Note que poderá ser necessário que você mova o arquivo de "\Downloads\" para o diretório principal do armazenamento. Esse link é o mesmo utilizado pelos servidores da OnePlus para realizar a atualização via OTA link:\n%1$s</string>
+	<string name="update_information_download_link">Ocorreu um erro ao fazer o download, você pode usar esse link para realizar o download pelo navegador. Note que poderá ser necessário que você mova o arquivo de \"Downloads\" para o diretório principal do armazenamento. Esse link é o mesmo utilizado pelos servidores da OnePlus para realizar a atualização via OTA link:\n%1$s</string>
 	<string name="update_information_header">Atualizar</string>
 	<string name="update_information_error_title">Não foi possível recuperar as informações dos dados de atualização mais recentes</string>
 	<string name="update_information_banner_server">Clique aqui para ver avisos importantes</string>
 	<string name="update_information_banner_advanced_mode_tip">Você selecionou \"%1$s\" canal de atualização. Habilite o modo avançado se você deseja mudar de canal.</string>
 	<string name="update_information_header_advanced_mode_hint">Modo avançado está habilitado</string>
-	<string name="update_information_header_advanced_mode_helper">Uma vez que ativou o modo avançado, você pode baixar o ZIP mais recente \"%1$s\".\n\nVocê pode desabilitar o modo avançado nas configurações.</string>
-	<string name="update_information_different_version_changelog_notice">Você está vendo uma nota de atualização do \"%1$s\" canal de atualiazçãi. Se você pretende instalar esta atualização, você deve ativar o modo avançado primeiro (nas configurações).\n\nNo entanto, se você deseja ver a nota de atualização para a versão atualmente instalada, você precisará voltar para o método de atualização correto.</string>
-	<string name="update_information_last_checked_on">Última verificação: %1$s</string>
+	<string name="update_information_header_advanced_mode_helper">Uma vez que ativou o modo avançado, você pode baixar o ZIP mais recente \"%1$s\". Você pode desabilitar o modo avançado nas configurações.</string>
+	<string name="update_information_different_version_changelog_notice_base">Observação: este registro de alterações se refere à versão mais recente disponível (%1$s) no método de atualização \"%2$s\"</string>
+	<string name="update_information_different_version_changelog_notice_advanced">. Se você pretende instalar essa atualização, deve ativar o \"Modo Avançado\" nas configurações.</string>
 	<string name="update_information_no_update_data_available">Nenhuma informação de atualização está disponível</string>
-	<string name="update_information_oxygen_os_version">OxygenOS %1$s</string>
 	<string name="update_information_system_is_up_to_date">Seu sistema está atualizado</string>
 	<string name="update_information_unknown_update_name">Atualização sem nome para %1$s</string>
 	<string name="update_information_view_update_information">Ver informações de atualização</string>
@@ -43,7 +40,7 @@
 	<string name="download_complete_notification">Clique para começar a instalação</string>
 
 	<string name="download_error">Erro no download</string>
-	<string name="download_error_close">FECHAR</string>
+	<string name="download_error_close">Fechar</string>
 	<string name="download_error_corrupt">O arquivo de atualização baixado está danificado! Por favor, tente baixá-lo novamente.</string>
 	<string name="download_error_server">Ocorreu um erro de servidor durante o download da atualização. Por favor, tente baixar a atualização novamente.</string>
 	<string name="download_error_internal">Infelizmente, ocorreu um erro técnico durante o download da atualização. Tente fazer o download novamente. Se isso continuar ocorrendo, entre em contato com o desenvolvedor deste aplicativo para obter assistência.</string>
@@ -52,8 +49,8 @@
 Se você quiser saber mais, sinta-se à vontade para nos contatar via <a href="mailto:support@oxygenupdater.com">email</a> ou pelo nosso <a href="https://discord.gg/5TXdhKJ">servidor do Discord</a>.]]></string>
 	<string name="download_error_could_not_move_temp_file">O arquivo foi baixado, mas não pôde ser movido para o diretório correto. Abra um gerenciador de arquivos, navegue até \"%1$s\" e mova manualmente o arquivo para o diretório principal de armazenamento interno.</string>
 
-	<string name="download_error_retry">TENTAR NOVAMENTE</string>
-	<string name="download_error_resume">RETOMAR</string>
+	<string name="download_error_retry">Tentar novamente</string>
+	<string name="download_error_resume">Retomar</string>
 	<string name="download_error_storage">Não há espaço de armazenamento suficiente disponível em seu dispositivo para baixar a atualização. Remova alguns arquivos e tente baixá-los novamente.</string>
 
 	<string name="download_failed">Erro no download</string>
@@ -90,9 +87,7 @@ Se você quiser saber mais, sinta-se à vontade para nos contatar via <a href="m
 	<string name="summary_please_wait">Por favor aguarde…</string>
 	<string name="summary_update_method">Selecione um dispositivo</string>
 	<!-- TODO: check the following translation -->
-	<string name="summary_important_notifications_disabled">Algumas notificações importantes são desativadas: \"%1$s\"</string>
-	<string name="summary_theme">Definir tema</string>
-	<string name="summary_language">Definir idioma</string>
+	<string name="summary_important_notifications_disabled">Algumas notificações importantes são desativadas:</string>
 	<string name="summary_privacy_policy">Ver on-line</string>
 	<string name="summary_rate_app">Avalie-nos com 5 estrelas</string>
 
@@ -124,78 +119,46 @@ conservar bateria</string>
 
 	<string name="settings_device">Device</string>
 	<string name="settings_entered_incorrectly">Erro ao salvar suas configurações. Volte e selecione seu dispositivo / método de atualização novamente.</string>
-	<string name="settings_explanation_incremental_full_update">Uma atualização incremental pode ser instalada de qualquer versão (exceto se você tiver um bootloader desbloqueado; então você deve sempre escolher a atualização completa como método de atualização).\n\nUma atualização beta do OxygenOS sempre pode ser instalada, se você estiver em uma versão estável. Para mudar de estável para beta, você deve habilitar o modo avançado nas configurações. Para os betas, os métodos de atualização completa e incremental funcionam da mesma maneira que nas versões estáveis.</string>
 
 	<string name="settings_push_from_server">Mensagens informativas e de aviso</string>
 
 	<string name="settings_saving">Suas configurações ainda estão sendo salvas. Se demorar muito: verifique sua conexão de rede, saia do aplicativo e inicie-o novamente.</string>
 
 	<string name="settings_advanced_mode">Modo Avançado</string>
-	<string name="settings_advanced_mode_explanation">O Modo Avançado desabilita a mensagem \"Seu sistema está atualizado\", permitindo que você baixe e instale todas as atualizações, mesmo que elas possam não ser compatíveis com o seu dispositivo.\n\nIsto pode ser útil quando:\n&#8226; Estiver atualizando da versão estável para a beta\n&#8226; Estiver voltando da versão beta para estável (lembre-se de realizar a resturação de fábrica)\n&#8226; Estiver reinstalando sua versão do sistema atual.</string>
+	<string name="settings_advanced_mode_explanation">"Normalmente, o aplicativo mostra as atualizações com base na versão atual do sistema operacional. Com o modo avançado, a última atualização disponível sempre será mostrada, independentemente da compatibilidade de dispositivo/versão.
+
+Isso pode ser útil se você quiser:"</string>
+	<string name="settings_advanced_mode_uses">"&#8226; Baixar novamente a versão mais recente, mesmo que você já esteja usando-a
+&#8226; Mudar para uma faixa de atualização diferente"</string>
+	<string name="settings_advanced_mode_caption">"O modo avançado pode ser necessário somente nas situações acima. Você não deve ativá-lo a menos que saiba o que está fazendo."</string>
 
 	<string name="settings_update_method">Método de atualização</string>
 	<string name="settings_upload_logs">Compartilhar dados e registros de uso</string>
+	<string name="settings_ad_privacy">Consentimento de anúncios do GDPR</string>
+	<string name="settings_ad_privacy_subtitle">"Para usuários no EEE/Reino Unido"</string>
 
 	<!-- FAQ strings -->
 	<string name="faq">FAQ</string>
 	<string name="faq_menu_item">FAQ</string>
 
 	<!-- First-time onboarding strings -->
-	<string name="onboarding">Bem-vindo</string>
+	<string name="onboarding">Configuração</string>
 	<string name="onboarding_finished_button">Iniciar o aplicativo</string>
 
-	<string name="onboarding_page_1_title">Bem-vindo ao Atualizador Oxygen!</string>
-	<string name="onboarding_page_1_text">Este aplicativo vai te possibilitar:\n\n&#8226; Obtenha acesso mais rápido às últimas atualizações do Android para o seu dispositivo com OxygenOS\n\n&#8226; Atualize facilmente um dispositivo com acesso root\n\n&#8226; Veja o que há de novo no software do sistema que você está usando atualmente\n\n&#8226; Leia as última notícias sobre OxygenOS e OnePlus\n\nDeslize para esquerda para continuar.</string>
-	<string name="onboarding_page_1_caption">Este não é um aplicativo oficial OnePlus. O uso deste aplicativo é totalmente por sua própria conta e risco. Nem a OnePlus nem o desenvolvedor do aplicativo são responsáveis por suas ações, incluindo quaisquer danos causados pelo uso deste aplicativo.\n\nAo usar este aplicativo, você concorda com os termos e condições indicados acima.</string>
-	<string name="onboarding_page_2_title">Escolha seu dispositivo</string>
-	<string name="onboarding_page_2_caption">Normalmente, o seu dispositivo já está selecionado acima. Caso contrário, selecione seu dispositivo acima.</string>
-	<string name="onboarding_page_3_title">Escolha o seu método de atualização</string>
-	<string name="onboarding_page_3_caption">Normalmente, a atualização incremental é a escolha certa aqui, porque oferece downloads muito mais rápidos e menores.\n\nNo entanto, não é compatível com dispositivos com acesso root. Se você tiver um dispositivo com acesso root, escolha a atualização completa.\n\nSe você tiver uma versão beta do OxygenOS, escolha (um dos) canais de atualização do Open Beta.</string>
-	<string name="onboarding_page_4_title">Você está pronto para ir!</string>
-	<string name="onboarding_page_4_text">Aprecie este aplicativo!\n\nVocê sempre pode alterar suas configurações mais tarde. Para fazer isso: toque nos três pontos no canto superior direito e toque em\"Configurações\".</string>
+	<string name="onboarding_app_uses">Este aplicativo vai te possibilitar:\n\n&#8226; Obtenha acesso mais rápido às últimas atualizações do Android para o seu dispositivo com OxygenOS\n&#8226; Atualize facilmente um dispositivo com acesso root\n&#8226; Veja o que há de novo no software do sistema que você está usando atualmente\n&#8226; Leia as última notícias sobre OxygenOS e OnePlus</string>
+	<string name="onboarding_disclaimer">Este não é um aplicativo oficial OnePlus. O uso deste aplicativo é totalmente por sua própria conta e risco. Nem a OnePlus nem o desenvolvedor do aplicativo são responsáveis por suas ações, incluindo quaisquer danos causados pelo uso deste aplicativo. Ao usar este aplicativo, você concorda com os termos e condições indicados acima.</string>
+	<string name="onboarding_device_chooser_title">Escolha seu dispositivo</string>
+	<string name="onboarding_device_chooser_caption">Normalmente, o seu dispositivo já está selecionado acima. Caso contrário, selecione seu dispositivo acima.</string>
+	<string name="onboarding_method_chooser_title">Escolha o seu método de atualização</string>
+	<string name="onboarding_method_chooser_caption">Normalmente, a atualização incremental é a escolha certa aqui, porque oferece downloads muito mais rápidos e menores. No entanto, não é compatível com dispositivos com acesso root. Se você tiver um dispositivo com acesso root, escolha a atualização completa. Se você tiver uma versão beta do OxygenOS, escolha (um dos) canais de atualização do Open Beta.</string>
+	<string name="onboarding_caption">Aprecie este aplicativo! Você sempre pode alterar suas configurações mais tarde.</string>
 
 	<!-- Automatic install strings -->
 	<string name="install">Install</string>
 
 	<!-- Install guide strings -->
-	<string name="install_guide_no_root">Instale a atualização de acordo com as instruções mostradas no guia de instalação.</string>
 	<string name="install_guide">Guia de instalação</string>
-	<string name="install_guide_subtitle">Guia de instalação - %1$d de %2$d</string>
-	<string name="install_guide_tip">&#8226; É recomendável anotar todas as etapas, pois você precisará desligar o dispositivo durante a instalação da atualização.</string>
-
-	<string name="install_guide_page_1_title">Baixar a atualização</string>
-	<string name="install_guide_page_1_text">&#8226; Pressione o botão Download para iniciar o download da atualização.\n\n&#8226; O andamento do download aparecerá no aplicativo e como uma notificação na tela de notificações.\n\n&#8226; Quando o download terminar, você verá uma notificação com o texto\"Download finalizado\".\nSe ocorrer um erro de download, abra o aplicativo e tente baixar a atualização novamente. Se isso não funcionar, verifique se a conexão de rede está funcionando. Caso contrário, entre em contato com o desenvolvedor do aplicativo. Você pode fazer isso visitando o\"Meus Aplicativos\" seção da Google Play Store.</string>
-
-	<string name="install_guide_page_2_title">Prepare-se para a instalação</string>
-	<string name="install_guide_page_2_text">"Nota: A instalação da atualização ocorre a partir de uma página especial da seção padrão de Atualizações do sistema do seu dispositivo. Se, por algum motivo, uma atualização do sistema aparecer ao abrir esta seção, você também pode optar por instalar essa atualização primeiro. Depois, abra o Oxygen Updater novamente para ver se você está completamente atualizado.
-
-Instruções:
-&#8226; Feche o Atualizador Oxygen pressionando o botão home.
-
-&#8226; Abra o aplicativo Configurações. Ele deve estar localizado na gaveta do aplicativo.
-
-&#8226; Role para baixo até ver as atualizações do sistema. Toque nele."</string>
-
-	<string name="install_guide_page_3_title">Instale a atualização</string>
-	<string name="install_guide_page_3_text">"Agora que você está no aplicativo Atualização do Sistema, é hora de instalar a atualização.
-
-&#8226; Na seção Atualizações do sistema, toque no ícone de engrenagem no canto superior direito
-
-&#8226; Agora, selecione \"Atualização Local\". Uma tela de seleção de arquivo deve aparecer.
-
-&#8226; Nesta tela, toque no arquivo de atualização que você baixou usando o Oxygen Updater. Seu nome deve começar com \"%1$sOxygen\".
-
-&#8226; Clique em \"Atualizar agora\". A instalação deve começar automaticamente."</string>
-
-	<string name="install_guide_page_4_title">Espere até que a instalação termine</string>
-	<string name="install_guide_page_4_text">"&#8226; O telefone agora instalará a atualização e exibirá uma barra de progresso. Por favor, espere até que a instalação termine. A instalação pode levar de alguns minutos a 15 minutos.
-
-&#8226;Depois disso, seu telefone será reiniciado para completar a atualização."</string>
-
-	<string name="install_guide_page_5_title">Pronto. Aproveite a nova versão do OxygenOS!</string>
-	<string name="install_guide_page_5_text">&#8226; Depois que seu dispositivo terminar de otimizar seus aplicativos, a atualização foi instalada com sucesso.\nPara verificar isso, você pode verificar a versão atual do seu sistema da seguinte forma:\n\n&#8226; Vá para Configurações, toque em\"Sobre o dispositivo\", e verifique a versão do OxygenOS.\n\n&#8226; Se você gosta deste aplicativo, dê 5 estrelas no Google Play!</string>
-
-	<string name="install_guide_close_button">Fechar Guia de Instalação</string>
+	<string name="install_guide_download_instructions">&#8226; Pressione o botão Download para iniciar o download da atualização.\n&#8226; O andamento do download aparecerá no aplicativo e como uma notificação na tela de notificações.\n&#8226; Quando o download terminar, você verá uma notificação com o texto\"Download finalizado\". Se ocorrer um erro de download, abra o aplicativo e tente baixar a atualização novamente. Se isso não funcionar, verifique se a conexão de rede está funcionando. Caso contrário, entre em contato com o desenvolvedor do aplicativo. Você pode fazer isso visitando o\"Meus Aplicativos\" seção da Google Play Store.</string>
 
 	<!-- Device information strings -->
 	<string name="device_information_supported_oxygen_os">Seu dispositivo é compatível</string>
@@ -212,7 +175,7 @@ Instruções:
 	<string name="device_information_image_description">Imagem do dispositivo</string>
 	<string name="device_information_incremental_os_version">Versão incremental do sistema operacional</string>
 	<string name="device_information_os_version">Versão do Android</string>
-	<string name="device_information_oxygen_os_version">Versão da OxygenOS</string>
+	<string name="device_information_oxygen_os_version">Versão da OS</string>
 	<string name="device_information_oxygen_os_ota_version">Versão do OTA</string>
 	<string name="device_information_patch_level_version">Data do patch de segurança</string>
 	<string name="device_information_serial_number">Número de série</string>
@@ -225,11 +188,14 @@ Instruções:
 	<string name="about_support">Se você gostaria de nos apoiar, você pode comprar o desbloqueio sem anúncios (nas configurações do aplicativo) ou verificar nosso<a href="https://patreon.com/oxygenupdater">Patreon</a>.</string>
 	<string name="about_background_story_header">História de fundo</string>
 	<string name="about_background_story">Este aplicativo foi desenvolvido originalmente por Arjan Vlek como uma continuação de outro de seus aplicativos, chamado<a href="https://cyanogenupdatetracker.com/">Cyanogen Update Tracker</a> (it provides similar functionality for Cyanogen OS users).\n\nApós 4 anos, em julho de 2019, Arjan decidiu renunciar a ambos os projetos e transferiu a propriedade do aplicativo para uma equipe de desenvolvedores vindos de diferentes países. Eles assumiram a responsabilidade de fornecer à comunidade um excelente serviço &amp; suporte para obter atualizações OnePlus mais rapidamente.\nVocê pode encontrar mais informações sobre o anúncio <a href="https://oxygenupdater.com/article/81/">aqui</a>.\n\n14 de agosto de 2019 marcou o primeiro lançamento com nova propriedade, que veio com novos recursos como o modo escuro e um redesenho completo.\n\nPara mais informações sobre a equipe, confira <a href="https://oxygenupdater.com/team/">no site</a>.</string>
-	<string name="about_third_party_app_notice">Observe que este não é um aplicativo oficial OnePlus. \nO nome OnePlus, o logotipo OnePlus e OxygenOS são propriedade da OnePlus. \nAndroid, Google, Google Play e o logotipo Google Play são marcas registradas da Google Inc. \nEste aplicativo usa dados do OnePlus e de sua empresa controladora Oppo para mostrar informações de atualização.</string>
+	<string name="about_third_party_app_notice">Observe que este não é um aplicativo oficial OnePlus.\nO nome OnePlus, o logotipo OnePlus e OxygenOS são propriedade da OnePlus.\nAndroid, Google, Google Play e o logotipo Google Play são marcas registradas da Google Inc.\nEste aplicativo usa dados do OnePlus e de sua empresa controladora Oppo para mostrar informações de atualização.</string>
 	<string name="about_rate_button_text">Avalie</string>
 	<string name="about_website_button_text">Site</string>
 	<string name="about_email_button_text">Email</string>
+
 	<!-- LocalNotifications strings -->
+	<string name="notification_permission_title">"Mantenha-se notificado"</string>
+	<string name="notification_permission_text">"Permita que o aplicativo o notifique sobre atualizações OTA, notícias, status de download em andamento e outras coisas importantes. Você pode ajustar suas preferências posteriormente nas configurações do aplicativo."</string>
 	<string name="notification_new_device_text">%1$s agora é compatível. Abra o aplicativo para escolher este dispositivo.</string>
 	<string name="notification_no_notification_support">Instale ou atualize o Google Play Services para habilitar notificações push.</string>
 	<string name="notification_version">%1$s agora está disponível para o %2$s!</string>
@@ -255,23 +221,9 @@ Instruções:
 	<string name="general_notification_channel_description">Notificações gerais que não se enquadram em outras categorias</string>
 	<string name="url_submitted_notification_channel_description">Seja notificado quando enviar URLs de OTAs com sucesso para nossa equipe.\nVocê pode desativar o envio automático de URLs nas configurações do aplicativo.</string>
 
-	<!-- Help strings -->
-	<string name="help">Ajuda</string>
-	<string name="help_updating_your_device_title">Atualizando seu dispositivo</string>
-	<string name="help_updating_your_device_text">Wuando abrir o aplicativo, você verá se uma atualização do sistema está disponível. Se houver uma atualização disponível, você poderá instalá-la.\n\nPara iniciar a instalação, toque no botão \"Download\" (abaixo da descrição da atualização) para iniciar o download. Quando o download terminar, a tela de instalação aparecerá. Se você saiu do aplicativo ou a tela não apareceu, toque no botão \"Instalar\" , que agora é mostrado próximo ao botão \"Download\" .\n\nA tela de instalação verificará primeiro se você tem um dispositivo com acesso root. Se você tiver um dispositivo com acesso root, conceda permissão de root quando solicitado e escolha como deseja instalar a atualização. Caso contrário, siga as instruções para instalação manual.\n\nInstalação automática:\nVocê só terá que escolher suas opções de instalação. As configurações padrão são recomendadas, exceto que você precisa especificar a raiz do instalador que precisa ser (re) instalada. Selecione uma raiz do instalador (arquivo zip) usando o botão de pasta azul e toque em \"Instalar\" para começar a instalação.\n\nInstalação Manual:\nVocê verá um guia de instalação na tela. Anote as instruções e execute-as conforme indicado para instalar a atualização.</string>
-	<string name="help_reading_news_title">Lendo as últimas notícias</string>
-	<string name="help_reading_news_text">Notícias são exibidas à esquerda da tela Atualizar. Os itens mais recentes aparecem no topo. Basta tocar em um item para lê-lo.\nToque na seta para trás ou pressione a tecla Voltar para retornar à tela de itens de notícias.</string>
-	<string name="help_device_information_title">Visualizando informações sobre o seu dispositivo</string>
-	<string name="help_device_information_text">Você pode ver algumas das especificações do seu dispositivo usando a tela à direita da tela Atualizar. Isso é útil ao fazer uma solicitação de suporte, durante a qual você pode ser solicitado a fornecer algumas das especificações do seu dispositivo.</string>
-	<string name="help_change_settings_title">Alterando configurações</string>
-	<string name="help_change_settings_text">Você pode alterar suas configurações tocando nos três pontos no canto superior direito, seguindo um toque em Configurações.\nVocê pode alterar as seguintes configurações:\n\n• Dispositivo e método de atualização\n• Notificações via push\n• Notificações do aplicativo\n• Configurações de privacidade (log de upload).\n\nUse os interruptores para ativar e desativar as configurações de notificação / privacidade. Selecione um dispositivo e / ou método de atualização usando os menus suspensos mostrados acima dos interruptores. Menus suspensos não visíveis? Verifique sua conexão com a Internet e abra a tela Configurações novamente.</string>
-
 	<!-- News strings -->
 	<string name="news">Notícias</string>
-	<string name="news_date_published">Última atualizalçao: %1$s</string>
-	<string name="news_empty">Este artigo não tem conteúdo.</string>
 	<string name="news_load_network_error">Falha ao abrir o artigo. Verifique sua conexão e pressione o botão \"Tentar Novamente\"para abrir o artigo.</string>
-	<string name="news_load_id_error"><![CDATA[Failed to open article from an invalid URL: %1$s. Check the URL or report this to us either via <a href="mailto:support@oxygenupdater.com">email</a> or on our <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
 	<string name="news_unread_count_1">Você tem %1$d artigos de notícias não lidos. Clique para visualizar todos.</string>
 	<string name="news_unread_count_2">Você tem %1$d artigos de notícias não lidos. Cliquei para mostrar todos os artigos.</string>
 	<string name="news_mark_read">Marcar como lido</string>
@@ -297,12 +249,10 @@ Instruções:
 	<string name="error_app_outdated">Ah não!</string>
 	<string name="error_app_outdated_message">Esta versão do aplicativo está desatualizada. É hora de atualizá-lo! Toque em \"Google Play\" abaixo. No Google Play, toque em \"Atualizar\".</string>
 	<string name="error_app_requires_network_connection">Sem conexão</string>
-	<string name="error_app_requires_network_connection_message">Falhou ao conectar com o servidor. Por favor, certifique-se de que você tenha uma conexão funcionando. O aplicativo será fechado agora.</string>
 	<string name="error_google_play_button_text">Google Play</string>
-	<string name="error_no_internet_connection">Sem conexão.</string>
 	<string name="error_maintenance">Manutenção do servidor</string>
 	<string name="error_maintenance_message">Por favor, espere. O servidor estará disponível em breve.</string>
-	<string name="error_maintenance_retry">O servidor pode estar inativo para manutenção. Tente novamente depois de algum tempo ou informe-nos via <a href="mailto:support@oxygenupdater.com">email</a> ou pelo nosso <a href="https://discord.gg/5TXdhKJ">servidor do Discord</a>.</string>
+	<string name="error_maintenance_retry"><![CDATA[O servidor pode estar inativo para manutenção. Tente novamente depois de algum tempo ou informe-nos via <a href="mailto:support@oxygenupdater.com">email</a> ou pelo nosso <a href="https://discord.gg/5TXdhKJ">servidor do Discord</a>.]]></string>
 	<string name="error_reload">Recarregar</string>
 
 	<string name="error_unable_to_rate_app">Você não pode avaliar o aplicativo, porque o Google Play Store não está instalado em seu dispositivo.</string>
@@ -327,7 +277,6 @@ Instruções:
 	<string name="purchase_error_after_payment">A compra da versão sem anúncios falhou porque ocorreu um erro interno. Por favor, tente novamente em alguns minutos. Se você já pagou, entre em contato com o suporte do Google Play para obter assistência.</string>
 
 	<!-- Other strings-->
-	<string name="error">Erro</string>
 	<string name="icon">Icone</string>
 	<string name="loading">Carregando…</string>
 	<string name="processing">Processando…</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="device_chooser_error_title">Nu s-a putut accesa lista de dispozitive suportate</string>
-
 	<!-- Update information strings-->
 	<string name="enable">Permite</string>
 	<string name="update_information_description_not_available">Nu există informații oficiale asupra noilor funcții din această actualizare. În general, o astfel de actualizare rezolvă bug-uri, îmbunătățește performanța, și / sau aduce actualizări de securitate importante pentru dispozitivul dumneavoastră.</string>
@@ -13,11 +11,10 @@
 	<string name="update_information_banner_server">Apăsați aici pentru a vedea noutăți importante</string>
 	<string name="update_information_banner_advanced_mode_tip">Ați selectat varianta de actualizare \"%1$s\". Activați modul avansat dacă plănuiți să treceți la această variantă de actualizare.</string>
 	<string name="update_information_header_advanced_mode_hint">Modul avansat este activat</string>
-	<string name="update_information_header_advanced_mode_helper">Pentru că ați activat modul avansat, puteți descărca ultimul fișier ZIP pentru \"%1$s\".\n\nPuteți dezactiva modul avansat din setări.</string>
-	<string name="update_information_different_version_changelog_notice">Vizualizați un jurnal de schimbări pentru cea mai recentă actualizare din lista de actualizări \"%1$s\". Dacă doriți să instalați această actualizare, trebuie să activați mai întâi modul avansat (în setări).\n\nTotuși, dacă doriți să vedeți jurnalul de schimbări pentru versiunea instalată în prezent, va trebui să reveniți la metoda potrivită de actualizare.</string>
-	<string name="update_information_last_checked_on">Ultima verificare: %1$s</string>
+	<string name="update_information_header_advanced_mode_helper">Pentru că ați activat modul avansat, puteți descărca ultimul fișier ZIP pentru \"%1$s\". Puteți dezactiva modul avansat din setări.</string>
+	<string name="update_information_different_version_changelog_notice_base">Notă: această listă de modificări se referă la ultima versiune disponibilă (%1$s) în metoda de actualizare \"%2$s\"</string>
+	<string name="update_information_different_version_changelog_notice_advanced">. Dacă intenționați să instalați această actualizare, trebuie să activați \"Mod avansat\" în setări.</string>
 	<string name="update_information_no_update_data_available">Nu există informații despre actualizare</string>
-	<string name="update_information_oxygen_os_version">OxygenOS %1$s</string>
 	<string name="update_information_system_is_up_to_date">Sistemul dumneavoastră este la zi</string>
 	<string name="update_information_unknown_update_name">Actualizare fără nume pentru %1$s</string>
 	<string name="update_information_view_update_information">Vizualizați informații despre actualizare</string>
@@ -43,7 +40,7 @@
 	<string name="download_complete_notification">Atingeți pentru a începe instalarea</string>
 
 	<string name="download_error">Eroare la descărcare</string>
-	<string name="download_error_close">ÎNCHIDE</string>
+	<string name="download_error_close">Închide</string>
 	<string name="download_error_corrupt">Fișierul descărcat este compromis! Vă rugăm să îl descărcați din nou.</string>
 	<string name="download_error_server">A avut loc o eroare de server la descărcarea actualizării. Vă rugăm să încercați din nou descărcarea.</string>
 	<string name="download_error_internal">Din păcate a avut loc o eroare tehnică în timpul descărcării. Încercați să descărcați actualizarea din nou. Dacă problema persistă, vă rugăm să contactați dezvoltatorii aplicației pentru asistență.</string>
@@ -51,8 +48,8 @@
 Dacă doriți să aflați mai multe, nu ezitați să ne contactați fie prin <a href="mailto:support@oxygenupdater.com">e-mail</a> sau intrând pe <a href="https://discord.gg/5TXdhKJ">server-ul nostru de Discord</a>.]]></string>
 	<string name="download_error_could_not_move_temp_file">Fișierul a fost descărcat, dar nu a putut fi mutat în directorul corespunzător. Deschideți un manager de fișiere, navigați către \"%1$s\" și mutați manual fișierul în cel mai de sus director al stocării interne.</string>
 
-	<string name="download_error_retry">REÎNCERCARE</string>
-	<string name="download_error_resume">RELUARE</string>
+	<string name="download_error_retry">Reîncercare</string>
+	<string name="download_error_resume">Reluare</string>
 	<string name="download_error_storage">Nu există suficient spațiu de stocare disponibil pe dispozitiv pentru a descărca actualizarea. Vă rugăm să eliberați spațiu și să încercați din nou.</string>
 
 	<string name="download_failed">Descărcare eșuată</string>
@@ -89,9 +86,7 @@ Dacă doriți să aflați mai multe, nu ezitați să ne contactați fie prin <a 
 	<string name="summary_please_wait">Vă rugăm așteptați…</string>
 	<string name="summary_update_method">Mai întâi selectați un dispozitiv</string>
 	<!-- TODO: check the following translation -->
-	<string name="summary_important_notifications_disabled">Unele notificări importante sunt dezactivate: \"%1$s\"</string>
-	<string name="summary_theme">Alegeți tema</string>
-	<string name="summary_language">Alegeți limba</string>
+	<string name="summary_important_notifications_disabled">Unele notificări importante sunt dezactivate:</string>
 	<string name="summary_privacy_policy">Vizualizați online</string>
 	<string name="summary_rate_app">Acordați-ne 5 stele</string>
 
@@ -122,78 +117,46 @@ Dacă doriți să aflați mai multe, nu ezitați să ne contactați fie prin <a 
 
 	<string name="settings_device">Dispozitiv selectat</string>
 	<string name="settings_entered_incorrectly">Eroare la salvarea setărilor. Vă rugăm să reveniți la selectarea dispozitivului / a modalității de actualizare.</string>
-	<string name="settings_explanation_incremental_full_update">O actualizare incrementală poate fi instalată din orice versiune (cu excepția cazului în care aveți un bootloader deblocat; atunci ar trebui să alegeți întotdeauna actualizarea completă ca metodă de actualizare).\n\nO actualizare beta pentru OxygenOS poate fi instalată întotdeauna, de asemenea, atunci când rulați o versiune stabilă. Pentru a trece de la o versiune stabilă la o versiune beta, trebuie să activați modul avansat în setări. Pentru versiunile beta, metodele de actualizare completă și incrementală funcționează în același mod ca pe versiunile stabile.</string>
 
 	<string name="settings_push_from_server">Informații și avertismente</string>
 
 	<string name="settings_saving">Setările dumneavoastră se salvează. Dacă operațiunea durează prea mult: Verificați conexiunea la rețea, închideți aplicația și porniți-o din nou.</string>
 
 	<string name="settings_advanced_mode">Mod avansat</string>
-	<string name="settings_advanced_mode_explanation">Modul avansat ascunde mesajul \"Sistemul dumneavoastră este la zi\", permițându-vă să descărcați și să instalați toate actualizările, chiar dacă este posibil ca unele să nu fie compatibile cu dispozitivul dumneavoastră.\n\nAcest lucru poate fi util atunci când:\n&#8226; Actualizați dispozitivul de la o versiune obișnuită la o versiune beta\n&#8226; Reveniți de la o versiune beta la cea obișnuită (nu uitați să vă resetați dispozitivul)\n&#8226; Reinstalați versiunea curentă a sistemului.</string>
+	<string name="settings_advanced_mode_explanation">"În mod normal, aplicația vă arată actualizările în funcție de versiunea curentă a sistemului de operare. Cu modul avansat, cea mai recentă actualizare disponibilă va fi afișată întotdeauna, indiferent de compatibilitatea dispozitiv/versiune.
+
+Acest lucru poate fi util dacă doriți să:"</string>
+	<string name="settings_advanced_mode_uses">"&#8226; Reîncărcați cea mai recentă versiune chiar dacă sunteți deja pe ea
+&#8226; Treceți la o altă cale de actualizare"</string>
+	<string name="settings_advanced_mode_caption">"Modul avansat poate fi necesar doar în situațiile de mai sus. Nu ar trebui să îl activați decât dacă știți ce faceți."</string>
 
 	<string name="settings_update_method">Metoda de actualizare</string>
 	<string name="settings_upload_logs">Împărtășiți date de utilizare și jurnale ale aplicației</string>
+	<string name="settings_ad_privacy">Consimțământul pentru reclame GDPR</string>
+	<string name="settings_ad_privacy_subtitle">"Pentru utilizatorii din SEE/UK"</string>
 
 	<!-- FAQ strings -->
 	<string name="faq">FAQ</string>
 	<string name="faq_menu_item">FAQ</string>
 
 	<!-- First-time onboarding strings -->
-	<string name="onboarding">Bine ați venit</string>
+	<string name="onboarding">Configurare</string>
 	<string name="onboarding_finished_button">Porniți aplicația</string>
 
-	<string name="onboarding_page_1_title">Bine ați venit la Oxygen Updater!</string>
-	<string name="onboarding_page_1_text">Această aplicație vă va permite să:\n\n&#8226; Obțineți acces mai rapid la cele mai recente actualizări Android pentru dispozitivul dumneavoastră cu OxygenOS\n\n&#8226; Actualizați cu ușurință un dispozitiv rootat\n\n&#8226; Vedeți ce este nou în software-ul de sistem pe care îl utilizați în prezent\n\n&#8226; Citiți cele mai recente noutăți despre OnePlus și OxygenOS\n\nGlisați spre stânga pentru a continua.</string>
-	<string name="onboarding_page_1_caption">Aceasta nu este o aplicație oficială OnePlus. Utilizați aplicația pe propria răspundere. Nici OnePlus și nici dezvoltatorul aplicației nu sunt responsabili pentru acțiunile dumneavoastră, nici pentru orice daune cauzate de utilizarea acestei aplicații.\n\nPrin utilizarea acestei aplicații, sunteți de acord cu termenii și condițiile menționate mai sus.</string>
-	<string name="onboarding_page_2_title">Selectați-vă dispozitivul</string>
-	<string name="onboarding_page_2_caption">De regulă, dispozitivul dumneavoastră este preselectat mai sus. În caz contrar, selectați-vă dispozitivul mai sus.</string>
-	<string name="onboarding_page_3_title">Alegeți metoda de actualizare</string>
-	<string name="onboarding_page_3_caption">De obicei, actualizarea incrementală este alegerea potrivită aici, deoarece oferă descărcări mult mai rapide și mai mici.\n\nCu toate acestea, nu este compatibilă cu dispozitivele rootate. Dacă aveți un dispozitiv rootat, alegeți Actualizarea completă.\n\nDacă aveți o versiune beta a OxygenOS, alegeți (una) dintre metodele de actualizare Open Beta.</string>
-	<string name="onboarding_page_4_title">Totul este pregătit!</string>
-	<string name="onboarding_page_4_text">Bucurați-vă de utilizarea acestei aplicații!\n\nVă puteți schimba oricând setările mai târziu. Pentru a face acest lucru: apăsați pe cele trei puncte din colțul din dreapta sus și selectați \"Setări\".</string>
+	<string name="onboarding_app_uses">Această aplicație vă va permite să:\n\n&#8226; Obțineți acces mai rapid la cele mai recente actualizări Android pentru dispozitivul dumneavoastră cu OxygenOS\n&#8226; Actualizați cu ușurință un dispozitiv rootat\n&#8226; Vedeți ce este nou în software-ul de sistem pe care îl utilizați în prezent\n&#8226; Citiți cele mai recente noutăți despre OnePlus și OxygenOS</string>
+	<string name="onboarding_disclaimer">Aceasta nu este o aplicație oficială OnePlus. Utilizați aplicația pe propria răspundere. Nici OnePlus și nici dezvoltatorul aplicației nu sunt responsabili pentru acțiunile dumneavoastră, nici pentru orice daune cauzate de utilizarea acestei aplicații. Prin utilizarea acestei aplicații, sunteți de acord cu termenii și condițiile menționate mai sus.</string>
+	<string name="onboarding_device_chooser_title">Selectați-vă dispozitivul</string>
+	<string name="onboarding_device_chooser_caption">De regulă, dispozitivul dumneavoastră este preselectat mai sus. În caz contrar, selectați-vă dispozitivul mai sus.</string>
+	<string name="onboarding_method_chooser_title">Alegeți metoda de actualizare</string>
+	<string name="onboarding_method_chooser_caption">De obicei, actualizarea incrementală este alegerea potrivită aici, deoarece oferă descărcări mult mai rapide și mai mici. Cu toate acestea, nu este compatibilă cu dispozitivele rootate. Dacă aveți un dispozitiv rootat, alegeți Actualizarea completă. Dacă aveți o versiune beta a OxygenOS, alegeți (una) dintre metodele de actualizare Open Beta.</string>
+	<string name="onboarding_caption">Bucurați-vă de utilizarea acestei aplicații! Vă puteți schimba oricând setările mai târziu.</string>
 
 	<!-- Automatic install strings -->
 	<string name="install">Instalare</string>
 
 	<!-- Install guide strings -->
-	<string name="install_guide_no_root">Instalați actualizarea conform instrucțiunilor prezentate în ghidul de instalare.</string>
 	<string name="install_guide">Ghid de instalare</string>
-	<string name="install_guide_subtitle">Ghid de instalare - %1$d din %2$d</string>
-	<string name="install_guide_tip">&#8226; Vă recomandăm să vă notați fiecare pas în parte, întrucât veți fi nevoit să opriți complet dispozitivul în timpul instalării actualizării.</string>
-
-	<string name="install_guide_page_1_title">Descărcarea actualizării</string>
-	<string name="install_guide_page_1_text">&#8226; Apăsați butonul Descărcare pentru a începe descărcarea actualizării.\n\n&#8226; Progresul descărcării va apărea atât în aplicație, cât și ca notificare în panoul de notificări.\n\n&#8226; Când descărcarea s-a încheiat, veți vedea o notificare cu textul \"Descărcare completă\".\nDacă a apărut o eroare de descărcare, deschideți aplicația și încercați să descărcați din nou actualizarea. Dacă acest lucru nu funcționează, asigurați-vă că aveți o conexiune funcțională. În caz contrar, luați legătura cu dezvoltatorul aplicației. Puteți face acest lucru accesând secțiunea \"Aplicațiile mele\" din Magazinul Google Play.</string>
-
-	<string name="install_guide_page_2_title">Pregătirea pentru instalare</string>
-	<string name="install_guide_page_2_text">"Atenție: Instalarea actualizării are loc pe o pagină specială din secțiunea standard de Actualizări de sistem a dispozitivului. Dacă, dintr-un motiv anume, apare o actualizare de sistem la deschiderea acestei secțiuni, puteți opta pentru a instala mai întâi a acea actualizare. Apoi, deschideți din nou Oxygen Updater pentru a vedea dacă sunteți la zi cu actualizările.
-
-Instrucțiuni:
-&#8226; Închideți Oxygen Updater apăsând pe butonul Acasă.
-
-&#8226; Deschideți aplicația Setări. Ar trebui să se afle în lista de aplicații.
-
-&#8226; Derulați în jos până când ajungeți la Actualizări de sistem. Apăsați pentru a continua."</string>
-
-	<string name="install_guide_page_3_title">Instalarea actualizării</string>
-	<string name="install_guide_page_3_text">"Acum că vă aflați în aplicația Actualizări de sistem, este timpul să instalați actualizarea.
-
-&#8226; În secțiunea Actualizări de sistem, atingeți pictograma rotiței din colțul din dreapta sus
-
-&#8226; Acum, selectați \"Actualizare locală\". Ar trebui să apară un meniu de selectare a fișierului.
-
-&#8226; În acest meniu, apăsați pe fișierul de actualizare pe care l-ați descărcat folosind Oxygen Updater. Numele fișierului ar trebui să înceapă cu \"%1$sOxygen\".
-
-&#8226; Apăsați pe \"Actualizați acum\". Instalarea ar trebui să înceapă automat."</string>
-
-	<string name="install_guide_page_4_title">Așteptați până când instalarea este finalizată</string>
-	<string name="install_guide_page_4_text">"&#8226; Telefonul va instala acum actualizarea și va afișa o bară de progres. Vă rugăm să așteptați până la finalizarea instalării. Instalarea poate dura de la câteva minute până la 15 minute.
-
-&#8226; Ulterior, telefonul dumneavoastră va reporni pentru a finaliza actualizarea."</string>
-
-	<string name="install_guide_page_5_title">Asta a fost tot. Bucurați-vă de noua versiune de OxygenOS!</string>
-	<string name="install_guide_page_5_text">&#8226; După ce dispozitivul dumneavoastră a terminat de optimizat aplicațiile sale, actualizarea a fost instalată cu succes.\nPentru a verifica acest lucru, puteți verifica versiunea curentă a sistemului dumneavoastră după cum urmează:\n\n&#8226; Duceți-vă la Setări, apăsați pe \"Despre telefon\" și verificați versiunea de OxygenOS.\n\n&#8226; Dacă vă place această aplicație, oferiți-ne 5 stele pe Google Play!</string>
-
-	<string name="install_guide_close_button">Închideți Ghidul de instalare</string>
+	<string name="install_guide_download_instructions">&#8226; Apăsați butonul Descărcare pentru a începe descărcarea actualizării.\n&#8226; Progresul descărcării va apărea atât în aplicație, cât și ca notificare în panoul de notificări.\n&#8226; Când descărcarea s-a încheiat, veți vedea o notificare cu textul \"Descărcare completă\". Dacă a apărut o eroare de descărcare, deschideți aplicația și încercați să descărcați din nou actualizarea. Dacă acest lucru nu funcționează, asigurați-vă că aveți o conexiune funcțională. În caz contrar, luați legătura cu dezvoltatorul aplicației. Puteți face acest lucru accesând secțiunea \"Aplicațiile mele\" din Magazinul Google Play.</string>
 
 	<!-- Device information strings -->
 	<string name="device_information_supported_oxygen_os">Dispozitivul dumneavoastră este suportat</string>
@@ -210,7 +173,7 @@ Instrucțiuni:
 	<string name="device_information_image_description">Imaginea dispozitivului</string>
 	<string name="device_information_incremental_os_version">Versiunea incrementală de OS</string>
 	<string name="device_information_os_version">Versiunea de Android</string>
-	<string name="device_information_oxygen_os_version">Versiunea de OxygenOS</string>
+	<string name="device_information_oxygen_os_version">Versiunea de OS</string>
 	<string name="device_information_oxygen_os_ota_version">Versiunea OTA</string>
 	<string name="device_information_patch_level_version">Data pachetului de securitate</string>
 	<string name="device_information_serial_number">Numărul de serie</string>
@@ -229,6 +192,8 @@ Instrucțiuni:
 	<string name="about_email_button_text">E-mail</string>
 
 	<!-- LocalNotifications strings -->
+	<string name="notification_permission_title">"Rămâneți notificat"</string>
+	<string name="notification_permission_text">"Permiteți aplicației să vă notifice cu privire la actualizări OTA, noutăți, starea descărcării în curs și alte lucruri importante. Vă puteți ajusta ulterior preferințele în setările aplicației."</string>
 	<string name="notification_new_device_text">%1$s este acum suportat. Deschideți aplicația pentru a alege acest dispozitiv.</string>
 	<string name="notification_no_notification_support">Instalați sau actualizați serviciile Google Play pentru a activa notificările push.</string>
 	<string name="notification_version">Actualizarea %1$s este acum disponibilă pentru %2$s!</string>
@@ -254,23 +219,9 @@ Instrucțiuni:
 	<string name="general_notification_channel_description">Notificări generale care nu se încadrează în alte categorii</string>
 	<string name="url_submitted_notification_channel_description">Primiți o notificare atunci când trimiteți cu succes URL-uri OTA către echipa noastră.\nPuteți renunța la trimiterea automată a URL-urilor în setările aplicației.</string>
 
-	<!-- Help strings -->
-	<string name="help">Ajutor</string>
-	<string name="help_updating_your_device_title">Actualizați dispozitivul</string>
-	<string name="help_updating_your_device_text">La deschiderea aplicației, veți vedea dacă este disponibilă o actualizare de sistem. Dacă este disponibilă o actualizare, atunci o puteți instala.\n\nPentru a începe instalarea, apăsați butonul de \"Descărcare\" (sub descrierea actualizării) pentru a începe descărcarea. Când descărcarea s-a încheiat, veți vedea meniul de instalare. Dacă ați părăsit aplicația sau în cazul în care meniul de instalare nu a apărut, apăsați pe butonul \"Instalare\", care va fi afișat lângă butonul de \"Descărcare\".\n\nProcesul de instalare va verifica mai întâi dacă aveți un dispozitiv rootat. Dacă aveți un dispozitiv rootat, acordați permisiunea de root atunci când vi se solicită și alegeți modul în care doriți să instalați actualizarea. În caz contrar, urmați instrucțiunile pentru instalarea manuală.\n\nInstalarea automată:\nVa trebui doar să alegeți opțiunile pentru instalare. Sunt recomandate setările implicite, cu excepția faptului că trebuie să specificați pachetul root care trebuie (re)instalat. Selectați un pachet root (în format .zip) folosind butonul albastru al directorului și apăsați pe \"Porniți instalarea\" pentru a porni instalarea.\n\nInstalarea manuală:\nVeți vedea un ghid de instalare pe ecran. Notați separat instrucțiunile și efectuați-le în ordinea în care sunt prezentate pentru a instala actualizarea.</string>
-	<string name="help_reading_news_title">Citiți ultimele noutăți</string>
-	<string name="help_reading_news_text">Noutățile și știrile sunt afișate în dreapta panoului de actualizări. Cele mai recente elemente apar în partea de sus. Pur și simplu atingeți un articol pentru a-l citi.\nAtingeți săgeata "înapoi" sau apăsați tasta "înapoi" pentru a reveni la ecranul de știri.</string>
-	<string name="help_device_information_title">Vizualizați informații despre dispozitiv</string>
-	<string name="help_device_information_text">Puteți vizualiza anumite specificații ale dispozitivului utilizând ecranul din dreapta panoului de actualizări. Acest lucru este util atunci când faceți o solicitare de asistență în care există posibilitatea să vi se solicite anumite specificații ale dispozitivului dumneavoastră.</string>
-	<string name="help_change_settings_title">Modificați setările</string>
-	<string name="help_change_settings_text">Puteți modifica setările apăsând pe cele trei puncte din dreapta sus, apoi pe Setări.\nPuteți modifica următoarele setări:\n\n• Dispozitiv și metodă de actualizare\n• Notificări\n• Notificări în aplicație\n• Setări de confidențialitate (încărcare jurnal).\n\nUtilizați comutatoarele pentru a activa și dezactiva setările de notificare / confidențialitate. Selectați un dispozitiv și / sau o metodă de actualizare folosind meniurile dropdown afișate deasupra comutatoarelor. Nu sunt vizibile meniurile dropdown? Verificați conexiunea la internet și deschideți din nou meniul de Setări.</string>
-
 	<!-- News strings -->
 	<string name="news">Noutăți</string>
-	<string name="news_date_published">Ultima actualizare: %1$s</string>
-	<string name="news_empty">Acest articol nu are conținut.</string>
-	<string name="news_load_network_error">Articolul nu a putut fi deschis. Verificați conexiunea și apăsați butonul \"REÎNCERCARE\" pentru a deschide articolul.</string>
-	<string name="news_load_id_error"><![CDATA[Deschiderea articolului nu a reușit din cauza unei adrese URL invalide: %1$s. Verificați adresa URL sau raportați-ne acest lucru fie prin <a href="mailto:support@oxygenupdater.com">e-mail</a> sau pe <a href="https://discord.gg/5TXdhKJ">server-ul nostru de Discord</a>.]]></string>
+	<string name="news_load_network_error">Articolul nu a putut fi deschis. Verificați conexiunea și apăsați butonul \"Reîncercare\" pentru a deschide articolul.</string>
 	<string name="news_unread_count_1">Aveți %1$d articole necitite. Atingeți pentru a le vizualiza.</string>
 	<string name="news_unread_count_2">Aveți %1$d articole necitite. Atingeți pentru a vizualiza toate articolele.</string>
 	<string name="news_mark_read">Marchează ca citit</string>
@@ -296,12 +247,10 @@ Instrucțiuni:
 	<string name="error_app_outdated">O nu!</string>
 	<string name="error_app_outdated_message">Se pare că nu rulați ultima versiune a aplicației. E timpul să o actualizați! Apăsați pe butonul \"Google Play\" de mai jos. În Google Play, apăsați \"Actualizare\".</string>
 	<string name="error_app_requires_network_connection">Lipsă conexiune</string>
-	<string name="error_app_requires_network_connection_message">Nu s-a putut realiza conexiunea la server. Vă rugăm să verificați conexiunea la rețea. Aplicația se va închide.</string>
 	<string name="error_google_play_button_text">Google Play</string>
-	<string name="error_no_internet_connection">Lipsă conexiune.</string>
 	<string name="error_maintenance">Mentenanță server</string>
 	<string name="error_maintenance_message">Vă rugăm așteptați. Server-ul va fi disponibil în curând.</string>
-	<string name="error_maintenance_retry">Este posibil ca server-ul să fie oprit pentru mentenanță. Încercați din nou mai târziu sau contactați-ne pe <a href="mailto:support@oxygenupdater.com">e-mail</a> sau pe <a href="https://discord.gg/5TXdhKJ">server-ul de Discord</a>.</string>
+	<string name="error_maintenance_retry"><![CDATA[Este posibil ca server-ul să fie oprit pentru mentenanță. Încercați din nou mai târziu sau contactați-ne pe <a href="mailto:support@oxygenupdater.com">e-mail</a> sau pe <a href="https://discord.gg/5TXdhKJ">server-ul de Discord</a>.]]></string>
 	<string name="error_reload">Reîncărcare</string>
 
 	<string name="error_unable_to_rate_app">Nu puteți evalua aplicația, întrucât Magazinul Google Play nu este instalat pe dispozitivul dumneavoastră.</string>
@@ -323,11 +272,10 @@ Instrucțiuni:
 	<string name="device_warning_checkbox_title">Nu mai arăta acest avertisment</string>
 
 	<!-- Purchasing strings -->
-	<string name="purchase_error_pending_payment">Achiziția se află în stadiul de \"procesare a plății"\. Odată ce plata este efectuată, veți avea parte de toate beneficiile oferite dumneavoastră.</string>
+	<string name="purchase_error_pending_payment">Achiziția se află în stadiul de \"procesare a plății\". Odată ce plata este efectuată, veți avea parte de toate beneficiile oferite dumneavoastră.</string>
 	<string name="purchase_error_after_payment">Achiziția nu a avut loc din cauza unei erori interne. Vă rugăm să încercați din nou în câteva minute. Dacă ați efectuat deja plata, vă rugăm să contactați asistența Google Play pentru detalii.</string>
 
 	<!-- Other strings-->
-	<string name="error">Eroare</string>
 	<string name="icon">Icoană</string>
 	<string name="loading">Se încarcă…</string>
 	<string name="processing">Procesare…</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools" tools:keep="@string/install_guide_page_*_*">
-
-	<string name="device_chooser_error_title">Не удалось получить список поддерживаемых устройств</string>
-
+<resources>
 	<!-- Update information strings -->
 	<string name="enable">включить</string>
 	<string name="update_information_file_name">"Имя файла: %1$s"</string>
@@ -13,11 +10,10 @@
 	<string name="update_information_banner_server">Нажмите здесь, чтобы просмотреть важные уведомления</string>
 	<string name="update_information_banner_advanced_mode_tip">Вы выбрали ветку обновлений \"%1$s\". Включите pасширенный режим, если вы планируете перейти на эту ветку обновлений.</string>
 	<string name="update_information_header_advanced_mode_hint">Расширенный режим включен</string>
-	<string name="update_information_header_advanced_mode_helper">Поскольку вы включили расширенный режим, вы можете загрузить последнюю версию ZIP для \"%1$s\". \n\nВы можете выключить pасширенный режим в настройках.</string>
-	<string name="update_information_different_version_changelog_notice">Вы просматриваете журнал изменений для последнего обновления в разделе обновлений \"%1$s\". Если вы собираетесь установить это обновление, вы должны сначала включить pасширенный режим (в настройках). \n\nОднако, если вы хотите вместо этого увидеть журнал изменений для текущей установленной версии, вам нужно будет вернуться к правильному методу обновления.</string>
-	<string name="update_information_last_checked_on">"Последняя проверка: %1$s"</string>
+	<string name="update_information_header_advanced_mode_helper">Поскольку вы включили расширенный режим, вы можете загрузить последнюю версию ZIP для \"%1$s\". Вы можете выключить pасширенный режим в настройках.</string>
+	<string name="update_information_different_version_changelog_notice_base">Примечание: данный журнал изменений предназначен для последней доступной версии (%1$s) при \"%2$s\" способе обновления</string>
+	<string name="update_information_different_version_changelog_notice_advanced">. Если вы собираетесь установить это обновление, необходимо включить \"Расширенный режим\" в настройках.</string>
 	<string name="update_information_no_update_data_available">"Информация об обновлении недоступна."</string>
-	<string name="update_information_oxygen_os_version">"OxygenOS %1$s"</string>
 	<string name="update_information_system_is_up_to_date">"Система обновлена."</string>
 	<string name="update_information_unknown_update_name">"Обновление для %1$s"</string>
 	<string name="update_information_view_update_information">"Посмотреть информацию об обновлении"</string>
@@ -84,9 +80,7 @@
 	<string name="summary_please_wait">пожалуйста, подождите…</string>
 	<string name="summary_update_method">Сначала выберите устройство</string>
 	<!-- TODO: check the following translation -->
-	<string name="summary_important_notifications_disabled">Некоторые важные уведомления отключены: \"%1$s\"</string>
-	<string name="summary_theme">Выберите тему</string>
-	<string name="summary_language">Установить язык</string>
+	<string name="summary_important_notifications_disabled">Некоторые важные уведомления отключены:</string>
 	<string name="summary_privacy_policy">Просмотреть онлайн</string>
 	<string name="summary_rate_app">Поставьте нам 5 звёзд</string>
 	<string name="label_buy_ad_free">Удалить рекламу</string>
@@ -113,115 +107,50 @@
 	<string name="settings_contribute_label">Помогите улучшить приложение</string>
 	<string name="settings_device">"Устройство"</string>
 	<string name="settings_entered_incorrectly">"Ошибка сохранения настроек. Пожалуйста, выберите снова ваше устройство / вариант обновления."</string>
-	<string name="settings_explanation_incremental_full_update">"Частичное обновление системы возможно только в случае, когда на момент выпуска обновления у вас уже была установлена последняя версия прошивки.
-
-Полное обновление системы может быть установлено всегда, независимо от установленной на данный момент версии прошивки.
-
-Бета обновление прошивки OxygenOS возможно только в том случае, когда вы уже используете Бета версию прошивки."</string>
 	<string name="settings_push_from_server">"Если какое-либо критическое предупреждение"</string>
 	<string name="settings_saving">"Ваши настройки сохраняются. Если сохранение будет долгим, проверьте подключение и перезапустите приложение."</string>
 	<string name="settings_advanced_mode">"Расширенный режим"</string>
-	<string name="settings_advanced_mode_explanation">"Расширенный режим прячет сообщение \"Ваша система обновлена\", позволяя скачивать и устанавливать все обновления, даже не подходящие для вашего устройства.
+	<string name="settings_advanced_mode_explanation">"Обычно приложение показывает обновления в зависимости от текущей версии ОС. В расширенном режиме всегда будет показано последнее доступное обновление, независимо от совместимости устройства и версии.
 
-Это может быть полезно:
- -При обновлении со стабильной прошивки на бету;
-- При возврате с беты на стабильную прошивку (не забудьте сделать сброс устройства);
-- При переустановке текущей версии прошивки."</string>
+Это может быть полезно, если необходимо:"</string>
+	<string name="settings_advanced_mode_uses">"&#8226; Повторно загрузить последнюю версию, даже если она уже установлена
+&#8226; Переключиться на другой путь обновления"</string>
+	<string name="settings_advanced_mode_caption">"Расширенный режим может понадобиться только в перечисленных выше ситуациях. Не следует включать его, если вы не знаете, что делаете."</string>
 	<string name="settings_update_method">"Вариант обновления"</string>
 	<string name="settings_upload_logs">Делитесь данными об использовании и журналами</string>
+	<string name="settings_ad_privacy">Согласие на размещение рекламы в соответствии с GDPR</string>
+	<string name="settings_ad_privacy_subtitle">"Для пользователей в странах ЕЭЗ/Великобритании"</string>
 
 	<!-- FAQ strings -->
 	<string name="faq">"FAQ"</string>
 	<string name="faq_menu_item">"FAQ"</string>
 
 	<!-- First-time setup strings -->
-	<string name="onboarding">"Добро пожаловать"</string>
+	<string name="onboarding">"Настройка"</string>
 	<string name="onboarding_finished_button">"Начать"</string>
-	<string name="onboarding_page_1_title">"Добро пожаловать в Oxygen Updater!"</string>
-	<string name="onboarding_page_1_text">"Данное приложение позволит вам:
+	<string name="onboarding_app_uses">"Данное приложение позволит вам:
 
-- Получить мгновенный доступ к последним версиям Android для устройств под управлением OxygenOS
-
-- Легко обновить устройство с рутом
-
-- Просмотреть, что нового в установленной прошивке
-
-- Читать последние новости о OnePlus и OxygenOS
-
-Проведите влево, чтобы продолжить."</string>
-	<string name="onboarding_page_1_caption">"Данное приложение не является официальным приложением OnePlus. Вы используете его на свой страх и риск. OnePlus и разработчик этого приложения не несут ответственности за нанесение какого-либо вреда вашему устройству.
-
-Используя Oxygen Updater, вы соглашаетесь с условиями, указанными выше.
-
-Проведите влево, чтобы продолжить."</string>
-	<string name="onboarding_page_2_title">"Выберите ваше устройство:"</string>
-	<string name="onboarding_page_2_caption">"Обычно устройство определяется автоматически. Если нет, выберите ваше устройство выше.
-
-Проведите влево, чтобы продолжить."</string>
-	<string name="onboarding_page_3_title">"Выберите метод обновления"</string>
-	<string name="onboarding_page_3_caption">"Обычно, частичное обновление является оптимальным решением, так как оно характеризуется быстрой загрузкой меньших по объему файлов.
-
-К сожалению его нельзя использовать с устройствами с рутом. Если у вас есть рут, используйте Полное обновление.
-
-Если вы используете бета версии прошивок, то выберите \"Community Edition\".
-
-Проведите влево, чтобы продолжить."</string>
-	<string name="onboarding_page_4_title">"Вы готовы!"</string>
-	<string name="onboarding_page_4_text">"Наслаждайтесь использованием данного приложения!
-
-Вы всегда можете изменить настройки приложения. Чтобы сделать это: Нажмите на три точки в правом верхнем углу, после нажмите на \"Настройки\"."</string>
+&#8226; Получить мгновенный доступ к последним версиям Android для устройств под управлением OxygenOS
+&#8226; Легко обновить устройство с рутом
+&#8226; Просмотреть, что нового в установленной прошивке
+&#8226; Читать последние новости о OnePlus и OxygenOS"</string>
+	<string name="onboarding_disclaimer">"Данное приложение не является официальным приложением OnePlus. Вы используете его на свой страх и риск. OnePlus и разработчик этого приложения не несут ответственности за нанесение какого-либо вреда вашему устройству. Используя Oxygen Updater, вы соглашаетесь с условиями, указанными выше."</string>
+	<string name="onboarding_device_chooser_title">"Выберите ваше устройство:"</string>
+	<string name="onboarding_device_chooser_caption">"Обычно устройство определяется автоматически. Если нет, выберите ваше устройство выше."</string>
+	<string name="onboarding_method_chooser_title">"Выберите метод обновления"</string>
+	<string name="onboarding_method_chooser_caption">"Обычно, частичное обновление является оптимальным решением, так как оно характеризуется быстрой загрузкой меньших по объему файлов. К сожалению его нельзя использовать с устройствами с рутом. Если у вас есть рут, используйте Полное обновление. Если вы используете бета версии прошивок, то выберите \"Open Beta\"."</string>
+	<string name="onboarding_caption">"Наслаждайтесь использованием данного приложения! Вы всегда можете изменить настройки приложения."</string>
 
 	<!-- Automatic install strings -->
 	<string name="install">"Установить"</string>
 
 	<!-- Install guide strings -->
-	<string name="install_guide_no_root">"Установите обновление, следуя инструкциям в руководстве по установке."</string>
 	<string name="install_guide">"Руководство по установке"</string>
-	<string name="install_guide_subtitle">"Руководство по установке - %1$d of %2$d"</string>
-	<string name="install_guide_tip">"&#8226; Рекомендуется записать все шаги установки, так как потребуется отключить устройство во время обновления."</string>
-	<string name="install_guide_page_1_title">"Загрузить обновление."</string>
-	<string name="install_guide_page_1_text">"&#8226; Нажмите кнопку Загрузить для скачивания обновления.
-
-- Прогресс загрузки будет отображаться в приложении и в уведомлении.
-
-- Когда загрузка завершится, вы увидите уведомление о завершении загрузки.
+	<string name="install_guide_download_instructions">"&#8226; Нажмите кнопку Загрузить для скачивания обновления.
+&#8226; Прогресс загрузки будет отображаться в приложении и в уведомлении.
+&#8226; Когда загрузка завершится, вы увидите уведомление о завершении загрузки.
 Если произошла ошибка загрузки, откройте приложение и попробуйте снова загрузить обновление. Если это не работает, убедитесь, что у вас работает интернет подключение.
 В противном случае обратитесь к разработчику приложения. Вы можете сделать это, посетив раздел «Мои приложения» в Google Play Mаркет."</string>
-
-	<string name="install_guide_page_2_title">Подготовка к установке</string>
-	<string name="install_guide_page_2_text">"Примечание: Установка обновления происходит со специальной страницы стандартного раздела «Обновления системы» вашего устройства. Если по какой-либо причине при открытии этого раздела появляется обновление системы, вы также можете сначала установить это обновление. После этого снова откройте Oxygen Updater, чтобы убедиться, что вы полностью обновились.
-
-Инструкции:
-&#8226; Закройте Oxygen Updater, нажав кнопку «Домой».
-
-&#8226; Откройте приложение Настройки. Оно должно находиться в ящике вашего приложения.
-
-&#8226; Прокрутите вниз до тех пор, пока не увидите "Обновление системы". Нажмите на это."</string>
-
-	<string name="install_guide_page_3_title">Установить обновление</string>
-	<string name="install_guide_page_3_text">"Теперь, когда вы находитесь в приложении «Обновления системы», пришло время установить обновление.
-
-&#8226; В разделе «Обновления системы» коснитесь значка шестеренки в правом верхнем углу.
-
-&#8226; Теперь выберите \"Локальное обновление\".  Должен появиться экран выбора файла.
-
-&#8226; На этом экране нажмите на файл обновления, который вы загрузили, используя Oxygen Updater. Его имя должно начинаться с \"%1$sOxygen\".
-
-&#8226; Нажмите на \"Обновить сейчас\". Установка должна начаться автоматически."</string>
-
-	<string name="install_guide_page_4_title">Дождитесь завершения установки</string>
-	<string name="install_guide_page_4_text">"&#8226; Теперь телефон установит обновление и отобразит индикатор выполнения. Подождите, пока установка не будет завершена. Установка может занять от нескольких минут до 15 минут.
-
-&#8226; После этого ваш телефон перезагрузится, чтобы завершить обновление."</string>
-
-	<string name="install_guide_page_5_title">"Готово. Наслаждайтесь новой версией OxygenOS!"</string>
-	<string name="install_guide_page_5_text">"&#8226; После завершения оптимизации приложений, обновление установлено успешно.
-Чтобы проверить это, вы можете узнать текущую версию системы следующим образом:
-
-- Зайдите в «Настройки», нажмите \"О телефоне\" и проверьте версию OxygenOS.
-
-- Если вам нравится это приложение, поставьте 5 звезд в Google Play!"</string>
-	<string name="install_guide_close_button">"Закрыть Руководство по установке"</string>
 
 	<!-- Device information strings -->
 	<string name="device_information_supported_oxygen_os">Ваше устройство поддерживается</string>
@@ -237,7 +166,7 @@
 	<string name="device_information_image_description">"Изображение устройства"</string>
 	<string name="device_information_incremental_os_version">"Номер сборки ПО:"</string>
 	<string name="device_information_os_version">"Версия Android:"</string>
-	<string name="device_information_oxygen_os_version">"Версия OxygenOS:"</string>
+	<string name="device_information_oxygen_os_version">"Версия OS:"</string>
 	<string name="device_information_oxygen_os_ota_version">"Версия OTA:"</string>
 	<string name="device_information_patch_level_version">"Патч безопасности от:"</string>
 	<string name="device_information_serial_number">"Серийный номер:"</string>
@@ -249,13 +178,15 @@
 	<string name="about_description">Это приложение загружает официальные обновления прямо с серверов OnePlus и даже проверяет целостность загруженного ZIP-файла перед установкой.  Таким образом приложение позволяет пропустить очередь развертывания и как можно скорее установить официальные обновления. Если вы обнаружите ошибки в ОС, сообщите о них в OnePlus напрямую: <a href="https://forums.oneplus.com/feedback">https://forums.oneplus.com/feedback</a>. Вы можете присоединиться к нашему <a href="https://discord.gg/5TXdhKJ">Discord server</a>, чтобы вы могли общаться с другими пользователями о последних обновлениях. В противном случае напишите нам по адресу <a href="mailto:support@oxygenupdater.com">support@oxygenupdater.com</a> со своими предложениями/отзывами.</string>
 	<string name="about_support">Если вы хотите поддержать нас, вы можете либо купить разблокировку без рекламы (настройки приложения), либо проверить наш <a href="https://patreon.com/oxygenupdater">Patreon page</a>.</string>
 	<string name="about_background_story_header">Предыстория</string>
-	<string name="about_background_story">Это приложение было первоначально разработано Арьяном Влеком как продолжение другого его приложения, которое называется <a href="https://cyanogenupdatetracker.com/">Cyanogen Update Tracker</a> (он предоставляет аналогичные функции для пользователей Cyanogen OS). \n\nЧерез 4 года, в июле 2019 года, Арьян решил уйти из обоих проектов и передал право владения приложением команде разработчиков из разных стран. Они взяли на себя ответственность предоставить сообществу отличный сервис и поддержку для более быстрого получения обновлений OnePlus. \nВы можете найти дополнительную информацию об объявлении <a href="https://oxygenupdater.com/article/81/">здесь</a>. \n\n14 августа 2019 года был выпущен первый выпуск под новым владельцем, который включал в себя новые функции, такие как темный режим и полностью переработанный дизайн. \n\nДля получения дополнительной информации о команде, проверьте <a href="https://oxygenupdater.com/team/">веб-сайт</a>.</string>
-	<string name="about_third_party_app_notice">Обратите внимание, что это не официальное приложение OnePlus. \nНазвание OnePlus, логотип OnePlus и OxygenOS являются собственностью OnePlus. \nAndroid, Google, Google Play и логотип Google Play являются зарегистрированными товарными знаками Google Inc. \nЭто приложение использует данные от OnePlus и его материнской компании Oppo для отображения информации об обновлениях.</string>
+	<string name="about_background_story">Это приложение было первоначально разработано Арьяном Влеком как продолжение другого его приложения, которое называется <a href="https://cyanogenupdatetracker.com/">Cyanogen Update Tracker</a> (он предоставляет аналогичные функции для пользователей Cyanogen OS).\n\nЧерез 4 года, в июле 2019 года, Арьян решил уйти из обоих проектов и передал право владения приложением команде разработчиков из разных стран. Они взяли на себя ответственность предоставить сообществу отличный сервис и поддержку для более быстрого получения обновлений OnePlus.\nВы можете найти дополнительную информацию об объявлении <a href="https://oxygenupdater.com/article/81/">здесь</a>.\n\n14 августа 2019 года был выпущен первый выпуск под новым владельцем, который включал в себя новые функции, такие как темный режим и полностью переработанный дизайн.\n\nДля получения дополнительной информации о команде, проверьте <a href="https://oxygenupdater.com/team/">веб-сайт</a>.</string>
+	<string name="about_third_party_app_notice">Обратите внимание, что это не официальное приложение OnePlus.\nНазвание OnePlus, логотип OnePlus и OxygenOS являются собственностью OnePlus.\nAndroid, Google, Google Play и логотип Google Play являются зарегистрированными товарными знаками Google Inc.\nЭто приложение использует данные от OnePlus и его материнской компании Oppo для отображения информации об обновлениях.</string>
 	<string name="about_rate_button_text">"Оценить"</string>
 	<string name="about_website_button_text">Веб-сайт</string>
 	<string name="about_email_button_text">Эл. адрес</string>
 
 	<!-- LocalNotifications strings -->
+	<string name="notification_permission_title">"Оставайтесь в курсе событий"</string>
+	<string name="notification_permission_text">"Разрешите приложению уведомлять вас об обновлениях OTA, новостях, текущем состоянии загрузки и других важных вещах. В дальнейшем вы можете изменить свои предпочтения в настройках приложения."</string>
 	<string name="notification_new_device_text">"%1$s теперь поддерживается. Откройте приложение, чтобы выбрать это устройство."</string>
 	<string name="notification_no_notification_support">"Установите или обновите службы Google Play, чтобы включить push-уведомления."</string>
 	<string name="notification_version">"%1$s доступен для %2$s!"</string>
@@ -273,7 +204,7 @@
 	<string name="general_notification_channel_name">Основной</string>
 	<string name="url_submitted_notification_channel_name">Представлен URL-адрес OTA</string>
 	<string name="download_status_notification_channel_description">Уведомления, отражающие текущее состояние загрузки: ожидающая, активная, завершенная или неудачная.</string>
-	<string name="verification_status_notification_channel_description">Уведомления, которые отражают текущее состояние задачи проверки файлов: выполняется, завершено или не удалось. \nПроверяются контрольные суммы MD5 для загруженных файлов, чтобы убедиться, что файл не был подделан и является допустимым файлом обновления.</string>
+	<string name="verification_status_notification_channel_description">Уведомления, которые отражают текущее состояние задачи проверки файлов: выполняется, завершено или не удалось.\nПроверяются контрольные суммы MD5 для загруженных файлов, чтобы убедиться, что файл не был подделан и является допустимым файлом обновления.</string>
 	<string name="installation_status_notification_channel_description">Получайте уведомления об успешной установке обновления</string>
 	<string name="update_notification_channel_description">Получайте уведомления, когда для выбранного устройства и метода обновления доступно новое обновление</string>
 	<string name="news_notification_channel_description">Получайте уведомления, когда мы публикуем новостную статью</string>
@@ -281,42 +212,9 @@
 	<string name="general_notification_channel_description">Общие уведомления, не относящиеся к другим категориям</string>
 	<string name="url_submitted_notification_channel_description">Получайте уведомления, когда вы успешно отправили URL-адреса OTA нашей команде.\nВы можете отказаться от автоматической отправки URL-адресов в настройках приложения.</string>
 
-	<!-- Help strings -->
-	<string name="help">"Помощь"</string>
-	<string name="help_updating_your_device_title">"Обновление устройства"</string>
-	<string name="help_updating_your_device_text">"При открытии приложения вы увидите, доступно ли обновление системы. Если обновление доступно, его можно установить.
-
-Чтобы начать установку, нажмите кнопку «Загрузить» (ниже описания обновления), чтобы начать загрузку. Когда загрузка завершена, появится экран установки. Если вы покинули приложение или экран не появился, нажмите кнопку «Установить», которая теперь отображается рядом с кнопкой «Загрузить».
-
-На экране установки сначала проверьте, есть ли у вас рут-права. Если есть, дайте приложению доступ к руту и выберите удобный способ установка обновления.
-
-Автоматическая установка:
-Вам нужно будет выбрать параметры установки. Рекомендуются настройки по умолчанию, за исключением того, что нужно будет выбрать архив с рутом, который должен быть установлен. Выберите файл установки рута (zip-архиа с помощью кнопки синей папки и нажмите «Начать установку».
-
-Ручная установка:
-На экране вы увидите руководство по установке. Запишите инструкции и выполните их, как указано для установки обновления."</string>
-	<string name="help_reading_news_title">"Чтение последних новостей."</string>
-	<string name="help_reading_news_text">"Новости отображаются слева от вкладки \"Обновить\". Самые актуальные новости находятся сверху. Просто нажмите на них, чтобы прочитать.
-Нажмиие на чёрную стрелку или кнопку \"назад\" для возврата к списку новостей."</string>
-	<string name="help_device_information_title">"Просмотр информации об устройстве"</string>
-	<string name="help_device_information_text">"Вы можете просмотреть некоторые характеристики вашего устройства, используя вкладку справа от информации об обновлении. Это пригодится при обращении в техподдержку, где вам могут потребоваться некоторые характеристики вашего устройства."</string>
-	<string name="help_change_settings_title">"Изменение настроек"</string>
-	<string name="help_change_settings_text">"Вы можете изменить настройки, нажав три точки в правом верхнем углу, затем выбрав «Настройки».
-Вы можете изменить следующие настройки:
-
-• Модель устройства и способ обновления;
-• Push-уведомления;
-• Уведомления приложения;
-• Настройки приватности (отправка log-файлов).
-
-Используйте переключатели для включения и выключения настроек уведомлений / конфиденциальности. Выберите устройство и/или способ обновления, используя раскрывающиеся меню, показанные выше переключателей. Выпадающие меню не видны? Проверьте подключение к Интернету и снова откройте настройки."</string>
-
 	<!-- News strings -->
 	<string name="news">"Новости"</string>
-	<string name="news_date_published">"Последнее обновление: %1$s"</string>
-	<string name="news_empty">"В этой статье нет содержания."</string>
 	<string name="news_load_network_error">"Не удалось открыть статью. Нет сетевого подключения. Нажмите «Повторить» для загрузки"</string>
-	<string name="news_load_id_error"><![CDATA[Не удалось открыть статью с недопустимого URL-адреса: %1$s. Проверьте URL-адрес или сообщите нам об этом через <a href="mailto:support@oxygenupdater.com">email</a> или на наш <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
 	<string name="news_unread_count_1">У вас %1$d непрочитанных новостных статей. Нажмите здесь, чтобы просмотреть их.</string>
 	<string name="news_unread_count_2">У вас %1$d непрочитанных новостных статей. Нажмите, чтобы показать все статьи.</string>
 	<string name="news_mark_read">Пометить, как прочитанное</string>
@@ -325,7 +223,7 @@
 	<string name="news_empty_state_none_available_header">Еще нет статей</string>
 	<string name="news_empty_state_all_read_header">Больше нечего читать</string>
 	<string name="news_empty_state_none_available_text">В данный момент нет доступных статей, проверьте позже.</string>
-	<string name="news_empty_state_all_read_text">Вы прочитали все статьи. Хорошая работа! \nМы надеемся, что вам понравилось читать наши статьи, и вы узнали из них что-то новое. \n\nСнова нажмите на баннер, чтобы показать все новостные статьи.</string>
+	<string name="news_empty_state_all_read_text">Вы прочитали все статьи. Хорошая работа!\nМы надеемся, что вам понравилось читать наши статьи, и вы узнали из них что-то новое.\n\nСнова нажмите на баннер, чтобы показать все новостные статьи.</string>
 
 	<!-- Contribute strings -->
 	<string name="contribute">Стать участником</string>
@@ -342,12 +240,10 @@
 	<string name="error_app_outdated">"О нет!"</string>
 	<string name="error_app_outdated_message">"Версия приложения устарела. Пришло время обновить его! Нажмите «Google Play» ниже. В Google Play нажмите «Обновить»."</string>
 	<string name="error_app_requires_network_connection">"Нет сетевого подключени"</string>
-	<string name="error_app_requires_network_connection_message">"Не удалось подключиться к серверу. Убедитесь, что у вас работает интернет. Приложение будет закрыто."</string>
 	<string name="error_google_play_button_text">Play Mаркет</string>
-	<string name="error_no_internet_connection">"Нет сетевого подключения"</string>
 	<string name="error_maintenance">"Обслуживание сервера"</string>
 	<string name="error_maintenance_message">"Пожалуйста, подождите. Сервер будет доступен очень скоро."</string>
-	<string name="error_maintenance_retry">Сервер может быть отключен для обслуживания. Повторите попытку через некоторое время или сообщите нам об этом по <a href="mailto:support@oxygenupdater.com">электронной почте</a> или на наш <a href="https://discord.gg/5TXdhKJ">Сервер Discord</a>.</string>
+	<string name="error_maintenance_retry"><![CDATA[Сервер может быть отключен для обслуживания. Повторите попытку через некоторое время или сообщите нам об этом по <a href="mailto:support@oxygenupdater.com">электронной почте</a> или на наш <a href="https://discord.gg/5TXdhKJ">Сервер Discord</a>.]]></string>
 	<string name="error_reload">"Повторить попытку"</string>
 	<string name="error_unable_to_rate_app">"Невозможно оценить приложение, так как на устройстве отсутствует Google Play Mаркет."</string>
 
@@ -371,7 +267,6 @@
 	<string name="purchase_error_after_payment">"Покупка версии без рекламы не удалось, поскольку произошла внутренняя ошибка. Пожалуйста, повторите попытку через несколько минут. Если деньги списались, свяжитесь с тех. поддержкой Google Play для помощи."</string>
 
 	<!-- Other strings -->
-	<string name="error">ошибка</string>
 	<string name="icon">"Иконка"</string>
 	<string name="loading">"Загрузка…"</string>
 	<string name="processing">"Обработка…"</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="device_chooser_error_title">Nepodarilo sa načítať zoznam podporovaných zariadení</string>
-
 	<!-- Update information strings-->
 	<string name="enable">Prijať</string>
 	<string name="update_information_description_not_available">Nie sú žiadne oficiálne informácie o nových funkciách, ktoré táto aktualizácia poskytuje. Aktualizácia zvyčajne poskytuje opravy chýb, vylepšenia výkonu a/alebo dôležité bezpečnostné aktualizácie vášho zariadenia.</string>
@@ -13,11 +11,10 @@
 	<string name="update_information_banner_server">Klepnutím tu zobrazíte dôležité oznámenia</string>
 	<string name="update_information_banner_advanced_mode_tip">Vybrali ste \"%1$s\" aktualizačný kanál. Ak plánujete prejsť na tento kanál aktualizácií, povoľte pokročilý režim.</string>
 	<string name="update_information_header_advanced_mode_hint">Pokročilý režim je povolený</string>
-	<string name="update_information_header_advanced_mode_helper">Pretože ste povolili pokročilý režim, môžete si stiahnuť najnovšiu verziu ZIP pre \"%1$s\".\n\nPokročilý režim môžete vypnúť v nastaveniach.</string>
-	<string name="update_information_different_version_changelog_notice">Prezeráte si zoznam zmien najnovšej aktualizácie v kanále aktualizácií \"%1$s\". Ak chcete nainštalovať túto aktualizáciu, musíte najskôr povoliť pokročilý režim (v nastaveniach).\n\nAk chcete však namiesto toho zobraziť zoznam zmien aktuálne nainštalovanej verzie, budete musieť prepnúť späť na správnu metódu aktualizácie.</string>
-	<string name="update_information_last_checked_on">Naposledy kontrolované: %1$s</string>
+	<string name="update_information_header_advanced_mode_helper">Pretože ste povolili pokročilý režim, môžete si stiahnuť najnovšiu verziu ZIP pre \"%1$s\". Pokročilý režim môžete vypnúť v nastaveniach.</string>
+	<string name="update_information_different_version_changelog_notice_base">Poznámka: tento zoznam zmien sa týka najnovšej dostupnej verzie (%1$s) v metóde aktualizácie \"%2$s\"</string>
+	<string name="update_information_different_version_changelog_notice_advanced">. Ak máte v úmysle nainštalovať túto aktualizáciu, musíte v nastaveniach povoliť \"Pokročilý režim\".</string>
 	<string name="update_information_no_update_data_available">Nie sú k dispozícii žiadne informácie o aktualizácii</string>
-	<string name="update_information_oxygen_os_version">OxygenOS %1$s</string>
 	<string name="update_information_system_is_up_to_date">Váš systém je aktuálny</string>
 	<string name="update_information_unknown_update_name">Nepomenovaná aktualizácia pre %1$s</string>
 	<string name="update_information_view_update_information">Zobraziť informácie o aktualizácii</string>
@@ -44,7 +41,7 @@
 	<string name="download_complete_notification">Klepnutím spustíte inštaláciu</string>
 
 	<string name="download_error">Chyba pri sťahovaní</string>
-	<string name="download_error_close">ZAVRIEŤ</string>
+	<string name="download_error_close">Zavrieť</string>
 	<string name="download_error_corrupt">Stiahnutý aktualizačný súbor je poškodený! Skúste ho stiahnuť znova.</string>
 	<string name="download_error_server">Počas sťahovania aktualizácie sa vyskytla chyba servera. Skúste aktualizáciu stiahnuť znova.</string>
 	<string name="download_error_internal">Počas sťahovania aktualizácie sa, bohužiaľ, vyskytla technická chyba. Skúste ju stiahnuť znova. Ak sa to bude opakovať, obráťte sa so žiadosťou o pomoc na vývojára tejto aplikácie.</string>
@@ -52,8 +49,8 @@
 Ak by ste sa chceli dozvedieť viac, neváhajte nás kontaktovať buď prostredníctvom <a href="mailto:support@oxygenupdater.com">emailu</a> alebo na našom <a href="https://discord.gg/5TXdhKJ">Discord serveri</a>.]]></string>
 	<string name="download_error_could_not_move_temp_file">Súbor bol stiahnutý, ale nepodarilo sa ho presunúť do správneho adresára. Otvorte správcu súborov, prejdite do \"%1$s\" a ručne presuňte súbor do najvyššieho adresára interného úložiska.</string>
 
-	<string name="download_error_retry">SKÚSIŤ ZNOVA</string>
-	<string name="download_error_resume">POKRAČOVAŤ</string>
+	<string name="download_error_retry">Skúsiť znova</string>
+	<string name="download_error_resume">Pokračovať</string>
 	<string name="download_error_storage">Vo vašom zariadení nie je k dispozícii dostatok úložného priestoru na stiahnutie aktualizácie. Odstráňte niektoré súbory a skúste aktualizáciu znovu stiahnuť.</string>
 
 	<string name="download_failed">Sťahovanie zlyhalo</string>
@@ -90,9 +87,7 @@ Ak by ste sa chceli dozvedieť viac, neváhajte nás kontaktovať buď prostredn
 	<string name="summary_please_wait">Prosím čakajte…</string>
 	<string name="summary_update_method">Najskôr vyberte zariadenie</string>
 	<!-- TODO: check the following translation -->
-	<string name="summary_important_notifications_disabled">Niektoré dôležité oznámenia sú vypnuté: \"%1$s\"</string>
-	<string name="summary_theme">Nastaviť tému</string>
-	<string name="summary_language">Nastaviť jazyk</string>
+	<string name="summary_important_notifications_disabled">Niektoré dôležité oznámenia sú vypnuté:</string>
 	<string name="summary_privacy_policy">Zobraziť online</string>
 	<string name="summary_rate_app">Ohodnoťte nás 5 hviezdičkami</string>
 
@@ -123,78 +118,46 @@ Ak by ste sa chceli dozvedieť viac, neváhajte nás kontaktovať buď prostredn
 
 	<string name="settings_device">Zariadenie</string>
 	<string name="settings_entered_incorrectly">Pri ukladaní nastavení sa vyskytla chyba. Vráťte sa späť a znova vyberte zariadenie/spôsob aktualizácie.</string>
-	<string name="settings_explanation_incremental_full_update">Inkrementálnu aktualizáciu je možné nainštalovať z ktorejkoľvek verzie (okrem prípadov, keď máte odomknutý bootloader; ako spôsob aktualizácie by ste si mali vždy zvoliť úplnú aktualizáciu).\n\nBeta aktualizáciu systému OxygenOS je možné nainštalovať vždy, aj keď ste na stabilnej verzii. Ak chcete prejsť zo stabilnej verzie na beta, musíte v nastaveniach povoliť pokročilý režim. V prípade beta verzií fungujú metódy úplnej a inkrementálnej aktualizácie rovnakým spôsobom ako v prípade stabilných verzií.</string>
 
 	<string name="settings_push_from_server">Informačné a varovné správy</string>
 
 	<string name="settings_saving">Vaše nastavenia sa stále ukladajú. Ak to trvá príliš dlho: Skontrolujte sieťové pripojenie, ukončite aplikáciu a spustite ju znova.</string>
 
 	<string name="settings_advanced_mode">Pokročilý režim</string>
-	<string name="settings_advanced_mode_explanation">Pokročilý režim skryje správu \"Váš systém je aktuálny\", ktorá vám umožní stiahnuť a nainštalovať všetky aktualizácie, aj keď nemusia byť kompatibilné s vaším zariadením.\n\nTTo môže byť užitočné, keď:\n&#8226; Aktualizujete z bežnej verzie na beta verziu\n&#8226; Vraciate sa z beta verzie na bežnú verziu (nezabudnite na obnovenie továrenských nastavení zariadenia)\n&#8226; Preinštalovávate aktuálnu verziu systému.</string>
+	<string name="settings_advanced_mode_explanation">"Aplikácia zvyčajne zobrazuje aktualizácie na základe aktuálnej verzie operačného systému. V rozšírenom režime sa vždy zobrazí najnovšia dostupná aktualizácia bez ohľadu na kompatibilitu zariadenia/verzie.
+
+To môže byť užitočné, ak chcete:"</string>
+	<string name="settings_advanced_mode_uses">"&#8226; Opätovne stiahnuť najnovšiu verziu, aj keď ju už používate
+&#8226; Prepnúť na inú aktualizačnú stopu"</string>
+	<string name="settings_advanced_mode_caption">"Rozšírený režim môže byť potrebný len vo vyššie uvedených situáciách. Nemali by ste ho zapínať, ak neviete, čo robíte."</string>
 
 	<string name="settings_update_method">Spôsob aktualizácie</string>
 	<string name="settings_upload_logs">Zdieľajte údaje o používaní a logy</string>
+	<string name="settings_ad_privacy">Súhlas s reklamou podľa GDPR</string>
+	<string name="settings_ad_privacy_subtitle">"Pre používateľov v EHP/UK"</string>
 
 	<!-- FAQ strings -->
 	<string name="faq">FAQ</string>
 	<string name="faq_menu_item">FAQ</string>
 
 	<!-- First-time onboarding strings -->
-	<string name="onboarding">Vitajte</string>
+	<string name="onboarding">Nastavenie</string>
 	<string name="onboarding_finished_button">Spustiť aplikáciu</string>
 
-	<string name="onboarding_page_1_title">Vitajte v Oxygen Updater!</string>
-	<string name="onboarding_page_1_text">Táto aplikácia vám umožní:\n\n&#8226; Získajte rýchlejší prístup k najnovším aktualizáciám systému Android pre svoje zariadenie so systémom OxygenOS\n\n&#8226; Ľahko aktualizujte rootované zariadenie\n\n&#8226; Prezrite si, čo je nové v softvéri, ktorý momentálne používate\n\n&#8226; Prečítajte si najnovšie správy o OnePlus a OxygenOS\n\nPokračujte prejdením doľava.</string>
-	<string name="onboarding_page_1_caption">Toto nie je oficiálna aplikácia OnePlus. Používanie tejto aplikácie je úplne na vaše vlastné riziko. Spoločnosť OnePlus ani vývojári aplikácie nezodpovedajú za vaše kroky vrátane škôd spôsobených používaním tejto aplikácie.\n\nPoužívaním tejto aplikácie vyjadrujete súhlas s vyššie uvedenými podmienkami.</string>
-	<string name="onboarding_page_2_title">Vyberte svoje zariadenie</string>
-	<string name="onboarding_page_2_caption">Vaše zariadenie by malo byť vybrané vyššie. Ak nie, vyberte svoje zariadenie vyššie.</string>
-	<string name="onboarding_page_3_title">Vyberte spôsob aktualizácie</string>
-	<string name="onboarding_page_3_caption">Tu je zvyčajne správnou voľbou inkrementálna aktualizácia, pretože ponúka oveľa rýchlejšie a menšie sťahovanie.\n\nNie je však kompatibilná s rootovanými zariadeniami. Ak máte rootované zariadenie, vyberte možnosť Úplnej aktualizácie.\n\nAk máte beta verziu systému OxygenOS, vyberte (jeden z) Open Beta spôsobov aktualizácie.</string>
-	<string name="onboarding_page_4_title">Ste pripravení začať!</string>
-	<string name="onboarding_page_4_text">Želáme príjemné používanie aplikácie!\n\nNeskôr môžete svoje nastavenia kedykoľvek zmeniť. Urobíte to takto: Klepnite na tri bodky v pravom hornom rohu a klepnite na \"Nastavenia\".</string>
+	<string name="onboarding_app_uses">Táto aplikácia vám umožní:\n\n&#8226; Získajte rýchlejší prístup k najnovším aktualizáciám systému Android pre svoje zariadenie so systémom OxygenOS\n&#8226; Ľahko aktualizujte rootované zariadenie\n&#8226; Prezrite si, čo je nové v softvéri, ktorý momentálne používate\n&#8226; Prečítajte si najnovšie správy o OnePlus a OxygenOS</string>
+	<string name="onboarding_disclaimer">Toto nie je oficiálna aplikácia OnePlus. Používanie tejto aplikácie je úplne na vaše vlastné riziko. Spoločnosť OnePlus ani vývojári aplikácie nezodpovedajú za vaše kroky vrátane škôd spôsobených používaním tejto aplikácie. Používaním tejto aplikácie vyjadrujete súhlas s vyššie uvedenými podmienkami.</string>
+	<string name="onboarding_device_chooser_title">Vyberte svoje zariadenie</string>
+	<string name="onboarding_device_chooser_caption">Vaše zariadenie by malo byť vybrané vyššie. Ak nie, vyberte svoje zariadenie vyššie.</string>
+	<string name="onboarding_method_chooser_title">Vyberte spôsob aktualizácie</string>
+	<string name="onboarding_method_chooser_caption">Tu je zvyčajne správnou voľbou inkrementálna aktualizácia, pretože ponúka oveľa rýchlejšie a menšie sťahovanie. Nie je však kompatibilná s rootovanými zariadeniami. Ak máte rootované zariadenie, vyberte možnosť Úplnej aktualizácie. Ak máte beta verziu systému OxygenOS, vyberte (jeden z) Open Beta spôsobov aktualizácie.</string>
+	<string name="onboarding_caption">Želáme príjemné používanie aplikácie! Neskôr môžete svoje nastavenia kedykoľvek zmeniť.</string>
 
 	<!-- Automatic install strings -->
 	<string name="install">Inštalovať</string>
 
 	<!-- Install guide strings -->
-	<string name="install_guide_no_root">Nainštalujte aktualizáciu podľa pokynov v sprievodcovi inštaláciou.</string>
 	<string name="install_guide">Sprievodca inštaláciou</string>
-	<string name="install_guide_subtitle">Sprievodca inštaláciou - %1$d z %2$d</string>
-	<string name="install_guide_tip">&#8226; Odporúča sa zapísať si všetky kroky, pretože počas inštalácie aktualizácie budete musieť zariadenie vypnúť.</string>
-
-	<string name="install_guide_page_1_title">Stiahnuť aktualizáciu</string>
-	<string name="install_guide_page_1_text">&#8226; Stlačením tlačidla Stiahnuť spustíte sťahovanie aktualizácie.\n\n&#8226; Priebeh sťahovania sa zobrazí v aplikácii a ako upozornenie na obrazovke s upozorneniami.\n\n&#8226; Po dokončení sťahovania sa zobrazí upozornenie s textom \"Sťahovanie dokončené\".\nAk sa vyskytla chyba pri sťahovaní, otvorte aplikáciu a skúste znova stiahnuť aktualizáciu. Ak to nefunguje, skontrolujte funkčnosť vášho pripojenia. V opačnom prípade kontaktujte vývojára aplikácie. Môžete to urobiť tak, že v obchode Google Play navštívite sekciu \"Moje aplikácie\".</string>
-
-	<string name="install_guide_page_2_title">Príprava na inštaláciu</string>
-	<string name="install_guide_page_2_text">"Poznámka: Inštalácia aktualizácie sa uskutočňuje na špeciálnej stránke štandardnej časti Aktualizácie systému vášho zariadenia. Ak sa pri otvorení tejto časti z nejakého dôvodu objaví aktualizácia systému, môžete sa tiež najskôr rozhodnúť nainštalovať túto aktualizáciu. Potom znova otvorte Oxygen Updater a zistite, či máte nainštalovanú najnovšiu verziu.
-
-Inštrukcie:
-&#8226; Zatvorte Oxygen Updater stlačením tlačidla Domov.
-
-&#8226; Otvorte nastavenia. Mali by sa nachádzať v zásuvke aplikácií.
-
-&#8226; Posúvajte sa dole, kým neuvidíte aktualizácie systému. Klepnite na ne."</string>
-
-	<string name="install_guide_page_3_title">Inštalácia aktualizácie</string>
-	<string name="install_guide_page_3_text">"Teraz, keď ste v aktualizáciach systému, je čas nainštalovať aktualizáciu.
-
-&#8226; V sekcii aktualizácie systému klepnite na ikonu ozubeného kolieska vpravo hore
-
-&#8226; Vyberte \"Lokálna aktualizácia\". Mala by sa zobraziť obrazovka na výber súboru.
-
-&#8226; Na tejto obrazovke klepnite na aktualizačný súbor, ktorý ste si stiahli pomocou Oxygen Updater. Jeho názov by mal začínať \"%1$sOxygen\".
-
-&#8226; Klepnite na \"Aktualizovať teraz\". Inštalácia by sa mala spustiť automaticky."</string>
-
-	<string name="install_guide_page_4_title">Počkajte, kým sa inštalácia nedokončí</string>
-	<string name="install_guide_page_4_text">"&#8226; Telefón teraz nainštaluje aktualizáciu a zobrazí priebeh inštalácie. Počkajte, kým sa inštalácia nedokončí. Môže to trvať od niekoľkých do 15 minút.
-
-&#8226; Následne sa telefón reštartuje, aby sa aktualizácia dokončila."</string>
-
-	<string name="install_guide_page_5_title">Hotovo. Užite si novú verziu OxygenOS!</string>
-	<string name="install_guide_page_5_text">&#8226; Po dokončení optimalizácie aplikácií v telefóne sa aktualizácia úspešne nainštalovala.\nAk to chcete overiť, môžete skontrolovať aktuálnu verziu vášho systému nasledovne:\n\n&#8226; Prejdite do Nastavení, klepnite na \"Informácie o telefóne\", a skontrolujte verziu OxygenOS.\n\n&#8226; Ak sa vám táto aplikácia páči, ohodnoťte ju 5 hviezdičkami v  Google Play!</string>
-
-	<string name="install_guide_close_button">Zavrieť Sprievodcu inštaláciou</string>
+	<string name="install_guide_download_instructions">&#8226; Stlačením tlačidla Stiahnuť spustíte sťahovanie aktualizácie.\n&#8226; Priebeh sťahovania sa zobrazí v aplikácii a ako upozornenie na obrazovke s upozorneniami.\n&#8226; Po dokončení sťahovania sa zobrazí upozornenie s textom \"Sťahovanie dokončené\". Ak sa vyskytla chyba pri sťahovaní, otvorte aplikáciu a skúste znova stiahnuť aktualizáciu. Ak to nefunguje, skontrolujte funkčnosť vášho pripojenia. V opačnom prípade kontaktujte vývojára aplikácie. Môžete to urobiť tak, že v obchode Google Play navštívite sekciu \"Moje aplikácie\".</string>
 
 	<!-- Device information strings -->
 	<string name="device_information_supported_oxygen_os">Vaše zariadenie je podporované</string>
@@ -211,7 +174,7 @@ Inštrukcie:
 	<string name="device_information_image_description">Snímka zariadenia</string>
 	<string name="device_information_incremental_os_version">Inkrementálna verzia OS</string>
 	<string name="device_information_os_version">Verzia Androidu</string>
-	<string name="device_information_oxygen_os_version">Verzia OxygenOS</string>
+	<string name="device_information_oxygen_os_version">Verzia OS</string>
 	<string name="device_information_oxygen_os_ota_version">Verzia OTA</string>
 	<string name="device_information_patch_level_version">Dátum bezpečnostnej opravy</string>
 	<string name="device_information_serial_number">Sériové číslo</string>
@@ -230,6 +193,8 @@ Inštrukcie:
 	<string name="about_email_button_text">Email</string>
 
 	<!-- LocalNotifications strings -->
+	<string name="notification_permission_title">"Zostaňte informovaní"</string>
+	<string name="notification_permission_text">"Povoľte aplikácii, aby vás upozorňovala na aktualizácie OTA, novinky, stav prebiehajúceho sťahovania a ďalšie dôležité veci. Svoje nastavenia môžete neskôr doladiť v nastaveniach aplikácie."</string>
 	<string name="notification_new_device_text">%1$s je teraz podporovaný. Otvorte aplikáciu a vyberte toto zariadenie.</string>
 	<string name="notification_no_notification_support">Nainštalujte alebo aktualizujte Google Play services a povoľte push notifikácie.</string>
 	<string name="notification_version">%1$s je k dispozícii pre %2$s!</string>
@@ -255,23 +220,9 @@ Inštrukcie:
 	<string name="general_notification_channel_description">Všeobecné oznámenia, ktoré sa nehodia do iných kategórií</string>
 	<string name="url_submitted_notification_channel_description">Dostávajte upozornenia, keď nášmu tímu úspešne odošlete adresy URL OTA.\nAutomatické odosielanie adries URL môžete odmietnuť v nastaveniach aplikácie.</string>
 
-	<!-- Help strings -->
-	<string name="help">Pomoc</string>
-	<string name="help_updating_your_device_title">Aktualizácia vášho zariadenia</string>
-	<string name="help_updating_your_device_text">Po otvorení aplikácie uvidíte, či je k dispozícii aktualizácia systému. Ak je k dispozícii aktualizácia, môžete si ju nainštalovať.\n\nInštaláciu spustíte klepnutím na tlačidlo \"Stiahnuť\" (pod popisom aktualizácie), pre spustenie sťahovania. Po dokončení sťahovania sa zobrazí inštalačná obrazovka. Ak ste aplikáciu opustili alebo sa obrazovka nezobrazila, klepnite na tlačidlo \"Inštalovať\", ktoré sa zobrazí vedľa tlačidla \"Stiahnuť\".\n\nInštalačná obrazovka najskôr skontroluje, či máte rootované zariadenie. Ak máte rootované zariadenie, na požiadanie udeľte povolenie root a vyberte, ako chcete aktualizáciu nainštalovať. V opačnom prípade postupujte podľa pokynov pre manuálnu inštaláciu.\n\nAutomatická inštalácia:\nBudete si musieť zvoliť možnosti inštalácie. Predvolené nastavenia sa odporúčajú, až na to, že musíte určiť root balík, ktorý je potrebné (znovu) nainštalovať. Vyberte root balík (súbor zip) pomocou modrého tlačidla priečinka a klepnutím na \"Začať inštaláciu\" spustíte inštaláciu.\n\nRučná inštalácia:\nNa obrazovke sa zobrazí sprievodca inštaláciou. Zapíšte si pokyny a podľa pokynov ich nainštalujte.</string>
-	<string name="help_reading_news_title">Čítanie najnovších správ</string>
-	<string name="help_reading_news_text">Správy sa zobrazujú naľavo od obrazovky Aktualizácia. Najnovšie položky sa zobrazujú navrchu. Stačí si ťuknúť na položku a prečítať si ju.\nKlepnutím na šípku späť alebo stlačením klávesu Späť sa vrátite na obrazovku so správami.</string>
-	<string name="help_device_information_title">Prezeranie informácií o vašom zariadení</string>
-	<string name="help_device_information_text">Niektoré technické parametre svojho prístroja môžete zobraziť pomocou obrazovky napravo od obrazovky Aktualizácia. To sa hodí pri podávaní žiadosti o podporu, počas ktorej sa od vás môžu vyžadovať niektoré zo špecifikácií vášho zariadenia.</string>
-	<string name="help_change_settings_title">Zmena nastavení</string>
-	<string name="help_change_settings_text">Svoje nastavenia môžete zmeniť klepnutím na tri bodky vpravo hore a klepnutím na Nastavenia.\nMôžete zmeniť nasledujúce nastavenia:\n\n• Zariadenie a spôsob aktualizácie\n• Push notifikácie\n• Notifikácie v aplikácii\n• Nastavenia súkromia (nahrávanie logov).\n\nPomocou prepínačov zapnite a vypnite nastavenia upozornení a súkromia. Vyberte zariadenie alebo spôsob aktualizácie pomocou rozbaľovacích ponúk zobrazených nad prepínačmi. Rozbaľovacie ponuky nie sú viditeľné? Skontrolujte svoje internetové pripojenie a znova otvorte Nastavenia.</string>
-
 	<!-- News strings -->
 	<string name="news">Novinky</string>
-	<string name="news_date_published">Posledná aktualizácia: %1$s</string>
-	<string name="news_empty">Tento článok nemá žiadny obsah.</string>
-	<string name="news_load_network_error">Článok sa nepodarilo otvoriť. Skontrolujte svoje pripojenie a stlačením tlačidla \"SKÚSIŤ ZNOVA\" otvorte článok</string>
-	<string name="news_load_id_error"><![CDATA[Nepodarilo sa otvoriť článok z neplatnej adresy URL: %1$s. Skontrolujte adresu URL alebo nám to nahláste prostredníctvom <a href="mailto:support@oxygenupdater.com">emailu</a> alebo na našom <a href="https://discord.gg/5TXdhKJ">Discord serveri</a>.]]></string>
+	<string name="news_load_network_error">Článok sa nepodarilo otvoriť. Skontrolujte svoje pripojenie a stlačením tlačidla \"Skúsiť znova\" otvorte článok</string>
 	<string name="news_unread_count_1">Máte %1$d neprečítaných správ. Klepnutím tu ich zobrazíte.</string>
 	<string name="news_unread_count_2">Máte %1$d neprečítaných správ. Klepnutím zobrazíte všetky články.</string>
 	<string name="news_mark_read">Označiť ako prečítané</string>
@@ -297,12 +248,10 @@ Inštrukcie:
 	<string name="error_app_outdated">Oh nie!</string>
 	<string name="error_app_outdated_message">Táto verzia aplikácie je zastaraná. Je čas to aktualizovať! Klepnite nižšie na \"Google Play\". V službe Google Play klepnite na \"Aktualizovať\".</string>
 	<string name="error_app_requires_network_connection">Žiadne pripojenie</string>
-	<string name="error_app_requires_network_connection_message">Nepodarilo sa pripojiť k serveru. Uistite sa, že máte funkčné pripojenie. Aplikácia sa teraz zatvorí.</string>
 	<string name="error_google_play_button_text">Google Play</string>
-	<string name="error_no_internet_connection">Žiadne pripojenie.</string>
 	<string name="error_maintenance">Údržba serverov</string>
 	<string name="error_maintenance_message">Prosím čakajte. Server bude čoskoro k dispozícii.</string>
-	<string name="error_maintenance_retry">Server môže byť kvôli údržbe mimo prevádzky. Skúste to znova po nejakom čase alebo nám to nahláste prostredníctvom <a href="mailto:support@oxygenupdater.com">emailu</a> alebo na našom <a href="https://discord.gg/5TXdhKJ">Discord serveri</a>.</string>
+	<string name="error_maintenance_retry"><![CDATA[Server môže byť kvôli údržbe mimo prevádzky. Skúste to znova po nejakom čase alebo nám to nahláste prostredníctvom <a href="mailto:support@oxygenupdater.com">emailu</a> alebo na našom <a href="https://discord.gg/5TXdhKJ">Discord serveri</a>.]]></string>
 	<string name="error_reload">Znova načítať</string>
 
 	<string name="error_unable_to_rate_app">Aplikáciu nemôžete hodnotiť, pretože vo vašom zariadení chýba Obchod Google Play.</string>
@@ -327,7 +276,6 @@ Inštrukcie:
 	<string name="purchase_error_after_payment">Nákup verzie bez reklám zlyhal, pretože sa vyskytla interná chyba. Prosím skúste znovu o pár minút. Ak ste už zaplatili, požiadajte o pomoc podporu Google Play.</string>
 
 	<!-- Other strings-->
-	<string name="error">Error</string>
 	<string name="icon">Ikona</string>
 	<string name="loading">Načítavam…</string>
 	<string name="processing">Spracovávam…</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools" tools:keep="@string/install_guide_page_*_*">
-	<string name="device_chooser_error_title">Није могуће преузети листу подржаних уређаја</string>
-
+<resources>
 	<!-- Update information strings-->
 	<string name="enable">Омогући</string>
 	<string name="update_information_description_not_available">Нема званичних информација о новим могућностима овог ажурирања. Обично, овакво ажурирање поправња грешке, повећавање перформанси, и / или критична ажурирања сигурности за ваш уређај.</string>
@@ -13,13 +11,12 @@
 	<string name="update_information_error_title">Не могу преузети најновије информације о ажурирању</string>
 	<string name="update_information_banner_server">Додирните овде да бисте видели важна обавештења</string>
 	<!-- TODO: translate these 2 strings below -->
-	<string name="update_information_banner_advanced_mode_tip">You\'ve selected the \"%1$s\" update track. Enable напредни мод if you plan to switch to this update track.</string>
+	<string name="update_information_banner_advanced_mode_tip">You\'ve selected the \"%1$s\" update method. Enable напредни мод if you plan to switch to this update method.</string>
 	<string name="update_information_header_advanced_mode_hint">Омогућен је напредни режим</string>
-	<string name="update_information_header_advanced_mode_helper">Пошто сте укључили напредни мод, можете преузети последњи ZIP за \"%1$s\".\n\nМожете искључити напредни мод из подешавања.</string>
-	<string name="update_information_different_version_changelog_notice">Прегледавате дневник измена за најновију исправку у систему \"%1$s\" записника надоградње. Ако намеравате да инсталирате ову исправку, морате прво укључити напредни мод (у подешавањима).\n\nКако год, ако уместо тога желите да видите дневник измена за тренутну верзију, мораћете се вратити на исправан начин ажурирања.</string>
-	<string name="update_information_last_checked_on">Задња провера: %1$s</string>
+	<string name="update_information_header_advanced_mode_helper">Пошто сте укључили напредни мод, можете преузети последњи ZIP за \"%1$s\". Можете искључити напредни мод из подешавања.</string>
+	<string name="update_information_different_version_changelog_notice_base">Напомена: овај дневник промена је за најновију доступну верзију (%1$s) у методи ажурирања \"%2$s\"</string>
+	<string name="update_information_different_version_changelog_notice_advanced">. Ако намеравате да инсталирате ову исправку, морате да омогућите „Напредни мод“ у подешавањима.</string>
 	<string name="update_information_no_update_data_available">Нема новости о ажурирању</string>
-	<string name="update_information_oxygen_os_version">OxygenOS %1$s</string>
 	<string name="update_information_system_is_up_to_date">Твој систем користи најновија ажурирања</string>
 	<string name="update_information_unknown_update_name">Неименовано ажурирање за %1$s</string>
 	<string name="update_information_view_update_information">Погледај податке о ажурирању</string>
@@ -46,7 +43,7 @@
 	<string name="download_complete_notification">Притисните за почетак инсталације</string>
 
 	<string name="download_error">Грешка при преузимању</string>
-	<string name="download_error_close">ЗАТВОРИ</string>
+	<string name="download_error_close">Затвори</string>
 	<string name="download_error_corrupt">Преузети фајл је оштећен! Молимо вас покушајте да преузмете поново.</string>
 	<string name="download_error_server">Грешка са сервером је настала приликом преузимања. Молимо вас покушајте да преузмете поново.</string>
 	<string name="download_error_internal">Нажалост, техничка грешка је настала приликом преузимања ажурирања. Молимо вас покушајте да преузмете поново. Ако грешка настави да се појављује, молимо вас контактирајте нас за помоћ.</string>
@@ -55,8 +52,8 @@
 Ако желите да сазнате више, осећајте се слободно да нас контактирате путем <a href="mailto:support@oxygenupdater.com">email</a> или на нашем <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
 	<string name="download_error_could_not_move_temp_file">Фајл је преузет, али не може бити пребачен у исправни директоријум. Отворите менаџер фајлова, идите на \"%1$s\" и ручно преместите фајл у највиши директориј интерне меморије.</string>
 
-	<string name="download_error_retry">ПОНОВИ</string>
-	<string name="download_error_resume">НАСТАВИ</string>
+	<string name="download_error_retry">Понови</string>
+	<string name="download_error_resume">Настави</string>
 	<string name="download_error_storage">Немате довољно простора на уређају за ажурирање. Молимо вас уклоните неке податке и покушајте поново.</string>
 
 	<string name="download_failed">Недовољно простора</string>
@@ -93,9 +90,7 @@
 	<string name="summary_please_wait">Молимо сачекајте…</string>
 	<string name="summary_update_method">Прво селектујте уређај</string>
 	<!-- TODO: check the following translation -->
-	<string name="summary_important_notifications_disabled">Нека важна обавештења су онемогућена: \"%1$s\"</string>
-	<string name="summary_theme">Поставите тему</string>
-	<string name="summary_language">Поставите језик</string>
+	<string name="summary_important_notifications_disabled">Нека важна обавештења су онемогућена:</string>
 	<string name="summary_privacy_policy">Погледајте на интернету</string>
 	<string name="summary_rate_app">Оставите нам 5 звездица</string>
 
@@ -126,78 +121,46 @@
 
 	<string name="settings_device">Уређај</string>
 	<string name="settings_entered_incorrectly">Грешка приликом чувања ваших подешавања. Молимо вас и изаберите ваш уређај / методу ажурирања.</string>
-	<string name="settings_explanation_incremental_full_update">Делимично ажурирање се може извршити са било које верзије (ако немате "bootloader" откључан; онда бисте требали изабрати методу пуног ажурирања).\n\nA beta ажурирање OxygenOS-а може увек бити инсталирано, и када сте на стабилној верзији. За пребацивање са стабилне на beta верзију, морате да омогућите напредни мод у подешавањима. За beta-е, методе целог и делимичног ажурирања раде на исти начин као на стабилним верзијама.</string>
 
 	<string name="settings_push_from_server">Важна порука је доступна</string>
 
 	<string name="settings_saving">Ваша подешавања се још убек чувају. Ако ово предуго траје: Проверите вашу конекцију, изађите из апликације и покушајте поново.</string>
 
 	<string name="settings_advanced_mode">Напредни мод</string>
-	<string name="settings_advanced_mode_explanation">Напредни мод скрива ову поруку \"Ваш систем је на најновијим ажурирањима\", дозвољавајући вам да преузмете и инсталирате сва ажурирања, иако она можда нису компатибилна са вашим уређајем.\n\nОво може бити корисно када:\n&#8226; Ажурирање са регуларне верзије на beta верзију\n&#8226; Враћање са beta верзије на регуларну верзију (не заборавите да вратите на фабричка подешавања ваш уређај)\n&#8226; Реинсталације ваше тренутне верзије система.</string>
+	<string name="settings_advanced_mode_explanation">"Обично вам апликација приказује ажурирања на основу ваше тренутне верзије ОС-а. Са напредним режимом, најновије доступно ажурирање ће увек бити приказано без обзира на компатибилност уређаја/верзије.
+
+Ово може бити корисно ако желите да:"</string>
+	<string name="settings_advanced_mode_uses">"&#8226; Поново преузмите најновију верзију чак и ако је већ користите
+&#8226; Пребаците се на другу стазу ажурирања"</string>
+	<string name="settings_advanced_mode_caption">"Напредни режим може бити потребан само у горе наведеним ситуацијама. Не би требало да га омогућавате осим ако не знате шта радите."</string>
 
 	<string name="settings_update_method">Методе ажурирања</string>
 	<string name="settings_upload_logs">Подели податке коришћења и записе</string>
+	<string name="settings_ad_privacy">ГДПР сагласност за оглашавање</string>
+	<string name="settings_ad_privacy_subtitle">"За кориснике ЕЕА/УК"</string>
 
 	<!-- FAQ strings -->
 	<string name="faq">FAQ</string>
 	<string name="faq_menu_item">FAQ</string>
 
 	<!-- First-time setup strings -->
-	<string name="onboarding">Добродошли</string>
+	<string name="onboarding">Подесити</string>
 	<string name="onboarding_finished_button">Покрените апликацију</string>
 
-	<string name="onboarding_page_1_title">Добродошли у Oxygen Updater!</string>
-	<string name="onboarding_page_1_text">Ова апликација ће вам омогућити:\n\n&#8226; Добијте бржи приступ последњим ажурирањима андроида за ваше уређаје који раде на OxgenOS-y.\n\n&#8226; Лако ажурирајте рутован уређај\n\n&#8226; Погледајте шта има ново у софтверу који тренутно користите\n\n&#8226; Прочитајте последње вести о OnePlus-у и OxgenOS-у\n\nПревуците лево за наставак.</string>
-	<string name="onboarding_page_1_caption">Ово није званична OnePlus апликација. Користите ову апликацију комплетно на ваш ризик. Ни OnePlus нити људи који раде на овој апликацији нису одговорни за ваше поступке, укључујући било коју штету која је настала коришћењем ове апликације.\n\nКоришћењем ове апликације прихватате услове наведене изнад.</string>
-	<string name="onboarding_page_2_title">Изаберите ваш уређај</string>
-	<string name="onboarding_page_2_caption">Обично је ваш уређај већ изабран. Ако није, изаберите уређај изнад.</string>
-	<string name="onboarding_page_3_title">Изаберите методу ажурирањ</string>
-	<string name="onboarding_page_3_caption">Обично је делимично ажурирање прави избор, зато што омогућава мања и бржа преузимања.\n\nАли тај метод ажурирања није компатибилан са рутованим уређајима. Ако имате рутован уређај изаберите пуно ажурирање.\n\nАко имате beta верзију OxgenOS-a, изаберите једну од Open Beta метода ажурирања.</string>
-	<string name="onboarding_page_4_title">Спремни сте за коришћење!</string>
-	<string name="onboarding_page_4_text">Уживајте у коришћењу апликације!\n\nМожете увек променити поставке у подешавањима касније. Да урадите то: кликните на три тачке у горњем десном углу, и притисните на \"Settings\".</string>
+	<string name="onboarding_app_uses">Ова апликација ће вам омогућити:\n\n&#8226; Добијте бржи приступ последњим ажурирањима андроида за ваше уређаје који раде на OxgenOS-y.\n&#8226; Лако ажурирајте рутован уређај\n&#8226; Погледајте шта има ново у софтверу који тренутно користите\n&#8226; Прочитајте последње вести о OnePlus-у и OxgenOS-у</string>
+	<string name="onboarding_disclaimer">Ово није званична OnePlus апликација. Користите ову апликацију комплетно на ваш ризик. Ни OnePlus нити људи који раде на овој апликацији нису одговорни за ваше поступке, укључујући било коју штету која је настала коришћењем ове апликације. Коришћењем ове апликације прихватате услове наведене изнад.</string>
+	<string name="onboarding_device_chooser_title">Изаберите ваш уређај</string>
+	<string name="onboarding_device_chooser_caption">Обично је ваш уређај већ изабран. Ако није, изаберите уређај изнад.</string>
+	<string name="onboarding_method_chooser_title">Изаберите методу ажурирањ</string>
+	<string name="onboarding_method_chooser_caption">Обично је делимично ажурирање прави избор, зато што омогућава мања и бржа преузимања. Али тај метод ажурирања није компатибилан са рутованим уређајима. Ако имате рутован уређај изаберите пуно ажурирање. Ако имате beta верзију OxgenOS-a, изаберите једну од Open Beta метода ажурирања.</string>
+	<string name="onboarding_caption">Уживајте у коришћењу апликације! Можете увек променити поставке у подешавањима касније.</string>
 
 	<!-- Automatic install strings -->
 	<string name="install">Инсталирај</string>
 
 	<!-- Install guide strings -->
-	<string name="install_guide_no_root">Инсталирај ажурирање према упуствима у "Упуство за инталацију"</string>
 	<string name="install_guide">Упуство за инталацију</string>
-	<string name="install_guide_subtitle">Упуство за инсталацију - %1$d од %2$d</string>
-	<string name="install_guide_tip">&#8226; Препоручљиво је да запишете све кораке на папир због тога што ћете морати да угасите уређај приликом инсталације ажурирања.</string>
-
-	<string name="install_guide_page_1_title">Преузмите ажурирање</string>
-	<string name="install_guide_page_1_text">&#8226; Притисните дугме за преузимање да започнете преузимање ажурирања.\n\n&#8226; Прогрес преузимања ће се појавити у апликацији, такође и као обавештење.\n\n&#8226; Када је преузимање завршено, видећете обавештење са текстом \"Преузимање завшено\".\nАко је дошло до грешке приликом преузимања, отворите апликацију и покушајте поново са преузимањем. Ако то не ради, проверите да ли имате интернет конекцију. У супротном, контактирајте нас. То можете учинити одласком на \" Моје апликације \" секцију на Goole Play продавници.</string>
-
-	<string name="install_guide_page_2_title">Припремите се за инталацију</string>
-	<string name="install_guide_page_2_text">"Белешка: Инсталација ажурирања врши се са посебне странице стандардног одељка Ажурирања система на вашем уређају. Ако се из неког разлога појављује ажурирање система приликом отварања овог одељка, можете  прво изабрати да њега инсталирате. Након тога поново отворите програм "Oxgen Updater" да видите да ли сте ажурирани на последњу верзију.
-
-Инструкције:
-&#8226; Затворите Oxygen Updater притиском на Хоме дугме.
-
-&#8226; Отворите подешавања телефона. Требало би да се налазе у менију са апликацијама.
-
-&#8226; Листајте доле док не дођете до Ажурирања система. Кликните на то."</string>
-
-	<string name="install_guide_page_3_title">Инсталирајте ажурирање</string>
-	<string name="install_guide_page_3_text">"Сада када сте у апликацији Ажурирање система, време је да инсталирате ажурирање.
-
-&#8226; У одељку „Ажурирања система“ кликните на икону зупчаника у горњем десном углу
-
-&#8226; Сада, одаберите \"Локално ажурирање\". Требало би да се појави екран за избор датотека.
-
-&#8226; На овом екрану, кликните на датотеку за ажурирање коју сте преузели помоћу Oxygen Updater-а. Име дадотеке би требало да почне са \"%1$sOxygen\".
-
-&#8226; Кликните на \"Ажурирај сада\". Инсталација би требала да почне аутоматски."</string>
-
-	<string name="install_guide_page_4_title">Сачекајте да се заврши инсталација</string>
-	<string name="install_guide_page_4_text">"&#8226; Телефон ће сада инсталирати ажурирање и приказати траку напретка. Молимо причекајте док се инсталација не заврши. Инсталација може трајати од неколико минута до 15 минута.
-
-&#8226; Након тога Ваш телефон ће се угасити и упалити да би завршио унсталацију ажурирања."</string>
-
-	<string name="install_guide_page_5_title">Завршено. Уживајте у новој OxygenOS верзији!</string>
-	<string name="install_guide_page_5_text">&#8226; Након што уређај заврши са оптимизовањем ваших апликација ажурирање ће бити успешно инсталирано.\nДа бисте проверили ово, можете проверити тренутну верзију система на следећи начин:\n\n&#8226; Идите у подешавања, кликните на \"About phone\", и проверите OxygenOS верзију.\n\n&#8226; Ако вам се свиђа апликација, молимо вас оцените нас са 5 звездица на Google Play продавници!</string>
-
-	<string name="install_guide_close_button">Затвори упуство за инсталацију</string>
+	<string name="install_guide_download_instructions">&#8226; Притисните дугме за преузимање да започнете преузимање ажурирања.\n&#8226; Прогрес преузимања ће се појавити у апликацији, такође и као обавештење.\n&#8226; Када је преузимање завршено, видећете обавештење са текстом \"Преузимање завшено\". Ако је дошло до грешке приликом преузимања, отворите апликацију и покушајте поново са преузимањем. Ако то не ради, проверите да ли имате интернет конекцију. У супротном, контактирајте нас. То можете учинити одласком на \" Моје апликације \" секцију на Goole Play продавници.</string>
 
 	<!-- Device information strings -->
 	<string name="device_information_supported_oxygen_os">Ваш уређај је подржан</string>
@@ -213,7 +176,7 @@
 	<string name="device_information_image_description">Слика уређаја</string>
 	<string name="device_information_incremental_os_version">Инкрементална OS верзија</string>
 	<string name="device_information_os_version">Верзија андроида</string>
-	<string name="device_information_oxygen_os_version">OxygenOS верзија</string>
+	<string name="device_information_oxygen_os_version">OS верзија</string>
 	<string name="device_information_oxygen_os_ota_version">OTA верзија</string>
 	<string name="device_information_patch_level_version">Датум сигурносне закрпе</string>
 	<string name="device_information_serial_number">Серијски број</string>
@@ -233,6 +196,8 @@
 	<string name="about_email_button_text">Емаил</string>
 
 	<!-- LocalNotifications strings -->
+	<string name="notification_permission_title">"Будите обавештени"</string>
+	<string name="notification_permission_text">"Дозволите апликацији да вас обавештава о ОТА ажурирањима, вестима, статусу преузимања у току и другим важним стварима. Касније можете фино подесити своја подешавања у подешавањима апликације."</string>
 	<string name="notification_new_device_text">%1$s је сада доступан. Отвори апликацију да изабереш овај уређај.</string>
 	<string name="notification_no_notification_support">Инсталирај или ажурирај Google Play сервисе да омогућиш обавештења.</string>
 	<string name="notification_version">%1$s је сада доступан за %2$s!</string>
@@ -259,24 +224,9 @@
 	<string name="general_notification_channel_description">General notifications that don\'t fit into other categories</string>
 	<string name="url_submitted_notification_channel_description">Примите обавештење када нашем тиму успешно пошаљете ОТА УРЛ адресе.\nМожете да онемогућите аутоматско слање УРЛ-ова у подешавањима апликације.</string>
 
-	<!-- Help strings -->
-	<string name="help">Помоћ</string>
-	<string name="help_updating_your_device_title">Ажурирање вашег уређаја</string>
-	<string name="help_updating_your_device_text">Када отворите апликацију видећете да ли је доступно ажурирање система. Ако је ажурирање доступно можете га инсталирати.\n\nДа покренете инсталацију притисните дугме \"Преузми\" (испод описа ажурирања) да покренете преузимање. Када преузимање буде завршено инсталациони екран ће се појавити. Ако напустите апликацију или се инсталациони екран није појавио притисните \"Инсталирај\" дугме, које је сада приказано поред \"Преузми\" дугмета.\n\nИнсталациони екран ће прво проверити да ли имате рутован уређај. Ако је ваш уређај рутован, дозволите рут приступ када будете упитани и изаберите како желите да инсталирате ажурирање. У супротном пратите упуства за ручно инсталирање.\n\nАутоматско инсталирање:\nПотребно је само да изабере инсталирај опцију. Препоручљива су фабричка подешавања, осим ако имате специфичан пакет за рут који мора поново да се инсталира. Изаберите рут пакет (zip фајл) користећи плаво фолдер дугме \"Покрени инсталацију\" за покретање инсталације.\n\nРучно инсталирањеl:\nВидећете упуство за инсталирање на вашем екрану. Запишите их и примењујте када почнете са инсталацијом.</string>
-	<string name="help_reading_news_title">Прочитајте најновије вести</string>
-	<string name="help_reading_news_text">Вести су приказане лево од прозора за ажурирање. Последње вести су на врху. Притисните на њих за читање.\nПритисните стрелицу за назад или ваше дугме за назад ради повратка на страницу са вестима.</string>
-	<string name="help_device_information_title">Преглед информација о вашем уређају</string>
-	<string name="help_device_information_text">Можете видети неке од спецификација вашег уређаја на прозору десно од прозора за ажурирање. Ово може бити корисно када правите захтев за помоћ током којег можете бити питани за неке спецификације вашег уређаја.</string>
-	<string name="help_change_settings_title">Промена подешавања</string>
-	<string name="help_change_settings_text">Можете променити ваша подешавања уласком на мени Подешавања који се налази када кликнете на три тачке у горњем десном углу.\nМожете променити следећа подешавања:\n\n• Уређај и метод ажурирања\n• Обавештења\n• Обавештења у апликацији\n• Подешавања сигурности (слање записа).\n\nКористите прекидач да бисте обавештења / подешавања сигурности упалили или угасили. Изаберите уређај и / или методу ажурирања користећи падајући мени приказан изнад прекидача. Падајући мени није видљив? Проверите конекцију са интернетом па поново погледајте подешавања.</string>
-
 	<!-- News strings -->
 	<string name="news">Вести</string>
-	<string name="news_date_published">Последње ажурирање: %1$s</string>
-	<string name="news_empty">Ова вест нема садржај.</string>
-	<string name="news_load_network_error">Грешка приликом отварања вести. Проверите конекцију и притисните \'ПОНОВИ\' дугме да отворите вест.</string>
-
-	<string name="news_load_id_error"><![CDATA[Није успео отварање чланка са неважеће УРЛ адресе: %1$s. Проверите УРЛ или нам то пријавите или путем <a href="mailto:support@oxygenupdater.com">email</a> или на нашем <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
+	<string name="news_load_network_error">Грешка приликом отварања вести. Проверите конекцију и притисните \'Понови\' дугме да отворите вест.</string>
 
 	<string name="news_unread_count_1">Имате %1$d непрочитаних вести. Кликните овде да их погледате.</string>
 	<string name="news_unread_count_2">Имате %1$d непрочитаних вести. Кликните овде да видите све непрочитане вести.</string>
@@ -303,13 +253,11 @@
 	<string name="error_app_outdated">О не!</string>
 	<string name="error_app_outdated_message">Ова верзија апликације није ажурирана. Време је да је ажурирате! Притисните на \"Google Play\" испод. У Google Play, притисните на \"Ажурирај\".</string>
 	<string name="error_app_requires_network_connection">Нема конекције</string>
-	<string name="error_app_requires_network_connection_message">Грешка у повезивању са сервером. Проверите да ли имате интернет конецкију која ради. Апликација ће се сада затворити.</string>
 	<string name="error_google_play_button_text">Google Play</string>
-	<string name="error_no_internet_connection">Нема конекције.</string>
 	<string name="error_maintenance">Одржавање сервера</string>
 	<string name="error_maintenance_message">Молимо вас сачекајте. Сервер ће ускоро бити поново доступан.</string>
 
-	<string name="error_maintenance_retry">Сервер је можда искључен ради одржавања. Покушајте поново након неког времена, или нам то пријавите путем <a href="mailto:support@oxygenupdater.com">мејла</a> или на нашем <a href="https://discord.gg/5TXdhKJ">Discord серверу</a>.</string>
+	<string name="error_maintenance_retry"><![CDATA[Сервер је можда искључен ради одржавања. Покушајте поново након неког времена, или нам то пријавите путем <a href="mailto:support@oxygenupdater.com">мејла</a> или на нашем <a href="https://discord.gg/5TXdhKJ">Discord серверу</a>.]]></string>
 	<string name="error_reload">Освежи</string>
 
 	<string name="error_unable_to_rate_app">Не можете оценити ову апликацију јер се Google Play продавница не налази на вашем уређају.</string>
@@ -336,7 +284,6 @@
 	<string name="purchase_error_after_payment">Куповина апликације без реклама није успела због интерне грешке. Молимо вас покушајте за неколико минута. Ако сте већ платили, молимо вас контактирајте Google Play подршку.</string>
 
 	<!-- Other strings-->
-	<string name="error">Грешка</string>
 	<string name="icon">Иконица</string>
 	<string name="loading">Учитавање…</string>
 	<string name="processing">Обрада…</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools" tools:keep="@string/install_guide_page_*_*">
-
-	<string name="device_chooser_error_title">Det gick inte att hämta en lista över enheter som stöds</string>
-
+<resources>
 	<!-- Update information strings -->
 	<string name="enable">Aktivera</string>
 	<string name="update_information_file_name">"Filnamn: %1$s"</string>
@@ -13,13 +10,12 @@
 	<string name="update_information_error_title">Det gick inte att hämta den senaste informationen om uppdateringen</string>
 	<string name="update_information_banner_server">Tryck här för att visa viktiga notiser</string>
 	<!-- TODO: translate these 2 strings below -->
-	<string name="update_information_banner_advanced_mode_tip">You\'ve selected the \"%1$s\" update track. Enable avancerat läge if you plan to switch to this update track.</string>
+	<string name="update_information_banner_advanced_mode_tip">You\'ve selected the \"%1$s\" update method. Enable avancerat läge if you plan to switch to this update method.</string>
 	<string name="update_information_header_advanced_mode_hint">Avancerat läge är aktiverat</string>
-	<string name="update_information_header_advanced_mode_helper">Eftersom du har aktiverat avancerat läge kan du ladda ner den senaste ZIP-filen för \"%1$s\".\n\nDu kan avaktivera avancerat läge i inställningarna.</string>
-	<string name="update_information_different_version_changelog_notice">Du tittar på en ändringslogg för den senaste uppdateringen för \"%1$s\". Om du istället vill installera uppdateringen måste du aktivera avancerat läge (i inställningarna).\n\nOm du istället vill se ändringsloggen för den senaste versionen kommer du behöva byta tillbaka till den rätta uppdateringsmetoden.</string>
-	<string name="update_information_last_checked_on">"Kollade senast den: %1$s"</string>
+	<string name="update_information_header_advanced_mode_helper">Eftersom du har aktiverat avancerat läge kan du ladda ner den senaste ZIP-filen för \"%1$s\". Du kan avaktivera avancerat läge i inställningarna.</string>
+	<string name="update_information_different_version_changelog_notice_base">Observera: Denna ändringslogg gäller den senaste tillgängliga versionen (%1$s) i uppdateringsmetoden \"%2$s\"</string>
+	<string name="update_information_different_version_changelog_notice_advanced">. Om du vill installera den här uppdateringen måste du aktivera "Avancerat läge" i inställningarna.</string>
 	<string name="update_information_no_update_data_available">"Ingen uppdateringsinformation är tillgänglig."</string>
-	<string name="update_information_oxygen_os_version">"OxygenOS %1$s"</string>
 	<string name="update_information_system_is_up_to_date">"Din enhet är uppdaterad"</string>
 	<string name="update_information_unknown_update_name">"Namnlös uppdatering för: %1$s"</string>
 	<string name="update_information_view_update_information">"Visa uppdateringsinformation"</string>
@@ -45,7 +41,7 @@
 	<string name="download_complete">"Nedladdning klar"</string>
 	<string name="download_complete_notification">Tryck här för att starta installationen</string>
 	<string name="download_error">"Nedladdningsfel"</string>
-	<string name="download_error_close">"STÄNG"</string>
+	<string name="download_error_close">"Stäng"</string>
 	<string name="download_error_corrupt">"Uppdateringsfilen är skadad! Försök ladda ner den igen."</string>
 	<string name="download_error_server">"Ett serverfel uppstod under nedladdningen av uppdateringen. Försök ladda ner den igen."</string>
 	<string name="download_error_internal">Tyvärr uppstod det ett tekniskt fel under nedladdningen av uppdateringen. Försök att ladda ner den igen. Vänligen kontakta apputvecklaren om detta händer igen.</string>
@@ -54,8 +50,8 @@
 Om du vill veta mer får du kontakta oss antingen genom <a href="mailto:support@oxygenupdater.com">e-post</a> eller i vår <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
 	<string name="download_error_could_not_move_temp_file">Filen har laddats ner men kunde inte flyttas till den rätta katalogen. Öppna en filhanterare, navigera till \"%1$s\" och flytta filen manuellt till den översta katalogen med intern lagring.</string>
 
-	<string name="download_error_retry">"FÖRSÖK IGEN"</string>
-	<string name="download_error_resume">"ÅTERUPPTA"</string>
+	<string name="download_error_retry">"Försök igen"</string>
+	<string name="download_error_resume">"Återuppta"</string>
 	<string name="download_error_storage">"Det finns inte tillräckligt med lagringskapacitet på din enhet. Ta bort filer och försök sedan ladda ned på nytt."</string>
 	<string name="download_failed">"Nerladdningen misslyckades"</string>
 	<string name="download_pending">"Din nedladdning påbörjas snart…"</string>
@@ -90,9 +86,7 @@ Om du vill veta mer får du kontakta oss antingen genom <a href="mailto:support@
 	<string name="summary_please_wait">Var god vänta…</string>
 	<string name="summary_update_method">Välj en enhet först</string>
 	<!-- TODO: check the following translation -->
-	<string name="summary_important_notifications_disabled">Vissa viktiga meddelanden är inaktiverade: \"%1$s\"</string>
-	<string name="summary_theme">Välj tema</string>
-	<string name="summary_language">Ställ in språk</string>
+	<string name="summary_important_notifications_disabled">Vissa viktiga meddelanden är inaktiverade:</string>
 	<string name="summary_privacy_policy">Visa online</string>
 	<string name="summary_rate_app">Ge ett femstjärnigt omdöme</string>
 
@@ -113,7 +107,7 @@ Om du vill veta mer får du kontakta oss antingen genom <a href="mailto:support@
 	<string name="theme_additional_note">Obs. om \"Auto\" är aktivt och batterispararläget är på kommer det mörka temat användas oavsett tid på dygnet för att spara batteri</string>
 
 	<string name="settings">"Inställningar"</string>
-	<string name="settings_buy_button_buy">"(%1$s)"</string>
+	<string name="settings_buy_button_buy">"Köp (%1$s)"</string>
 	<string name="settings_buy_button_bought">"Köpt"</string>
 	<string name="settings_buy_button_not_possible">"Otillgänglig"</string>
 	<string name="settings_buy_ad_free_label">"Uppgradera till reklamfritt"</string>
@@ -122,116 +116,48 @@ Om du vill veta mer får du kontakta oss antingen genom <a href="mailto:support@
 
 	<string name="settings_device">"Enhet"</string>
 	<string name="settings_entered_incorrectly">"Kunde inte spara dina inställningar. Gå tillbaka och välj din enhet och uppdateringsmetod igen."</string>
-	<string name="settings_explanation_incremental_full_update">"En inkrementell uppdatering kan installeras från vilken version som helst (förutom om du har en olåst bootloader, då ska du alltid välja den fullständiga uppdateringen som uppdateringsmetod) så länge vi har den uppdateringen tillgänglig.
-
-En fullständig uppdatering kan alltid installeras - oavsett vilken systemversion som körs på din enhet.
-
-En betauppdatering av OxygenOS kan alltid installeras, även när du har den stabila versionen av OxygenOS installerad. För att göra detta måste du aktivera avancerat läge i inställningarna. Uppdateringsmetoden är densamma som för de stabila uppdateringarna.</string>
 	<string name="settings_push_from_server">"Viktigt meddelande är tillgängligt"</string>
 	<string name="settings_saving">"Dina inställningar sparas fortfarande. Om detta tar för lång tid: Kolla din nätverksanslutning, stäng sedan av applikationen och starta den igen."</string>
 	<string name="settings_advanced_mode">"Avancerat läge"</string>
-	<string name="settings_advanced_mode_explanation">"Avancerat läge döljer texten \"Din enhet är uppdaterad\". Det tillåter dig att ladda ner och installera uppdateringar även fast de kanske inte är kompatibla med din enhet.
+	<string name="settings_advanced_mode_explanation">"Normalt visar appen uppdateringar baserat på din aktuella OS-version. Med avancerat läge visas alltid den senaste tillgängliga uppdateringen, oavsett kompatibilitet mellan enhet och version.
 
-Detta kan vara användbart när du:
-- Uppdaterar från en vanlig version till en betaversion
-- Går tillbaka till en vanlig version från en beta version (glöm inte att fabriksåterställa din enhet)
-- Ominstallerar din nuvarande systemversion
-"</string>
+Detta kan vara användbart om du vill:"</string>
+	<string name="settings_advanced_mode_uses">"&#8226; Ladda ner den senaste versionen igen, även om du redan har den
+&#8226; Växla till ett annat uppdateringsspår"</string>
+	<string name="settings_advanced_mode_caption">"Avancerat läge kan behövas endast i ovanstående situationer. Du bör inte aktivera det om du inte vet vad du gör."</string>
 	<string name="settings_update_method">"Uppdateringsmetod"</string>
 	<string name="settings_upload_logs">Dela användningsdata och loggar</string>
+	<string name="settings_ad_privacy">GDPR samtycke för annonser</string>
+	<string name="settings_ad_privacy_subtitle">"För användare i EES/Storbritannien"</string>
 
 	<!-- FAQ strings -->
 	<string name="faq">"FAQ"</string>
 	<string name="faq_menu_item">"FAQ"</string>
 
 	<!-- First-time setup strings -->
-	<string name="onboarding">"Välkommen"</string>
+	<string name="onboarding">"Inställning"</string>
 	<string name="onboarding_finished_button">Starta appen</string>
-	<string name="onboarding_page_1_title">"Välkommen till Oxygen Updater!"</string>
-	<string name="onboarding_page_1_text">"Denna app kommer låta dig:
+	<string name="onboarding_app_uses">"Denna app kommer låta dig:
 
-- Få snabbare tillgång till Android uppdateringar för din enhet med OxygenOS
-
-- Enkelt uppdatera en rootad enhet
-
-- Ta reda på vad som är nytt i den system mjukvaran du använder just nu
-
-- Läsa de senaste nyheterna som relaterar till OnePlus och OXygenOS
-
-Dra till vänster för att fortsätta."</string>
-	<string name="onboarding_page_1_caption">"Detta är inte en officiell OnePlus applikation. Användande av denna app är helt på egen risk. Vare sig OnePlus eller utvecklaren av denna app är ansvariga för dina handlingar, detta inkluderar skada av din enhet som har tillkommit efter användande av denna app.
-
-Genom att använda denna app accepterar du de ovanstående villkoren.
-
-Dra till vänster för att fortsätta."</string>
-	<string name="onboarding_page_2_title">"Välj din enhet:"</string>
-	<string name="onboarding_page_2_caption">"Din enhet är oftast redan förvald ovan, om inte, välj din enhet ovan.
-
-Dra till vänster för att fortsätta."</string>
-	<string name="onboarding_page_3_title">"Välj din uppdateringsmetod:"</string>
-	<string name="onboarding_page_3_caption">"Vanligtvis är en inkrementell uppdatering rätt val eftersom den möjliggör snabbare och mindre nedladdningsstorlek.
-
-Däremot är det inte kompatibelt med rostade enheter. Välj istället en full uppdatering om du har en rootad enhet.
-
-Om du har installerat en beta version av OxygenOS, välj en av uppdateringsmetoderna för Open Beta.
-
-Svep vänster för att fortsätta."</string>
-	<string name="onboarding_page_4_title">"Du är redo!"</string>
-	<string name="onboarding_page_4_text">"Hoppas du kommer tycka om appen!
-
-Du kan alltid ändra inställningar senare. För att göra det: Tryck på de tre punkterna i översta högra hörnet och tryck sedan på \"Inställningar\"."</string>
+&#8226; Få snabbare tillgång till Android uppdateringar för din enhet med OxygenOS
+&#8226; Enkelt uppdatera en rootad enhet
+&#8226; Ta reda på vad som är nytt i den system mjukvaran du använder just nu
+&#8226; Läsa de senaste nyheterna som relaterar till OnePlus och OXygenOS"</string>
+	<string name="onboarding_disclaimer">"Detta är inte en officiell OnePlus applikation. Användande av denna app är helt på egen risk. Vare sig OnePlus eller utvecklaren av denna app är ansvariga för dina handlingar, detta inkluderar skada av din enhet som har tillkommit efter användande av denna app. Genom att använda denna app accepterar du de ovanstående villkoren."</string>
+	<string name="onboarding_device_chooser_title">"Välj din enhet:"</string>
+	<string name="onboarding_device_chooser_caption">"Din enhet är oftast redan förvald ovan, om inte, välj din enhet ovan."</string>
+	<string name="onboarding_method_chooser_title">"Välj din uppdateringsmetod:"</string>
+	<string name="onboarding_method_chooser_caption">"Vanligtvis är en inkrementell uppdatering rätt val eftersom den möjliggör snabbare och mindre nedladdningsstorlek. Däremot är det inte kompatibelt med rostade enheter. Välj istället en full uppdatering om du har en rootad enhet. Om du har installerat en beta version av OxygenOS, välj en av uppdateringsmetoderna för Open Beta."</string>
+	<string name="onboarding_caption">"Hoppas du kommer tycka om appen! Du kan alltid ändra inställningar senare."</string>
 
 	<!-- Automatic install strings -->
 	<string name="install">"Installera"</string>
 
 	<!-- Install guide strings -->
-	<string name="install_guide_no_root">"Installera uppdateringen enligt installationsguidens instruktioner."</string>
 	<string name="install_guide">"Installationsguide"</string>
-	<string name="install_guide_subtitle">Installationsguide - %1$d av %2$d</string>
-	<string name="install_guide_tip">"&#8226; Det är rekommenderat att skriva ner alla stegen eftersom du kommer behöva stänga av din enhet under installationsprocessen."</string>
-	<string name="install_guide_page_1_title">"Ladda ner uppdateringen."</string>
-	<string name="install_guide_page_1_text">"&#8226; Tryck på nedladdningsknappen för att starta nedladdningen av uppdateringen.
-
-- Nedladdningens status kommer visas i appen och som en notifikation på din enhet.
-
-- När nedladdningen är klar visas en notifikation med texten \"Nedladdning klar\". Om ett nedladdningsfel inträffat öppnar du appen och försöker hämta uppdateringen igen. Om det inte fungerar, se till att du har en fungerande anslutning. Annars kontakta utvecklaren av appen. Du kan göra det genom att besöka sektionen \"Mina appar\" i Google Play Butik."</string>
-
-	<string name="install_guide_page_2_title">Förberedelse inför installation</string>
-	<!-- TODO: translate this string below -->
-	<string name="install_guide_page_2_text">"Note: The installation of the update takes place from a special page of the standard System Updates section of your device. If, for some reason, a system update appears when opening this section, you may also opt to install that update first. Afterwards, open Oxygen Updater again to see if you're completely up-to-date.
-
-Instructions:
-&#8226; Close Oxygen Updater by pressing the home button.
-
-&#8226; Open the Settings app. It should be located in your app drawer.
-
-&#8226; Scroll down until you see System updates. Tap on it."</string>
-
-	<string name="install_guide_page_3_title">Installera uppdateringen</string>
-	<!-- TODO: translate this string below -->
-	<string name="install_guide_page_3_text">"Now that you're in the System Updates app, it's time to install the update.
-
-&#8226; Within the System Updates section, tap the gear icon in the top right
-
-&#8226; Now, select \"Local upgrade\". A file selection screen should appear.
-
-&#8226; In this screen, tap on the update file you downloaded using Oxygen Updater. Its name should start with \"%1$sOxygen\".
-
-&#8226; Tap on \"Upgrade Now\". The installation should start automatically."</string>
-
-	<string name="install_guide_page_4_title">Vänta tills installationen är klar</string>
-	<string name="install_guide_page_4_text">"&#8226; Telefonen kommer nu att installera uppdateringen och visa ett framstegsfält. Var god vänta tills installationen är slutförd. Installationen kan ta upp till 15 minuter.
-
-&#8226; Efter det kommer din telefon att startas om för att tillämpa uppdateringen."</string>
-
-	<string name="install_guide_page_5_title">"Klar. Njut av den nya versionen av OxygenOS!"</string>
-	<string name="install_guide_page_5_text">"&#8226; När enheten har slutfört optimeringen av apparna har uppdateringen installerats.
-För att verifiera detta kan du kontrollera nuvarande version av ditt system enligt följande instruktioner:
-
-- Gå till Inställningar, tryck på \"Om telefonen\", och kolla OxygenOS Version.
-
-- Om du gillar den här appen, ge den 5 stjärnor på Google Play!"</string>
-	<string name="install_guide_close_button">Stäng installationsguiden</string>
+	<string name="install_guide_download_instructions">"&#8226; Tryck på nedladdningsknappen för att starta nedladdningen av uppdateringen.
+&#8226; Nedladdningens status kommer visas i appen och som en notifikation på din enhet.
+&#8226; När nedladdningen är klar visas en notifikation med texten \"Nedladdning klar\". Om ett nedladdningsfel inträffat öppnar du appen och försöker hämta uppdateringen igen. Om det inte fungerar, se till att du har en fungerande anslutning. Annars kontakta utvecklaren av appen. Du kan göra det genom att besöka sektionen \"Mina appar\" i Google Play Butik."</string>
 
 	<!-- Device information strings -->
 	<string name="device_information_supported_oxygen_os">Vi har stöd flr din enhet</string>
@@ -248,7 +174,7 @@ För att verifiera detta kan du kontrollera nuvarande version av ditt system enl
 	<string name="device_information_image_description">"Enhetsbild"</string>
 	<string name="device_information_incremental_os_version">Inkrementell OS-version</string>
 	<string name="device_information_os_version">Android-version</string>
-	<string name="device_information_oxygen_os_version">OxygenOS-version</string>
+	<string name="device_information_oxygen_os_version">OS-version</string>
 	<string name="device_information_oxygen_os_ota_version">OTA-version</string>
 	<string name="device_information_patch_level_version">"Version av säkerhetsuppdatering:"</string>
 	<string name="device_information_serial_number">"Serienummer:"</string>
@@ -268,6 +194,8 @@ För att verifiera detta kan du kontrollera nuvarande version av ditt system enl
 	<string name="about_email_button_text">E-post</string>
 
 	<!-- LocalNotifications strings -->
+	<string name="notification_permission_title">"Håll dig underrättad"</string>
+	<string name="notification_permission_text">"Tillåt att appen meddelar dig om OTA-uppdateringar, nyheter, pågående nedladdningsstatus och andra viktiga saker. Du kan finjustera dina preferenser senare i appens inställningar."</string>
 	<string name="notification_new_device_text">"%1$s har nu våran support. Öppna appen för att välja denna enhet."</string>
 	<string name="notification_no_notification_support">"Installera eller uppdatera Google Play services för att slå på push-notifikationer."</string>
 	<string name="notification_version">"%1$s är nu tillgänglig för %2$s!"</string>
@@ -294,42 +222,9 @@ För att verifiera detta kan du kontrollera nuvarande version av ditt system enl
 	<string name="general_notification_channel_description">General notifications that don\'t fit into other categories</string>
 	<string name="url_submitted_notification_channel_description">Få ett meddelande när du har skickat in OTA-adresser till vårt team.\nDu kan välja bort att automatiskt skicka in webbadresser i appens inställningar.</string>
 
-	<!-- Help strings -->
-	<string name="help">"Hjälp"</string>
-	<string name="help_updating_your_device_title">"Uppdaterar din enhet"</string>
-	<string name="help_updating_your_device_text">"När du öppnar appen ser du om en systemuppdatering är tillgänglig. Om en uppdatering är tillgänglig kan du installera den.
-
-För att starta installationen, tryck på knappen \"Ladda ner\" (nedanför uppdateringsbeskrivningen) för att starta nedladdningen. När nedladdningen är klar visas installationsskärmen upp. Om du lämnade appen eller skärmen inte kom upp, tryck på \"Installera\" -knappen, som nu visas bredvid knappen \"Ladda ner\".
-
-Installationsskärmen kontrollerar först om du har en rootad enhet. Om du har en rootad enhet, bevilja rootförfrågan när den kommer upp och välj hur du vill installera uppdateringen. Du kan också följa instruktionerna för manuell installation.
-
-Automatisk installation:
-Du behöver bara välja dina installationsalternativ. Standardinställningarna rekommenderas, däremot måste du ange rootpaketet som ska installeras. Välj ett rootpaket (zip-fil) med den blå mappknappen och tryck på \"Starta installation\" för att starta installationen.
-
-Manuell installation:
-Du får se en installationsguide på skärmen. Skriv ner instruktionerna och utför dem enligt guiden för att installera uppdateringen."</string>
-	<string name="help_reading_news_title">"Läser de senaste nyheterna"</string>
-	<string name="help_reading_news_text">"Nyheter visas till vänster om uppdateringsinformationsskärmen. De senaste nyheterna visas på toppen. Klicka bara på en nyhet för att läsa den.
-Tryck på bakåtpilen eller tryck på tillbaka-knappen för att återgå till skärmen för nyheter."</string>
-	<string name="help_device_information_title">"Kollar information om din enhet"</string>
-	<string name="help_device_information_text">"Du kan se några av specifikationerna för din enhet på skärmen till höger om uppdateringsinformationen. Det här är bra att ha när du gör en supportförfrågan, där du kanske blir frågad om några av specifikationerna för din enhet."</string>
-	<string name="help_change_settings_title">"Ändrar inställningar"</string>
-	<string name="help_change_settings_text">"Du kan ändra dina inställningar genom att trycka på de tre prickarna längst upp till höger, klicka därefter på \"inställningar\"
-Du kan ändra inställningar för följande delar:
-
-• Enhet och uppdateringsmetod
-• Pushnotifikationer
-• Interna appnotifikationer
-• Sekretessinställningar (logguppladdning).
-
-Använd knapparna för att aktivera och inaktivera meddelande / sekretessinställningar. Välj en enhet och / eller uppdateringsmetod med hjälp av rullgardinsmenyerna som visas ovanför knapparna. Ser du inte rullgardinsmenyerna? Kontrollera din Internetanslutning och öppna Inställningarna igen."</string>
-
 	<!-- News strings -->
 	<string name="news">"Nyheter"</string>
-	<string name="news_date_published">"Senaste uppdatering: %1$s"</string>
-	<string name="news_empty">"Denna artikel har inget innehåll."</string>
-	<string name="news_load_network_error">"Misslyckades att öppna artikeln. Kontrollera din anslutning och tryck sedan på 'FÖRSÖK IGEN' knappen för att öppna artikeln."</string>
-	<string name="news_load_id_error"><![CDATA[Misslyckades att öppna artikel från ogiltig länk: %1$s. Kolla länken eller rapportera detta till oss genom att antingen <a href="mailto:support@oxygenupdater.com">maila oss</a> eller på vår <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
+	<string name="news_load_network_error">"Misslyckades att öppna artikeln. Kontrollera din anslutning och tryck sedan på 'Försök igen' knappen för att öppna artikeln."</string>
 	<string name="news_unread_count_1">Du har %1$d olästa nyhetsartiklar. Tryck här för att se dem.</string>
 	<string name="news_unread_count_2">Du har %1$d olästa nyhetsartiklar. Tryck för att visa alla artiklar.</string>
 	<string name="news_mark_read">Markera som läst</string>
@@ -354,12 +249,10 @@ Använd knapparna för att aktivera och inaktivera meddelande / sekretessinstäl
 	<string name="error_app_outdated">"Åh nej!"</string>
 	<string name="error_app_outdated_message">"Den här versionen av appen är utdaterad- Det är dags att uppdatera den! Tryck på \"Google Pay\" nedan. Klicka sedan på \"Uppdatera\" inuti appen."</string>
 	<string name="error_app_requires_network_connection">Ingen anslutning</string>
-	<string name="error_app_requires_network_connection_message">Misslyckades att ansluta til servern. Kolla så att du har en fungerande anslutning. Appen kommer att stängas.</string>
 	<string name="error_google_play_button_text">"Google Play"</string>
-	<string name="error_no_internet_connection">"Ingen anslutning."</string>
 	<string name="error_maintenance">"Serverunderhåll"</string>
 	<string name="error_maintenance_message">"Var god vänta. Servern är strax tillgänglig."</string>
-	<string name="error_maintenance_retry">Servern kan vara nere för underhåll. Försök igen om en stund eller rapportera det via <a href="mailto:support@oxygenupdater.com">e-post</a> eller i vår <a href="https://discord.gg/5TXdhKJ">Discord server</a>.</string>
+	<string name="error_maintenance_retry"><![CDATA[Servern kan vara nere för underhåll. Försök igen om en stund eller rapportera det via <a href="mailto:support@oxygenupdater.com">e-post</a> eller i vår <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
 	<string name="error_reload">"Ladda om"</string>
 	<string name="error_unable_to_rate_app">"Du kan inte rösta på appen eftersom Google Play Butik saknas på din enhet"</string>
 
@@ -387,7 +280,6 @@ Andra enheter samt OnePlus enheter som har \"Custom ROMs\" installerade är inte
 	<string name="purchase_error_after_payment">"Köpet av den reklamfria utgåvan misslyckades på grund av ett internt fel. Vänligen försök igen om några minuter. Har du redan betalat kan du kontakta Google Play supporten för assistans."</string>
 
 	<!-- Other strings -->
-	<string name="error">Fel</string>
 	<string name="icon">"Ikon"</string>
 	<string name="loading">"Laddar…"</string>
 	<string name="processing">"Bearbetar…"</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools" tools:keep="@string/install_guide_page_*_*">
-	<!-- TODO: translate this string below -->
-	<string name="device_chooser_error_title">Couldn\'t retrieve list of supported devices</string>
-
+<resources>
 	<!-- Update information strings-->
 	<!-- TODO: translate this string below -->
 	<string name="enable">เปิดใช้งาน</string>
@@ -16,13 +13,12 @@
 	<!-- TODO: translate these 6 strings below -->
 	<string name="update_information_error_title">Couldn\'t retrieve latest update data information</string>
 	<string name="update_information_banner_server">Tap here to view important notices</string>
-	<string name="update_information_banner_advanced_mode_tip">You\'ve selected the \"%1$s\" update track. Enable โหมดขั้นสูง if you plan to switch to this update track.</string>
+	<string name="update_information_banner_advanced_mode_tip">You\'ve selected the \"%1$s\" update method. Enable โหมดขั้นสูง if you plan to switch to this update method.</string>
 	<string name="update_information_header_advanced_mode_hint">เปิดใช้งานโหมดขั้นสูง</string>
-	<string name="update_information_header_advanced_mode_helper">Since you\'ve enabled โหมดขั้นสูง, you can download the latest ZIP for \"%1$s\".\n\nYou can turn โหมดขั้นสูง off from settings.</string>
-	<string name="update_information_different_version_changelog_notice">You\'re viewing a changelog for the latest update in the \"%1$s\" upgrade track. If you intend to install this update, you must turn โหมดขั้นสูง on first (in settings).\n\nHowever, if you wish to see the changelog for the currently installed version instead, you\'ll need to switch back to the correct update method.</string>
-	<string name="update_information_last_checked_on">ตรวจสอบครั้งสุดท้ายเมื่อ: %1$s</string>
+	<string name="update_information_header_advanced_mode_helper">Since you\'ve enabled โหมดขั้นสูง, you can download the latest ZIP for \"%1$s\". You can turn โหมดขั้นสูง off from settings.</string>
+	<string name="update_information_different_version_changelog_notice_base">หมายเหตุ: บันทึกการเปลี่ยนแปลงนี้มีไว้สำหรับเวอร์ชันล่าสุดที่มีอยู่ (%1$s) ในวิธีการอัปเดต \"%2$s\"</string>
+	<string name="update_information_different_version_changelog_notice_advanced"> หากคุณต้องการติดตั้งการอัปเดตนี้ คุณต้องเปิดใช้งาน \"โหมดขั้นสูง\" ในการตั้งค่า</string>
 	<string name="update_information_no_update_data_available">ยังไม่มีการอัพเดทถูกปล่อยออกมา</string>
-	<string name="update_information_oxygen_os_version">OxygenOS %1$s</string>
 	<string name="update_information_system_is_up_to_date">ระบบของคุณเป็นเวอร์ชั่นล่าสุดแล้ว</string>
 	<string name="update_information_unknown_update_name">มีอัพเดทจากแหล่งที่มาที่ไม่รู้จักสำหรับ %1$s</string>
 	<string name="update_information_view_update_information">ดูรายละเอียดการอัพเดท</string>
@@ -98,9 +94,7 @@ If you\'d like to know more, feel free to contact us either via <a href="mailto:
 	<string name="summary_please_wait">รอสักครู่…</string>
 	<string name="summary_update_method">เลือกอุปกรณ์</string>
 	<!-- TODO: check the following translation -->
-	<string name="summary_important_notifications_disabled">การแจ้งเตือนที่สำคัญบางอย่างถูกปิดใช้งาน: \"%1$s\"</string>
-	<string name="summary_theme">ตั้งค่าธีม</string>
-	<string name="summary_language">ตั้งค่าภาษา</string>
+	<string name="summary_important_notifications_disabled">การแจ้งเตือนที่สำคัญบางอย่างถูกปิดใช้งาน:</string>
 	<string name="summary_privacy_policy">ดูออนไลน์</string>
 	<string name="summary_rate_app">ถ้าชอบพวกเรากรุณาให้ 5 ดาว</string>
 
@@ -131,81 +125,46 @@ If you\'d like to know more, feel free to contact us either via <a href="mailto:
 
 	<string name="settings_device">อุปกรณ์</string>
 	<string name="settings_entered_incorrectly">เกิดข้อผิดพลาดระหว่างบันทึกการตั้งค่า กรุณากลับไปเลือกอุปกรณ์หรือวิธีติดตั้งใหม่</string>
-	<string name="settings_explanation_incremental_full_update">การอัพเดทแบบปกติสามารถอัพเดทจากเวอร์ชั่นไหนก็ได้ (ยกเว้นคุณจะปลดล็อค bootloader แล้ว คุณควรเลือกวิธีติดตั้งแบบเต็มรูปแบบ)\n\nOxygenOS เวอร์ชั่นทดลองสามารถติดตั้งได้ตลอดเวลาตราบใดที่คุณอยู่บนเวอร์ชั่นสเถียร การที่คุณจะเปลี่ยนไปใช้เวอร์ชั่นทดลองนั้น คุณต้องเปิดขั้นสูงในตั้งค่าก่อนและสำหรับเวอร์ชั่นทดลองนั้น การติดตั้งแบบเต็มรูปแบบกับธรรมดาสามารถใช้แทนกันได้</string>
 
 	<string name="settings_push_from_server">แจ้งเตือนข้อมูลและข้อควรระวัง</string>
 
 	<string name="settings_saving">การตั้งค่าของคุณกำลังถูกบันทึก ถ้ากระบวนการนี้ใช้เวลานานเกินไป กรุณาเช็คการเชื่อมต่อของคุณและเริ่มต้นแอพพลิเคชั่น</string>
 
 	<string name="settings_advanced_mode">โหมดขั้นสูง</string>
-	<string name="settings_advanced_mode_explanation">โหมดขั้นสูงจะข้อความ \"ระบบของคุณใหม่ล่าสุดแล้ว\", และอนุญาตให้คุณดาวน์โหลดและติดตั้งทุกเวอร์ชั่นของระบบถึงแม้ว่าระบบจะไม่สามารถติดตั้งได้\n\n การทำแบบนี้จะมีประโยชน์อย่างมากเมื่อ:\n&#8226; อัพเดทจากเวอร์ชั่นธรรมดาไปเวอร์ชั่นทดลอง\n&#8226; วิธีการกลับจากเวอร์ชั่นทดลองมาเวอร์ชั่นธรรมดา(อย่าลืมคืนค่าโรงงานก่อน)\n&#8226; คือติดตั้งระบบเวอร์ชั่นธรรมดาใหม่อีกครั้ง</string>
+	<string name="settings_advanced_mode_explanation">"โดยปกติแล้ว แอปจะแสดงการอัปเดตตามเวอร์ชันระบบปฏิบัติการปัจจุบันของคุณ ด้วยโหมดขั้นสูง การอัปเดตล่าสุดที่มีอยู่จะแสดงเสมอโดยไม่คำนึงถึงความเข้ากันได้ของอุปกรณ์/เวอร์ชัน
+
+สิ่งนี้มีประโยชน์หากคุณต้องการ:"</string>
+	<string name="settings_advanced_mode_uses">"&#8226; ดาวน์โหลดเวอร์ชันล่าสุดอีกครั้งแม้ว่าคุณจะใช้เวอร์ชันนั้นอยู่แล้วก็ตาม
+&#8226; สลับไปยังแทร็กอัปเดตอื่น"</string>
+	<string name="settings_advanced_mode_caption">"โหมดขั้นสูงอาจจำเป็นในสถานการณ์ข้างต้นเท่านั้น คุณไม่ควรเปิดใช้งานจนกว่าคุณจะรู้ว่าคุณกำลังทำอะไรอยู่"</string>
 
 	<string name="settings_update_method">วิธีการอัพเดท</string>
 	<string name="settings_upload_logs">แบ่งปันข้อมูลการใช้และล็อก</string>
+	<string name="settings_ad_privacy">ความยินยอมโฆษณา GDPR</string>
+	<string name="settings_ad_privacy_subtitle">"สำหรับผู้ใช้ EEA/สหราชอาณาจักร"</string>
 
 	<!-- FAQ strings -->
 	<string name="faq">FAQ</string>
 	<string name="faq_menu_item">FAQ</string>
 
 	<!-- First-time setup strings -->
-	<string name="onboarding">ยินดีต้อนรับ</string>
+	<string name="onboarding">ตั้งค่า</string>
 	<string name="onboarding_finished_button">เริ่มใช้งาน</string>
 
-	<string name="onboarding_page_1_title">ยินดีต้อนรับสู่ Oxygen Updater!</string>
-	<string name="onboarding_page_1_text">แอพนนี้จะทำให้คุณสามารถ:\n\n&#8226; ติดตั้ง OxygenOS เวอร์ชั่นใหม่ได้ก่อน\n\n&#8226; ง่ายต่อเครื่องที่ผ่านการรูท\n\n&#8226; และสามารถดูข้อมูลการอัพเดทต่างๆของระบบเวอร์ชั่นปัจจุบันที่คุณกำลังใช้อยู่\n\n&#8226; อ่านข่าวล่าสุดเกี่ยวกับ OnePlus และ OxygenOS\n\nปัดไปทางซ้ายเพื่อดำเนินการต่อ</string>
-	<string name="onboarding_page_1_caption">นี้ไม่ใช่แอพพลิเคชั่นอย่างทางการของ OnePlus ใช้แอพพลิเคชั่นนี้ด้วยความเสี่ยงของคุณเอง OnePlus หรือผู้พัฒนาแอปจะไม่รับผิดชอบต่อการกระทำของคุณร่วมถึงความเสียหายทีเกิดขี้นจากแอพนี้\n\nโดยการใช้แอพนี้คุณยอมรับข้อกำหนดและเงื่อนไขตามที่ระบุไว้ข้างต้น</string>
-	<string name="onboarding_page_2_title">เลือกอุปกรณ์ของคุณ</string>
-	<string name="onboarding_page_2_caption">โดยปกติอุปกรณ์ของคุณจะถูกเลือกไว้ด้านบน หากไม่ คุณสามารถเลือกอุปกรณ์ของคุณด้านบน</string>
-	<string name="onboarding_page_3_title">เลือกวิธีการอัพเดทของคุณ</string>
-	<string name="onboarding_page_3_caption">โดยปกติแล้วการอัปเดตธรรมดาจะเป็นตัวเลือกที่เหมาะสมเนื่องจากมีการดาวน์โหลดที่เร็วกว่าและเล็กกว่ามาก\n\n อย่างไรก็ตามมันเข้ากันไม่ได้กับอุปกรณ์ที่รูท หากคุณมีอุปกรณ์รูทให้เลือกการอัพเดทแบบเต็มรูปแบบ\n\nหากคุณมี OxygenOS รุ่นเบต้าให้เลือก (หนึ่งใน) วิธีการอัปเดต Open Beta</string>
-	<string name="onboarding_page_4_title">คุณพร้อมแล้ว!</string>
-	<string name="onboarding_page_4_text">ขอสนุกกับการใช้แอพนี้!\n\n คุณสามารถเปลี่ยนการตั้งค่าได้ในภายหลัง โดยทำดังนี้: แตะจุดสามจุดที่มุมขวาบนแล้วแตะที่ \"การตั้งค่า \".</string>
+	<string name="onboarding_app_uses">แอพนนี้จะทำให้คุณสามารถ:\n\n&#8226; ติดตั้ง OxygenOS เวอร์ชั่นใหม่ได้ก่อน\n&#8226; ง่ายต่อเครื่องที่ผ่านการรูท\n&#8226; และสามารถดูข้อมูลการอัพเดทต่างๆของระบบเวอร์ชั่นปัจจุบันที่คุณกำลังใช้อยู่\n&#8226; อ่านข่าวล่าสุดเกี่ยวกับ OnePlus และ OxygenOS</string>
+	<string name="onboarding_disclaimer">นี้ไม่ใช่แอพพลิเคชั่นอย่างทางการของ OnePlus ใช้แอพพลิเคชั่นนี้ด้วยความเสี่ยงของคุณเอง OnePlus หรือผู้พัฒนาแอปจะไม่รับผิดชอบต่อการกระทำของคุณร่วมถึงความเสียหายทีเกิดขี้นจากแอพนี้ โดยการใช้แอพนี้คุณยอมรับข้อกำหนดและเงื่อนไขตามที่ระบุไว้ข้างต้น</string>
+	<string name="onboarding_device_chooser_title">เลือกอุปกรณ์ของคุณ</string>
+	<string name="onboarding_device_chooser_caption">โดยปกติอุปกรณ์ของคุณจะถูกเลือกไว้ด้านบน หากไม่ คุณสามารถเลือกอุปกรณ์ของคุณด้านบน</string>
+	<string name="onboarding_method_chooser_title">เลือกวิธีการอัพเดทของคุณ</string>
+	<string name="onboarding_method_chooser_caption">โดยปกติแล้วการอัปเดตธรรมดาจะเป็นตัวเลือกที่เหมาะสมเนื่องจากมีการดาวน์โหลดที่เร็วกว่าและเล็กกว่ามาก อย่างไรก็ตามมันเข้ากันไม่ได้กับอุปกรณ์ที่รูท หากคุณมีอุปกรณ์รูทให้เลือกการอัพเดทแบบเต็มรูปแบบ หากคุณมี OxygenOS รุ่นเบต้าให้เลือก (หนึ่งใน) วิธีการอัปเดต Open Beta</string>
+	<string name="onboarding_caption">ขอสนุกกับการใช้แอพนี้! คุณสามารถเปลี่ยนการตั้งค่าได้ในภายหลัง.</string>
 
 	<!-- Automatic install strings -->
 	<string name="install">ติดตั้ง</string>
 
 	<!-- Install guide strings -->
-	<string name="install_guide_no_root">ติดตั้งการอัปเดตตามคำแนะนำที่แสดงในคู่มือการติดตั้ง</string>
 	<string name="install_guide">คู่มือการติดตั้ง</string>
-	<string name="install_guide_subtitle">คู่มือการติดตั้ง - %1$d จาก %2$d</string>
-	<string name="install_guide_tip">&#8226; แนะนำให้จดหรือจำขั้นตอนทั้งหมดลงเนื่องจากคุณจะต้องปิดอุปกรณ์ในระหว่างการติดตั้งการอัปเดต</string>
-
-	<string name="install_guide_page_1_title">ดาวน์โหลดการอัพเดต</string>
-	<string name="install_guide_page_1_text">&#8226; กดปุ่มดาวน์โหลดเพื่อเริ่มดาวน์โหลดการอัปเดต\n\n&#8226; ความคืบหน้าการดาวน์โหลดจะปรากฏในแอปและเป็นการแจ้งเตือนในหน้าจอการแจ้งเตือนของคุณ\n\n&#8226; เมื่อการดาวน์โหลดเสร็จสิ้นคุณจะเห็น การแจ้งเตือนด้วยข้อความ \"ดาวน์โหลดเสร็จสมบูรณ์ \".\n หากเกิดข้อผิดพลาดในการดาวน์โหลดให้เปิดแอปแล้วลองดาวน์โหลดการอัปเดตอีกครั้ง หากไม่สามารถใช้งานได้ให้ตรวจสอบว่าคุณมีการเชื่อมต่อที่ใช้งานได้ มิฉะนั้นติดต่อผู้พัฒนาแอป คุณสามารถทำได้โดยไปที่ส่วน \"แอพของฉัน \" ของ Google Play Store</string>
-
-	<!-- TODO: translate these 2 strings below -->
-	<string name="install_guide_page_2_title">Prepare for installation</string>
-	<string name="install_guide_page_2_text">"Note: The installation of the update takes place from a special page of the standard System Updates section of your device. If, for some reason, a system update appears when opening this section, you may also opt to install that update first. Afterwards, open Oxygen Updater again to see if you're completely up-to-date.
-
-Instructions:
-&#8226; Close Oxygen Updater by pressing the home button.
-
-&#8226; Open the Settings app. It should be located in your app drawer.
-
-&#8226; Scroll down until you see System updates. Tap on it."</string>
-
-	<!-- TODO: translate these 2 strings below -->
-	<string name="install_guide_page_3_title">Install the update</string>
-	<string name="install_guide_page_3_text">"Now that you're in the System Updates app, it's time to install the update.
-
-&#8226; Within the System Updates section, tap the gear icon in the top right
-
-&#8226; Now, select \"Local upgrade\". A file selection screen should appear.
-
-&#8226; In this screen, tap on the update file you downloaded using Oxygen Updater. Its name should start with \"%1$sOxygen\".
-
-&#8226; Tap on \"Upgrade Now\". The installation should start automatically."</string>
-
-	<!-- TODO: translate these 2 strings below -->
-	<string name="install_guide_page_4_title">Wait until the installation completes</string>
-	<string name="install_guide_page_4_text">"&#8226; The phone will now install the update and displays a progress bar. Please wait until the installation has finished. Installation may take anywhere from a few minutes up to 15 minutes.
-
-&#8226; Afterwards, your phone will restart to complete the update."</string>
-
-	<string name="install_guide_page_5_title">เสร็จสิ้น ขอสนุกกับ OxygenOS เวอร์ชั่นใหม่!</string>
-	<string name="install_guide_page_5_text">&#8226; หลังจากอุปกรณ์ของคุณเพิ่มประสิทธิภาพแอปเรียบร้อยแล้วและการอัปเดตได้รับการติดตั้งเรียบร้อยแล้ว\n หากต้องการตรวจสอบความถูกต้องของไฟล์คุณสามารถตรวจสอบเวอร์ชั่นปัจจุบันของระบบของคุณดังต่อไปนี้:\n\n&#8226; ไปที่การตั้งค่า และตรวจสอบเวอร์ชัน OxygenOS\n\n&#8226; หากคุณชอบแอพนี้โปรดให้คะแนน 5 ดาวที่ Google Play!</string>
-
-	<string name="install_guide_close_button">ปิดคู่มือการติดตั้ง</string>
+	<string name="install_guide_download_instructions">&#8226; กดปุ่มดาวน์โหลดเพื่อเริ่มดาวน์โหลดการอัปเดต\n&#8226; ความคืบหน้าการดาวน์โหลดจะปรากฏในแอปและเป็นการแจ้งเตือนในหน้าจอการแจ้งเตือนของคุณ\n&#8226; เมื่อการดาวน์โหลดเสร็จสิ้นคุณจะเห็น การแจ้งเตือนด้วยข้อความ \"ดาวน์โหลดเสร็จสมบูรณ์\". หากเกิดข้อผิดพลาดในการดาวน์โหลดให้เปิดแอปแล้วลองดาวน์โหลดการอัปเดตอีกครั้ง หากไม่สามารถใช้งานได้ให้ตรวจสอบว่าคุณมีการเชื่อมต่อที่ใช้งานได้ มิฉะนั้นติดต่อผู้พัฒนาแอป คุณสามารถทำได้โดยไปที่ส่วน \"แอพของฉัน \" ของ Google Play Store</string>
 
 	<!-- Device information strings -->
 	<!-- TODO: translate these 4 strings below -->
@@ -223,7 +182,7 @@ Instructions:
 	<string name="device_information_image_description">รูปภาพอุปกรณ์</string>
 	<string name="device_information_incremental_os_version">Incremental OS version</string>
 	<string name="device_information_os_version">Android version</string>
-	<string name="device_information_oxygen_os_version">OxygenOS version</string>
+	<string name="device_information_oxygen_os_version">OS version</string>
 	<string name="device_information_oxygen_os_ota_version">OTA version</string>
 	<string name="device_information_patch_level_version">Security patch date</string>
 	<string name="device_information_serial_number">Serial number</string>
@@ -236,14 +195,16 @@ Instructions:
 	<string name="about_description">This app downloads official updates directly from OnePlus servers, and even verifies the integrity of the downloaded ZIP before allowing you to install. By doing so, the app allows you to skip the rollout queue and install official updates ASAP. If you encounter bugs in the OS, report them to OnePlus directly: <a href="https://forums.oneplus.com/feedback">https://forums.oneplus.com/feedback</a>. You might want to join our <a href="https://discord.gg/5TXdhKJ">Discord server</a> as well, so that you can talk to other users about the latest updates. Otherwise feel free to email us at <a href="mailto:support@oxygenupdater.com">support@oxygenupdater.com</a> with your suggestions/feedback.</string>
 	<string name="about_support">If you\'d like to support us, you can either buy the ad-free unlock (app\'s settings), or check our <a href="https://patreon.com/oxygenupdater">Patreon page</a>.</string>
 	<string name="about_background_story_header">Background story</string>
-	<string name="about_background_story">แอพนี้พัฒนาโดย Arjan Vlek เพื่อติดตามแอพตัวอื่นของเขา <a href="https://cyanogenupdatetracker.com/">Cyanogen Update Tracker</a> (มันมีฟังก์ชั่นการทำงานที่คล้ายกันสำหรับผู้ใช้ Cyanogen OS)\n\n หลังจาก 4 ปีในเดือนกรกฎาคม 2019 Arjan ตัดสินใจที่จะลดระดับจากทั้งสองโครงการและโอนสิทธิ์การเป็นเจ้าของแอพให้กับทีมนักพัฒนาที่มาจากประเทศต่างๆ พวกเขารับผิดชอบในการให้บริการชุมชนที่ยอดเยี่ยม &amp; สนับสนุนการอัปเดต OnePlus เร็วขึ้น\n คุณสามารถค้นหาข้อมูลเพิ่มเติมเกี่ยวกับประกาศ <a href="https://oxygenupdater.com/article/81/">here</a>.\n\n14 สิงหาคม 2019 ทำเครื่องหมายรุ่นแรกภายใต้ความเป็นเจ้าของใหม่ซึ่งมาพร้อมกับคุณสมบัติใหม่เช่นโหมดมืดและการออกแบบใหม่อย่างสมบูรณ์\n\n สำหรับข้อมูลเพิ่มเติมเกี่ยวกับทีมตรวจสอบ <a href="https://oxygenupdater.com/team/">the website</a>.</string>
-	<string name="about_third_party_app_notice">โปรดทราบว่านี่ไม่ใช่แอปพลิเคชัน OnePlus อย่างเป็นทางการ\n ชื่อ OnePlus, โลโก้ OnePlus และ OxygenOS เป็นทรัพย์สินของ OnePlus\nAndroid, Google, Google Play และโลโก้ Google Play เป็นเครื่องหมายการค้าจดทะเบียนของ Google Inc.\n แอพนี้ใช้ข้อมูลจาก OnePlus และ Oppo บริษัท แม่เพื่อแสดงข้อมูลอัปเดต</string>
+	<string name="about_background_story">แอพนี้พัฒนาโดย Arjan Vlek เพื่อติดตามแอพตัวอื่นของเขา <a href="https://cyanogenupdatetracker.com/">Cyanogen Update Tracker</a> (มันมีฟังก์ชั่นการทำงานที่คล้ายกันสำหรับผู้ใช้ Cyanogen OS)\n\nหลังจาก 4 ปีในเดือนกรกฎาคม 2019 Arjan ตัดสินใจที่จะลดระดับจากทั้งสองโครงการและโอนสิทธิ์การเป็นเจ้าของแอพให้กับทีมนักพัฒนาที่มาจากประเทศต่างๆ พวกเขารับผิดชอบในการให้บริการชุมชนที่ยอดเยี่ยม &amp; สนับสนุนการอัปเดต OnePlus เร็วขึ้น\nคุณสามารถค้นหาข้อมูลเพิ่มเติมเกี่ยวกับประกาศ <a href="https://oxygenupdater.com/article/81/">here</a>.\n\n14 สิงหาคม 2019 ทำเครื่องหมายรุ่นแรกภายใต้ความเป็นเจ้าของใหม่ซึ่งมาพร้อมกับคุณสมบัติใหม่เช่นโหมดมืดและการออกแบบใหม่อย่างสมบูรณ์\n\nสำหรับข้อมูลเพิ่มเติมเกี่ยวกับทีมตรวจสอบ <a href="https://oxygenupdater.com/team/">the website</a>.</string>
+	<string name="about_third_party_app_notice">โปรดทราบว่านี่ไม่ใช่แอปพลิเคชัน OnePlus อย่างเป็นทางการ\nชื่อ OnePlus, โลโก้ OnePlus และ OxygenOS เป็นทรัพย์สินของ OnePlus\nAndroid, Google, Google Play และโลโก้ Google Play เป็นเครื่องหมายการค้าจดทะเบียนของ Google Inc.\nแอพนี้ใช้ข้อมูลจาก OnePlus และ Oppo บริษัท แม่เพื่อแสดงข้อมูลอัปเดต</string>
 	<string name="about_rate_button_text">ให้คะแนนบน</string>
 	<!-- TODO: translate this string below -->
 	<string name="about_website_button_text">เว็บไซต์</string>
 	<string name="about_email_button_text">อีเมล์</string>
 
 	<!-- LocalNotifications strings -->
+	<string name="notification_permission_title">"รับการแจ้งเตือน"</string>
+	<string name="notification_permission_text">"โปรดอนุญาตให้แอปแจ้งให้คุณทราบถึงการอัปเดต OTA ข่าวสาร สถานะการดาวน์โหลดที่กำลังดำเนินอยู่ และสิ่งที่สำคัญอื่น ๆ คุณสามารถปรับแต่งการตั้งค่าของคุณได้ในภายหลังในการตั้งค่าของแอป"</string>
 	<string name="notification_new_device_text">%1$s ได้รับการสนับสนุนแล้ว เปิดแอพเพื่อเลือกอุปกรณ์นี้</string>
 	<string name="notification_no_notification_support">ติดตั้งหรืออัปเดตบริการ Google Play เพื่อเปิดใช้งานการแจ้งเตือนแบบพุช</string>
 	<string name="notification_version">%1$s พร้อมใช้งานสำหรับ %2$s!</string>
@@ -270,24 +231,10 @@ Instructions:
 	<string name="general_notification_channel_description">General notifications that don\'t fit into other categories</string>
 	<string name="url_submitted_notification_channel_description">รับการแจ้งเตือนเมื่อคุณส่ง OTA URL ให้กับทีมงานของเราเรียบร้อยแล้ว\nคุณสามารถยกเลิกการส่ง URL โดยอัตโนมัติได้ในการตั้งค่าของแอป</string>
 
-	<!-- Help strings -->
-	<string name="help">ช่วยเหลือ</string>
-	<string name="help_updating_your_device_title">กำลังอัปเดตอุปกรณ์ของคุณ</string>
-	<string name="help_updating_your_device_text">เมื่อเปิดแอพคุณจะเห็นว่ามีการอัปเดตระบบหรือไม่ หากมีการอัปเดตคุณสามารถติดตั้งได้\n\n หากต้องการเริ่มการติดตั้งให้แตะปุ่ม \"ดาวน์โหลด \" (ด้านล่างคำอธิบายการอัปเดต) เพื่อเริ่มการดาวน์โหลด เมื่อการดาวน์โหลดเสร็จสิ้นหน้าจอการติดตั้งจะปรากฏขึ้น หากคุณออกจากแอปหรือหน้าจอไม่ปรากฏขึ้นให้แตะปุ่ม \"ติดตั้ง \" ซึ่งจะปรากฏถัดจากปุ่ม \"ดาวน์โหลด \"\n\n หน้าจอติดตั้งจะตรวจสอบก่อนว่าคุณมี อุปกรณ์ที่รูท หากคุณมีอุปกรณ์รูทให้สิทธิ์การรูทเมื่อถูกถามและเลือกวิธีที่คุณต้องการติดตั้งการอัปเดต มิฉะนั้นให้ทำตามคำแนะนำสำหรับการติดตั้งด้วยตนเอง\n\n การติดตั้งอัตโนมัติ:\n คุณจะต้องเลือกตัวเลือกการติดตั้งของคุณเท่านั้น แนะนำให้ใช้การตั้งค่าเริ่มต้นยกเว้นว่าคุณจะต้องระบุรูทแพ็กเกจซึ่งจำเป็นต้องติดตั้งอีกครั้ง เลือกรูทแพ็กเกจ (ไฟล์ zip) โดยใช้ปุ่มโฟลเดอร์สีน้ำเงินแล้วแตะที่ \"เริ่มการติดตั้ง \" เพื่อเริ่มการติดตั้ง\n\n การติดตั้งแบบแมนนวล:\n คุณจะเห็นคู่มือการติดตั้งบนหน้าจอของคุณ จดคำแนะนำและดำเนินการตามที่ระบุไว้เพื่อติดตั้งการอัพเดท</string>
-	<string name="help_reading_news_title">อ่านข่าวล่าสุด</string>
-	<string name="help_reading_news_text">ข่าวจะปรากฏที่ด้านซ้ายของหน้าจออัปเดต รายการล่าสุดปรากฏที่ด้านบน เพียงแตะที่รายการเพื่ออ่าน\n แตะที่ลูกศรย้อนกลับหรือกดปุ่มย้อนกลับเพื่อกลับไปที่หน้าจอรายการข่าว</string>
-	<string name="help_device_information_title">ดูข้อมูลเกี่ยวกับอุปกรณ์ของคุณ</string>
-	<string name="help_device_information_text">คุณสามารถดูข้อมูลจำเพาะบางอย่างของอุปกรณ์ของคุณโดยใช้หน้าจอทางด้านขวาของหน้าจออัปเดต สิ่งนี้มีประโยชน์เมื่อคุณติดต่อทึมสนับสนุนในระหว่างที่คุณอาจถูกขอข้อมูลจำเพาะบางอย่างของอุปกรณ์ของคุณ</string>
-	<string name="help_change_settings_title">เปลี่ยนการตั้งค่า</string>
-	<string name="help_change_settings_text">คุณสามารถเปลี่ยนการตั้งค่าได้โดยแตะที่จุดสามจุดที่มุมบนขวาหลังจากแตะที่การตั้งค่า\n คุณสามารถเปลี่ยนการตั้งค่าต่อไปนี้:\n\n •อุปกรณ์และวิธีการอัปเดต\n •การแจ้งเตือนแบบกด\n\n •การตั้งค่าความเป็นส่วนตัว (อัปโหลดล็อก)\n\n ใช้สวิตช์เพื่อเปิด / ปิดการตั้งค่าการแจ้งเตือน / ความเป็นส่วนตัว เลือกอุปกรณ์และ / หรือวิธีการอัปเดตโดยใช้เมนูแบบเลื่อนลงที่แสดงด้านบนสวิตช์ เมนูแบบเลื่อนลงไม่ปรากฏหรือไม่ ตรวจสอบการเชื่อมต่ออินเทอร์เน็ตของคุณและเปิดหน้าจอการตั้งค่าอีกครั้ง</string>
-
 	<!-- News strings -->
 	<string name="news">ข่าว</string>
-	<string name="news_date_published">การอัพเดทครั้งล่าสุด: %1$s</string>
-	<string name="news_empty">บทความนี้ไม่มีเนื้อหา</string>
 	<string name="news_load_network_error">ไม่สามารถเปิดบทความ ตรวจสอบการเชื่อมต่อของคุณและกดปุ่ม \'ลองอีกครั้ง \' เพื่อเปิดบทความ</string>
 	<!-- TODO: translate this string below -->
-	<string name="news_load_id_error"><![CDATA[Failed to open article from an invalid URL: %1$s. Check the URL or report this to us either via <a href="mailto:support@oxygenupdater.com">email</a> or on our <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
 	<!-- TODO: translate these 2 strings below -->
 	<string name="news_unread_count_1">You have %1$d unread news articles. Tap here to view them.</string>
 	<string name="news_unread_count_2">You have %1$d unread news articles. Tap to show all articles.</string>
@@ -315,13 +262,11 @@ Instructions:
 	<string name="error_app_outdated">ไม่นะ!</string>
 	<string name="error_app_outdated_message">แอพเวอร์ชันนี้ล้าสมัยแล้ว ได้เวลาอัปเดตแล้ว! แตะที่ \"Google Play \" ด้านล่าง ภายใน Google Play ให้แตะที่ \"อัปเดต \"</string>
 	<string name="error_app_requires_network_connection">ไม่มีการเชื่อมต่อ</string>
-	<string name="error_app_requires_network_connection_message">ไม่สามารถเชื่อมต่อกับเซิร์ฟเวอร์ โปรดตรวจสอบให้แน่ใจว่าคุณมีการเชื่อมต่อที่ใช้งานได้ แอพพลิเคชั่นจะปิดลง</string>
 	<string name="error_google_play_button_text">Google Play</string>
-	<string name="error_no_internet_connection">ไม่มีการเชื่อมต่อ</string>
 	<string name="error_maintenance">การบำรุงรักษาเซิร์ฟเวอร์</string>
 	<string name="error_maintenance_message">โปรดรอ. เซิร์ฟเวอร์จะพร้อมใช้งานในไม่ช้า</string>
 	<!-- TODO: translate this string below -->
-	<string name="error_maintenance_retry">The server may be down for maintenance. Try again after some time, or report it to us either via <a href="mailto:support@oxygenupdater.com">email</a> or on our <a href="https://discord.gg/5TXdhKJ">Discord server</a>.</string>
+	<string name="error_maintenance_retry"><![CDATA[The server may be down for maintenance. Try again after some time, or report it to us either via <a href="mailto:support@oxygenupdater.com">email</a> or on our <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
 	<string name="error_reload">โหลดใหม่</string>
 
 	<string name="error_unable_to_rate_app">คุณไม่สามารถให้คะแนนแอพพลิเคชั่นได้ เนื่องจาก Google Play Store ไม่มีอยู่ในอุปกรณ์ของคุณ</string>
@@ -335,7 +280,7 @@ Instructions:
 	<!-- TODO: translate the 2 strings below -->
 	<string name="carrier_exclusive_device_warning_message">It looks like you\'re using a carrier-exclusive device. Even though you\'re running OxygenOS, you won\'t be able to install updates. Carriers usually lock down the device so that users can\'t update or modify the firmware without permission from the carrier itself. This is a common practice in the USA: the "Local Upgrade" option is removed from carrier-exclusive versions of OxygenOS. This option is necessary to install updates by yourself, even if you don\'t use this app. Unfortunately, we can\'t do anything about this, as we\'re technically, and possibly, legally limited. Reach out to us via email or Discord for more clarity.</string>
 	<string name="unsupported_device_warning_message">Congratulations on your new OnePlus device! Unfortunately, we haven\'t added support for this device yet. Don\'t worry though, we\'ll add it as soon as we can. We don\'t like making mistakes, and it\'s a time-consuming process to verify and test support for new devices, so please be patient. Email us or join our Discord server if you\'d like to help us, or to get notified when we release a new version of the app that includes support for your device.</string>
-	<string name="unsupported_os_warning_message">ดูเหมือนว่าอุปกรณ์ของคุณไม่ได้ใช้ OxygenOS โปรดทราบว่าคุณสามารถติดตั้งอัปเดตระบบในอุปกรณ์ที่ใช้ OxygenOS เท่านั้น ไม่รองรับ\n\n อุปกรณ์อื่น ๆ รวมถึงอุปกรณ์ OnePlus ที่ใช้ ROM ที่กำหนดเอง</string>
+	<string name="unsupported_os_warning_message">ดูเหมือนว่าอุปกรณ์ของคุณไม่ได้ใช้ OxygenOS โปรดทราบว่าคุณสามารถติดตั้งอัปเดตระบบในอุปกรณ์ที่ใช้ OxygenOS เท่านั้น ไม่รองรับ\n\nอุปกรณ์อื่น ๆ รวมถึงอุปกรณ์ OnePlus ที่ใช้ ROM ที่กำหนดเอง</string>
 
 	<!-- TODO: translate these 2 strings below -->
 	<string name="incorrect_device_warning_title">Selected device mismatch</string>
@@ -350,7 +295,6 @@ Instructions:
 
 	<!-- Other strings-->
 	<!-- TODO: translate this string below -->
-	<string name="error">ข้อผิดพลาด</string>
 	<string name="icon">ไอคอน</string>
 	<string name="loading">กำลังโหลด…</string>
 	<string name="processing">กำลังประมวลผล…</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools" tools:keep="@string/install_guide_page_*_*">
-	<!-- TODO: translate this string below -->
-	<string name="device_chooser_error_title">Couldn\'t retrieve list of supported devices</string>
-
+<resources>
 	<!-- Update information strings-->
 	<!-- TODO: translate this string below -->
 	<string name="enable">Etkinleştirme</string>
@@ -16,13 +13,12 @@
 	<!-- TODO: translate these 6 strings below -->
 	<string name="update_information_error_title">Couldn\'t retrieve latest update data information</string>
 	<string name="update_information_banner_server">Tap here to view important notices</string>
-	<string name="update_information_banner_advanced_mode_tip">You\'ve selected the \"%1$s\" update track. Enable gelişmiş mod if you plan to switch to this update track.</string>
+	<string name="update_information_banner_advanced_mode_tip">You\'ve selected the \"%1$s\" update method. Enable gelişmiş mod if you plan to switch to this update method.</string>
 	<string name="update_information_header_advanced_mode_hint">Gelişmiş mod etkinleştirildi</string>
-	<string name="update_information_header_advanced_mode_helper">Since you\'ve enabled gelişmiş mod, you can download the latest ZIP for \"%1$s\".\n\nYou can turn gelişmiş mod off from settings.</string>
-	<string name="update_information_different_version_changelog_notice">You\'re viewing a changelog for the latest update in the \"%1$s\" upgrade track. If you intend to install this update, you must turn gelişmiş mod on first (in settings).\n\nHowever, if you wish to see the changelog for the currently installed version instead, you\'ll need to switch back to the correct update method.</string>
-	<string name="update_information_last_checked_on">Son kontrol: %1$s</string>
+	<string name="update_information_header_advanced_mode_helper">Since you\'ve enabled gelişmiş mod, you can download the latest ZIP for \"%1$s\". You can turn gelişmiş mod off from settings.</string>
+	<string name="update_information_different_version_changelog_notice_base">Not: Bu değişiklik günlüğü \"%2$s\" güncelleme yöntemindeki mevcut en son sürüm (%1$s) içindir</string>
+	<string name="update_information_different_version_changelog_notice_advanced">. Bu güncellemeyi yüklemek istiyorsanız, ayarlarda \"Gelişmiş mod\" seçeneğini etkinleştirmeniz gerekir.</string>
 	<string name="update_information_no_update_data_available">Herhangi bir güncelleme bilgisi bulunmamaktadır.</string>
-	<string name="update_information_oxygen_os_version">OxygenOS %1$s</string>
 	<string name="update_information_system_is_up_to_date">Sisteminiz güncel.</string>
 	<string name="update_information_unknown_update_name">İsimsiz güncelleme: %1$s</string>
 	<string name="update_information_view_update_information">Güncelleme bilgilerini görüntüle</string>
@@ -50,7 +46,7 @@
 	<string name="download_complete_notification">Yüklemeyi başlatmak için dokunun</string>
 
 	<string name="download_error">İndirilemedi</string>
-	<string name="download_error_close">KAPAT</string>
+	<string name="download_error_close">Kapat</string>
 	<string name="download_error_corrupt">Güncelleme dosyası zarar görmüş! Lütfen tekrar indirmeyi deneyin.</string>
 	<string name="download_error_server">A server error occurred while downloading the update. Please try downloading the update again.</string>
 	<string name="download_error_internal">Unfortunately, a technical error occurred while downloading the update. Try downloading it again. If this keeps occurring, please contact the developer of this app for assistance.</string>
@@ -60,8 +56,8 @@
 If you\'d like to know more, feel free to contact us either via <a href="mailto:support@oxygenupdater.com">email</a> or on our <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
 	<string name="download_error_could_not_move_temp_file">The file has been downloaded, but couldn\'t be moved to the correct directory. Open a file manager, navigate to \"%1$s\" and manually move the file to the topmost directory of internal storage.</string>
 
-	<string name="download_error_retry">RETRY</string>
-	<string name="download_error_resume">RESUME</string>
+	<string name="download_error_retry">Retry</string>
+	<string name="download_error_resume">Resume</string>
 	<string name="download_error_storage">There is insufficient storage space available on your device to download the update. Please remove some files and try downloading it again.</string>
 
 	<string name="download_failed">Download failed</string>
@@ -98,9 +94,7 @@ If you\'d like to know more, feel free to contact us either via <a href="mailto:
 	<string name="summary_please_wait">Lütfen bekleyin…</string>
 	<string name="summary_update_method">Lütfen öncelikle cihazınızı belirtin.</string>
 	<!-- TODO: check the following translation -->
-	<string name="summary_important_notifications_disabled">Bazı önemli bildirimler devre dışı bırakılır: \"%1$s\"</string>
-	<string name="summary_theme">Temayı seçiniz</string>
-	<string name="summary_language">Dili ayarla</string>
+	<string name="summary_important_notifications_disabled">Bazı önemli bildirimler devre dışı bırakılır:</string>
 	<string name="summary_privacy_policy">Online görüntüleyiniz.</string>
 	<string name="summary_rate_app">5 yıldızlı yorum bırakınız.</string>
 	<string name="label_buy_ad_free">Reklamları kaldırın</string>
@@ -130,81 +124,46 @@ If you\'d like to know more, feel free to contact us either via <a href="mailto:
 
 	<string name="settings_device">Aygıt</string>
 	<string name="settings_entered_incorrectly">Ayarlar kaydedilirken hata oluştu. Lütfen geri gidin ve güncelleme metodunuzu değiştirin, veya tekrar seçin.</string>
-	<string name="settings_explanation_incremental_full_update">Artımlı güncelleme her versiyonda yapılabilir. (Eğer bootloaderınız açıksa, tam güncellemeleri seçmeniz önerilir.).\n\nOxygenOSun herhangi bir beta versiyonu kurulabililr, ayrıca sabit bir sürümde de aynısı geçerlidir. Sabit sürümden beta sürüme geçmek için, cihazınızın bootloaderı açık olması gerekmektedir. Beta versiyonlar içinde tam ve artımlı sürüm güncellemeleri de aynı şekilde çalışmaktadır.</string>
 
 	<string name="settings_push_from_server">Bilgilendirme ve uyarı mesajları.</string>
 
 	<string name="settings_saving">Ayarlarınız hala kaydedilmektedir. Eğer çok uzun sürerse: Bağlantınızı kontrol ediniz, uygulamayı kapatıp tekrar açınız.</string>
 
 	<string name="settings_advanced_mode">Gelişmiş mod</string>
-	<string name="settings_advanced_mode_explanation">Gelişmiş mod sayesinde yeni gelen güncellemelere cihazınız uyumlu olmasa bile indirebilir ve kurabilmenizi sağlar.</string>
+	<string name="settings_advanced_mode_explanation">"Normalde, uygulama güncellemeleri mevcut işletim sistemi sürümünüze göre gösterir. Gelişmiş modda, cihaz/sürüm uyumluluğuna bakılmaksızın her zaman mevcut en son güncelleme gösterilir.
+
+Eğer isterseniz bu faydalı olabilir:"</string>
+	<string name="settings_advanced_mode_uses">"&#8226; En son sürümü zaten kullanıyor olsanız bile yeniden indirin
+&#8226; Farklı bir güncelleme yoluna geçin"</string>
+	<string name="settings_advanced_mode_caption">"Gelişmiş mod yalnızca yukarıdaki durumlarda gerekli olabilir. Ne yaptığınızı bilmiyorsanız etkinleştirmemelisiniz."</string>
 
 	<string name="settings_update_method">Güncelleme metodu</string>
 	<string name="settings_upload_logs">Data kullanım verilerini paylaş.</string>
+	<string name="settings_ad_privacy">GDPR reklam izni</string>
+	<string name="settings_ad_privacy_subtitle">"AEA/İngiltere'deki kullanıcılar için"</string>
 
 	<!-- FAQ strings -->
 	<string name="faq">SSS</string>
 	<string name="faq_menu_item">SSS</string>
 
 	<!-- First-time setup strings -->
-	<string name="onboarding">Hoşgelidiniz</string>
+	<string name="onboarding">Kurulum</string>
 	<string name="onboarding_finished_button">Uygulamayı başlat</string>
 
-	<string name="onboarding_page_1_title">Oxygen Updatera hoşgeldiniz!</string>
-	<string name="onboarding_page_1_text">Bu uygulama size:\n\n&#8226; En sonki Android güncellemelerini OxygenOS kullanan cihazınıza kurmanızda yardımcı olacak.\n\n&#8226; Rootlu bir cihazı kolayca güncellemenizi sağlayacak.\n\n&#8226; Kullandığınız sistem yazılımında nelerin yeni olduğunu görmeniz için.\n\n&#8226; OnePlus ve OxygenOS hakkındaki yenilikleri görmek için yardımcı olacak.\n\n Devam etmek için sola kaydırın.</string>
-	<string name="onboarding_page_1_caption">Orijinal bir OnePlus uygulaması değildir. Uygulamayı kullanmak tamamen sizin sorumluluğunuzdadır. Her türlü durum altında cihazınızda oluşan sorunlarla ilgili OnePlus ve uygulama geliştiricileri sorumlu değildir.\n\n Bu uygulamayı kullanarak, belirtilen şartları kabul etmiş olursunuz.</string>
-	<string name="onboarding_page_2_title">Cihazınızı seçin</string>
-	<string name="onboarding_page_2_caption">Cihazınız genellikle otomatik olarak tanınır ve burada seçilir, eğer değilse lütfen seçiniz.</string>
-	<string name="onboarding_page_3_title">Güncelleme metodunuzu seçiniz</string>
-	<string name="onboarding_page_3_caption">Genellikle artımlı güncelleme yöntemi tercih edilendir, çünkü bu yöntemde daha az ve daha hızlı indirmeler yapılır.\n\nAncak rootlu cihazlar için uygun değildir. Eğer rootlu cihazınız varsa, bu yöntemi seçmeyiniz.\n\nEğer OxygenOS un beta sürümüne sahipseniz, Açık Beta güncelleme yöntemlerinden birini seçiniz.</string>
-	<string name="onboarding_page_4_title">Başlamak için hazırsınız!</string>
-	<string name="onboarding_page_4_text">Uygulamayı güle güle kullanın!\n\nHer zaman ayarlarınızı daha sonra değiştirebilirsiniz. Yapmak için: Sol üst köşedeki üç noktadan \"Ayarlar\" ı seçiniz.</string>
+	<string name="onboarding_app_uses">Bu uygulama size:\n\n&#8226; En sonki Android güncellemelerini OxygenOS kullanan cihazınıza kurmanızda yardımcı olacak.\n&#8226; Rootlu bir cihazı kolayca güncellemenizi sağlayacak.\n&#8226; Kullandığınız sistem yazılımında nelerin yeni olduğunu görmeniz için.\n&#8226; OnePlus ve OxygenOS hakkındaki yenilikleri görmek için yardımcı olacak.</string>
+	<string name="onboarding_disclaimer">Orijinal bir OnePlus uygulaması değildir. Uygulamayı kullanmak tamamen sizin sorumluluğunuzdadır. Her türlü durum altında cihazınızda oluşan sorunlarla ilgili OnePlus ve uygulama geliştiricileri sorumlu değildir. Bu uygulamayı kullanarak, belirtilen şartları kabul etmiş olursunuz.</string>
+	<string name="onboarding_device_chooser_title">Cihazınızı seçin</string>
+	<string name="onboarding_device_chooser_caption">Cihazınız genellikle otomatik olarak tanınır ve burada seçilir, eğer değilse lütfen seçiniz.</string>
+	<string name="onboarding_method_chooser_title">Güncelleme metodunuzu seçiniz</string>
+	<string name="onboarding_method_chooser_caption">Genellikle artımlı güncelleme yöntemi tercih edilendir, çünkü bu yöntemde daha az ve daha hızlı indirmeler yapılır. Ancak rootlu cihazlar için uygun değildir. Eğer rootlu cihazınız varsa, bu yöntemi seçmeyiniz. Eğer OxygenOS un beta sürümüne sahipseniz, Açık Beta güncelleme yöntemlerinden birini seçiniz.</string>
+	<string name="onboarding_caption">Uygulamayı güle kullanın! Her zaman ayarlarınızı daha sonra değiştirebilirsiniz.</string>
 
 	<!-- Automatic install strings -->
 	<string name="install">Yükle</string>
 
 	<!-- Install guide strings -->
-	<string name="install_guide_no_root">Güncellemeyi rehberde gösterildiği sekilde uygulayınız.</string>
 	<string name="install_guide">Yükleme rehberi</string>
-	<string name="install_guide_subtitle">Yükleme rehberi - %1$d of %2$d</string>
-	<string name="install_guide_tip">&#8226; Bütün adımları not etmeniz önerilir, güncelleme sırasında cihazınız kapalı olacaktır.</string>
-
-	<string name="install_guide_page_1_title">Güncellemeyi indirmek</string>
-	<string name="install_guide_page_1_text">&#8226; Güncellemeyi indirmeyi başlatmak için butona basınız.\n\n&#8226; İndirme işlemi uygulama içinde gözükecektir, ayrıca bildirim olarakta gösterilecektir.\n\n&#8226; İndirme bittiğinde, Bu bildirimi göreceksiniz \"İndirme tamamlandı\".\nEğer indirmede sorun oluşutuysa, Uygulamayı tekrar açın ve indirmeyi birdaha başlatın. Eğer çalışmazsa, internet bağlantınız olduğundan emin olun. Aksi takdirde, uygulama geliştiricileriyle iletişime geçiniz. Google Play\'de \"Uygulamalarım\" bölümünden bakabilirsiniz.</string>
-
-	<!-- TODO: translate these 2 strings below -->
-	<string name="install_guide_page_2_title">Prepare for installation</string>
-	<string name="install_guide_page_2_text">"Note: The installation of the update takes place from a special page of the standard System Updates section of your device. If, for some reason, a system update appears when opening this section, you may also opt to install that update first. Afterwards, open Oxygen Updater again to see if you're completely up-to-date.
-
-Instructions:
-&#8226; Close Oxygen Updater by pressing the home button.
-
-&#8226; Open the Settings app. It should be located in your app drawer.
-
-&#8226; Scroll down until you see System updates. Tap on it."</string>
-
-	<!-- TODO: translate these 2 strings below -->
-	<string name="install_guide_page_3_title">Install the update</string>
-	<string name="install_guide_page_3_text">"Now that you're in the System Updates app, it's time to install the update.
-
-&#8226; Within the System Updates section, tap the gear icon in the top right
-
-&#8226; Now, select \"Local upgrade\". A file selection screen should appear.
-
-&#8226; In this screen, tap on the update file you downloaded using Oxygen Updater. Its name should start with \"%1$sOxygen\".
-
-&#8226; Tap on \"Upgrade Now\". The installation should start automatically."</string>
-
-	<!-- TODO: translate these 2 strings below -->
-	<string name="install_guide_page_4_title">Wait until the installation completes</string>
-	<string name="install_guide_page_4_text">"&#8226; The phone will now install the update and displays a progress bar. Please wait until the installation has finished. Installation may take anywhere from a few minutes up to 15 minutes.
-
-&#8226; Afterwards, your phone will restart to complete the update."</string>
-
-	<string name="install_guide_page_5_title">Bitti. OxygenOS un yeni sürümünün tadını çıkarın!</string>
-	<string name="install_guide_page_5_text">&#8226; Optimize edilme bittiğinde, güncelleme de başarılı şekilde olmuş demektir.\n Sistem ayarlarınızdan bunu görüntüleyebilirsiniz.\n\n&#8226; Uygulamayı beğendiyseniz, lütfen Google Play\'de 5 yıldız vermeyi unutmayınız!</string>
-
-	<string name="install_guide_close_button">Yükleme Rehberini Kapat</string>
+	<string name="install_guide_download_instructions">&#8226; Güncellemeyi indirmeyi başlatmak için butona basınız.\n&#8226; İndirme işlemi uygulama içinde gözükecektir, ayrıca bildirim olarakta gösterilecektir.\n&#8226; İndirme bittiğinde, Bu bildirimi göreceksiniz \"İndirme tamamlandı\". Eğer indirmede sorun oluşutuysa, Uygulamayı tekrar açın ve indirmeyi birdaha başlatın. Eğer çalışmazsa, internet bağlantınız olduğundan emin olun. Aksi takdirde, uygulama geliştiricileriyle iletişime geçiniz. Google Play\'de \"Uygulamalarım\" bölümünden bakabilirsiniz.</string>
 
 	<!-- Device information strings -->
 	<!-- TODO: translate these 4 strings below -->
@@ -222,7 +181,7 @@ Instructions:
 	<string name="device_information_image_description">Cihaz imajı</string>
 	<string name="device_information_incremental_os_version">OS versiyonu</string>
 	<string name="device_information_os_version">Android versiyonu</string>
-	<string name="device_information_oxygen_os_version">OxygenOS versiyonu</string>
+	<string name="device_information_oxygen_os_version">OS versiyonu</string>
 	<string name="device_information_oxygen_os_ota_version">OTA versiyonu</string>
 	<string name="device_information_patch_level_version">Güvenlik duvarı versiyonu</string>
 	<string name="device_information_serial_number">Seri numarası</string>
@@ -236,13 +195,15 @@ Instructions:
 	<string name="about_support">If you\'d like to support us, you can either buy the ad-free unlock (app\'s settings), or check our <a href="https://patreon.com/oxygenupdater">Patreon page</a>.</string>
 	<string name="about_background_story_header">Background story</string>
 	<string name="about_background_story">Bu uygulama ilk olarak Arjan Vlek tarafından <a href="https://cyanogenupdatetracker.com/">Cyanogen Update Tracker</a> (Cyanogen OS kullanıcıları için benzer bir işlevsellik sağlar) adlı diğer bir uygulamasının devamı olarak geliştirilmiştir.\n\n4 yıl sonra, Temmuz 2019\'da Arjan, her iki projeden de vazgeçmeye ve uygulamanın sahipliğini farklı ülkelerden gelen bir geliştiriciler ekibine aktarmaya karar verdi. Topluma mükemmel hizmet sağlama sorumluluğunu üstlendiler &amp; OnePlus güncellemelerini daha hızlı alma desteği.\nDuyuru ile ilgili daha fazla bilgiyi <a href="https://oxygenupdater.com/article/81/">burada</a> bulabilirsiniz.\n\n14 Ağustos 2019, karanlık mod ve tam bir yeniden tasarım gibi yeni özelliklerle gelen yeni mülkiyet altındaki ilk sürümü işaretledi.\n\nTakım hakkında daha fazla bilgi için <a href="https://oxygenupdater.com/team/">web sitesini</a> kontrol edin.</string>
-	<string name="about_third_party_app_notice">Lütfen dikkat edin, bu resmi bir OnePlus uygulaması değildir.\n OnePlus adı, OnePlus Logosu ve OxygenOS, OnePlusa aittir.\n Android, Google, Google Play ve Google Play logosunun mülkiyetindedir Google Inc. in tescilli ticari markalarıdır.\nBu uygulama güncelleme bilgilerini göstermek için "OnePlus" ve ana şirketi "Oppo" \'ya ait verileri kullanır.</string>
+	<string name="about_third_party_app_notice">Lütfen dikkat edin, bu resmi bir OnePlus uygulaması değildir.\nOnePlus adı, OnePlus Logosu ve OxygenOS, OnePlusa aittir.\nAndroid, Google, Google Play ve Google Play logosunun mülkiyetindedir Google Inc. in tescilli ticari markalarıdır.\nBu uygulama güncelleme bilgilerini göstermek için "OnePlus" ve ana şirketi "Oppo" \'ya ait verileri kullanır.</string>
 	<string name="about_rate_button_text">Derecelendir</string>
 	<!-- TODO: translate this string below -->
 	<string name="about_website_button_text">İnternet sitesi</string>
 	<string name="about_email_button_text">E-posta</string>
 
 	<!-- LocalNotifications strings -->
+	<string name="notification_permission_title">"Haberdar olun"</string>
+	<string name="notification_permission_text">"Lütfen uygulamanın sizi OTA güncellemeleri, haberler, devam eden indirme durumu ve diğer önemli şeyler hakkında bilgilendirmesine izin verin. Tercihlerinize daha sonra uygulamanın ayarlarından ince ayar yapabilirsiniz."</string>
 	<string name="notification_new_device_text">"Artık bu cihazda destekleniyor %1$s. Cihazı seçmek için uygulamayı açın."</string>
 	<string name="notification_no_notification_support">Bildirimler için uygulamayı güncel tutmayı unutmayın.</string>
 	<string name="notification_version">%1$s artık mevcut %2$s bu cihazlar için!</string>
@@ -269,24 +230,10 @@ Instructions:
 	<string name="general_notification_channel_description">General notifications that don\'t fit into other categories</string>
 	<string name="url_submitted_notification_channel_description">OTA URL\'lerini ekibimize başarıyla gönderdiğinizde bildirim alın.\nUygulamanın ayarlarından URL\'lerin otomatik olarak gönderilmesini devre dışı bırakabilirsiniz.</string>
 
-	<!-- Help strings -->
-	<string name="help">Yardım</string>
-	<string name="help_updating_your_device_title">Cihazı güncellemek</string>
-	<string name="help_updating_your_device_text">Uygulamayı açtığınızda, eğer güncelleme varsa bunu göreceksinizdir. Varsa, güncellemeyi indiredebilirsiniz.\n\n İndirmeyi başlatmak için, \"İndir\" butonuna basınız. (Güncelleme detayları altında). İndirme bittiğinde, yükleme ekranı karşınıza çıkacaktır. Herhangi bir şey olmadıysa(indirme sonrası), \"Yükle\" butonuna tıklayınız, Normalde \"İndir\" butonunun yanında bulunmakta.\n\nYükleme ekranı öncelikle cihazınız rootlu mu diye kontrol edecektir. Rootlu cihazınız varsa, sizden root erişimi istendiğinde izin vermeniz gerekecektir. Aksi takdirde, Manuel yükleme rehberini inceleyiniz.\n\nOtomatik yükleme:\n Sadece yükleme ayarlarını seçeceksiniz. Varsayılan ayarlar önerilmektedir, root paketinizi tekrar kurmak için seçmeniz gerekecek bölüm dışında. Root paketi içeren bir ZIP dosyasını "mavi dosya" simgesinden seçiniz ve daha sonra \"Yüklemeyi Başlat\" a tıklayıp başlatınız.\n\nManuel yükleme:\nEkranınızda yükleme rehberini göreceksiniz. Rehberde gözüken adımları not etmeniz önerilir.</string>
-	<string name="help_reading_news_title">Güncel haberleri okumak.</string>
-	<string name="help_reading_news_text">Haberler, güncelleme bölümünün solunda bulunmaktadır. En sonki haberler en üsttedir. Okumak için sadece tıklayın.\n Geri dönmek için ok simgesine tıklayın veya cihazınızdaki geri tuşuna dokunun.</string>
-	<string name="help_device_information_title">Cihaz hakkında bilgileri inceleme</string>
-	<string name="help_device_information_text">Güncelleme bölümünün sağ tarafında bulunmaktadır. Bu bölümden bilgi alabilirsiniz ve bu sayede yardım alırken bu bilgileri kullanabilirsiniz.</string>
-	<string name="help_change_settings_title">Ayarları değiştirme</string>
-	<string name="help_change_settings_text">Sağ üstten ayarlara girerek onları istediğiniz şekilde değiştirebilirsiniz.\nBelirtilen ayarları değiştirebilirsiniz:\n\n• Aygıt ve güncelleme bilgileri\n• Bildirimler\n• Uygulama içi bildirimler\n• Gizlilik ayarları.</string>
-
 	<!-- News strings -->
 	<string name="news">Haberler</string>
-	<string name="news_date_published">Son güncelleme: %1$s</string>
-	<string name="news_empty">Bu içerikte bir şey bulunmamakta.</string>
 	<string name="news_load_network_error">İçerik açılamadı. İnternet bağlantınızı kontrol edin ve \"Tekrar\" tuşuna basınız.</string>
 	<!-- TODO: translate this string below -->
-	<string name="news_load_id_error"><![CDATA[Failed to open article from an invalid URL: %1$s. Check the URL or report this to us either via <a href="mailto:support@oxygenupdater.com">email</a> or on our <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
 	<!-- TODO: translate these 2 strings below -->
 	<string name="news_unread_count_1">You have %1$d unread news articles. Tap here to view them.</string>
 	<string name="news_unread_count_2">You have %1$d unread news articles. Tap to show all articles.</string>
@@ -314,13 +261,11 @@ Instructions:
 	<string name="error_app_outdated">Oh olamaz!</string>
 	<string name="error_app_outdated_message">Uygulamanızın sürümü eski. Güncelleme vakti gelmiş!</string>
 	<string name="error_app_requires_network_connection">Bağlantı bulunamadı</string>
-	<string name="error_app_requires_network_connection_message">Sunucuya bağlanılamadı. Çalışan bir bağlantınızın olduğundan emin olun. Uygulama kapatılacak.</string>
 	<string name="error_google_play_button_text">Google Play</string>
-	<string name="error_no_internet_connection">Bağlantı yok.</string>
 	<string name="error_maintenance">Sunucu bakımı</string>
 	<string name="error_maintenance_message">Lütfen bekleyiniz. Sunucu en kısa zamanda tekrar aktif olacak.</string>
 	<!-- TODO: translate this string below -->
-	<string name="error_maintenance_retry">The server may be down for maintenance. Try again after some time, or report it to us either via <a href="mailto:support@oxygenupdater.com">email</a> or on our <a href="https://discord.gg/5TXdhKJ">Discord server</a>.</string>
+	<string name="error_maintenance_retry"><![CDATA[The server may be down for maintenance. Try again after some time, or report it to us either via <a href="mailto:support@oxygenupdater.com">email</a> or on our <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
 	<string name="error_reload">Yeniden yükle</string>
 
 	<string name="error_unable_to_rate_app">Uygulamayı değerlendiremezsiniz, çünkü Google Play Store cihazınızda bulunmamakta.</string>
@@ -349,7 +294,6 @@ Instructions:
 
 	<!-- Other strings-->
 	<!-- TODO: translate this string below -->
-	<string name="error">Hata</string>
 	<string name="icon">İkon</string>
 	<string name="loading">Yükleniyor…</string>
 	<string name="processing">İşleniyor…</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools" tools:keep="@string/install_guide_page_*_*">
-	<string name="device_chooser_error_title">Не вдалося отримати список підтримуваних пристроїв</string>
-
+<resources>
 	<!-- Update information strings-->
 	<string name="enable">Увімкнути</string>
 	<string name="update_information_description_not_available">Немає офіційної інформації про зміни і нові функції, які містить це оновлення. Зазвичай, таке оновлення містить виправлення помилок, покращення продуктивності, та / або важливі оновлення безпеки для вашого пристрою.</string>
@@ -13,11 +11,10 @@
 	<string name="update_information_banner_server">Натисніть, щоб переглянути важливі повідомлення</string>
 	<string name="update_information_banner_advanced_mode_tip">Ви вибрали режим оновлення \"%1$s\". Увімкніть розширений режим якщо плануєте використовувати цей режим.</string>
 	<string name="update_information_header_advanced_mode_hint">Увімкнено розширений режим</string>
-	<string name="update_information_header_advanced_mode_helper">Оскільки увімкнено розширений режим, ви можете завантажити останній ZIP з \"%1$s\".\n\nРозширений режим можна вимкнути в налаштуваннях.</string>
-	<string name="update_information_different_version_changelog_notice">Ви переглядаєте список змін для способу оновлення \"%1$s\". Якщо ви маєте намір встановити це оновлення, спочатку необхідно увімкнути розширений режим в налаштуваннях.\n\nПроте, якщо ви хочете переглянути список змін до поточної встановленої версії, вам потрібно вибрати відповідний спосіб оновлення в налаштуваннях.</string>
-	<string name="update_information_last_checked_on">Востаннє перевірено: %1$s</string>
+	<string name="update_information_header_advanced_mode_helper">Оскільки увімкнено розширений режим, ви можете завантажити останній ZIP з \"%1$s\". Розширений режим можна вимкнути в налаштуваннях.</string>
+	<string name="update_information_different_version_changelog_notice_base">Примітка: цей журнал змін стосується останньої доступної версії (%1$s) у методі оновлення \"%2$s\"</string>
+	<string name="update_information_different_version_changelog_notice_advanced">. Якщо ви маєте намір встановити це оновлення, вам слід увімкнути \"Розширений режим\" у налаштуваннях.</string>
 	<string name="update_information_no_update_data_available">Немає інформації про оновлення</string>
-	<string name="update_information_oxygen_os_version">OxygenOS %1$s</string>
 	<string name="update_information_system_is_up_to_date">Система оновлена</string>
 	<string name="update_information_unknown_update_name">Оновлення без назви для %1$s</string>
 	<string name="update_information_view_update_information">Інформація про оновлення</string>
@@ -44,7 +41,7 @@
 	<string name="download_complete_notification">Натисніть, щоб встановити</string>
 
 	<string name="download_error">Помилка завантаження</string>
-	<string name="download_error_close">ЗАКРИТИ</string>
+	<string name="download_error_close">Закрити</string>
 	<string name="download_error_corrupt">Завантажене оновлення пошкоджене! Будь ласка, спробуйте завантажити його знову.</string>
 	<string name="download_error_server">Під час завантаження оновлення сталася помилка на сервері. Будь ласка, спробуйте завантажити оновлення знову.</string>
 	<string name="download_error_internal">На жаль, під час завантаження оновлення виникла технічна помилка. Спробуйте завантажити його знову. Але якщо помилка не зникне, тоді зв\'яжіться з розробником застосунку для консультації.</string>
@@ -53,8 +50,8 @@
 Якщо хочете дізнатися більше, можете зв\'язатися з нами через <a href="mailto:support@oxygenupdater.com">електронну пошту</a> або написати в <a href="https://discord.gg/5TXdhKJ">чат на Discord</a>.]]></string>
 	<string name="download_error_could_not_move_temp_file">Файл завантажено, але його не вдалося перемістити в потрібну теку. Відкрийте менеджер файлів, перейдіть в \"%1$s\", і вручну перемістіть файл в теку \"topmost\" на внутрішньому сховищі.</string>
 
-	<string name="download_error_retry">ПОВТОРИТИ</string>
-	<string name="download_error_resume">ПРОДОВЖИТИ</string>
+	<string name="download_error_retry">Повторити</string>
+	<string name="download_error_resume">Продовжити</string>
 	<string name="download_error_storage">На вашому пристрої недостатньо місця, щоб завантажити оновлення. Будь ласка, видаліть деякі файли і спробуйте завантажити його знову.</string>
 
 	<string name="download_failed">Не вдалося завантажити</string>
@@ -91,9 +88,7 @@
 	<string name="summary_please_wait">Будь ласка, зачекайте…</string>
 	<string name="summary_update_method">Спершу виберіть пристрій</string>
 	<!-- TODO: check the following translation -->
-	<string name="summary_important_notifications_disabled">Деякі важливі сповіщення вимкнено: \"%1$s\"</string>
-	<string name="summary_theme">Вибрати тему оформлення</string>
-	<string name="summary_language">Встановити мову</string>
+	<string name="summary_important_notifications_disabled">Деякі важливі сповіщення вимкнено:</string>
 	<string name="summary_privacy_policy">Переглянути онлайн</string>
 	<string name="summary_rate_app">Зилишіть відгук з 5-ма зірочками</string>
 
@@ -124,78 +119,46 @@
 
 	<string name="settings_device">Вибрати пристрій</string>
 	<string name="settings_entered_incorrectly">Помилка під час збереження налаштувань. Будь ласка, верніться назад і виберіть ваш пристрій / спосіб оновлення знову.</string>
-	<string name="settings_explanation_incremental_full_update">Інкрементне оновлення (Incremental update) можна встановлювати з будь-якої версії, якщо у вас заблокований завантажувач. Інакше, якщо завантажувач розблоковано — слід вибрати \"Повне оновлення\" (Full update).\n\nБета оновлення (Open Beta) для OxygenOS можна встановлювати, якщо у вас стабільна версія. Щоб встановити бета версію, потрібно увімкнути \"Розширений режим\" в налаштуваннях. Для бета версій, способи Повного та Інкрементного оновлення працюють так само, як і у стабільних версіях.</string>
 
 	<string name="settings_push_from_server">Інформаційні повідомлення та попередження</string>
 
 	<string name="settings_saving">Ваші налаштування досі зберігаються. Якщо це триває занадто довго: перевірте з\'єднання з мережею, вийдіть із застосунку і запустіть його знову.</string>
 
 	<string name="settings_advanced_mode">Розширений режим</string>
-	<string name="settings_advanced_mode_explanation">Розширений режим приховує повідомлення \"Система оновлена\", дозволяючи вам завантажувати і встановлювати всі оновлення, навіть якщо вони можуть бути не сумісні з вашим пристроєм.\n\nЦей режим може бути корисним, коли потрібно:\n&#8226; оновитися зі звичайної версії до бета версії;\n&#8226; відкотитися з бета версії до звичайної версії (не забувайте повністю очищати ваш пристрій);\n&#8226; перевстановити вашу поточну систему.</string>
+	<string name="settings_advanced_mode_explanation">"Зазвичай програма показує оновлення на основі поточної версії ОС. У розширеному режимі завжди буде показано останнє доступне оновлення, незалежно від сумісності пристрою/версії.
+
+Це може бути корисно, якщо ви хочете:"</string>
+	<string name="settings_advanced_mode_uses">"&#8226; Повторно завантажити останню версію, навіть якщо вона вже встановлена
+&#8226; Переключитися на інший шлях оновлення"</string>
+	<string name="settings_advanced_mode_caption">"Розширений режим може знадобитися лише у вищезазначених ситуаціях. Не вмикайте його, якщо не знаєте, що робите."</string>
 
 	<string name="settings_update_method">Спосіб оновлення</string>
 	<string name="settings_upload_logs">Ділитися даними про використання та журналом помилок</string>
+	<string name="settings_ad_privacy">Згода на рекламу GDPR</string>
+	<string name="settings_ad_privacy_subtitle">"Для користувачів з ЄЕЗ/Великобританії"</string>
 
 	<!-- FAQ strings -->
 	<string name="faq">ЧаПи</string>
 	<string name="faq_menu_item">ЧаПи</string>
 
 	<!-- First-time onboarding strings -->
-	<string name="onboarding">Вітання</string>
+	<string name="onboarding">Налаштування</string>
 	<string name="onboarding_finished_button">розпочати</string>
 
-	<string name="onboarding_page_1_title">Ласкаво просимо до Oxygen Updater!</string>
-	<string name="onboarding_page_1_text">Цей застосунок дозволить вам:\n\n&#8226; Отримувати миттєвий доступ до останніх оновлень Android для вашого пристрою під керуванням OxygenOS\n\n&#8226; Легко оновлювати пристрій з рутом\n\n&#8226; Переглядати, що нового на встановленій прошивці\n\n&#8226; Читати останні новини про OnePlus і OxygenOS\n\nПроведіть вліво, щоб продовжити.</string>
-	<string name="onboarding_page_1_caption">Це не офіційний застосунок від компанії OnePlus. Ви використовуєте його на свій страх і ризик. OnePlus і розробник цього застосунку не несуть відповідальності за заподіяння будь-якої шкоди вашому пристрою, спричинених цим застосунком.\n\nВикористовуючи Oxygen Updater, ви погоджуєтеся з умовами, вказаними вище.</string>
-	<string name="onboarding_page_2_title">Виберіть ваш пристрій</string>
-	<string name="onboarding_page_2_caption">Зазвичай пристрій визначається автоматично. Якщо ні, тоді виберіть його зі списку.</string>
-	<string name="onboarding_page_3_title">Виберіть спосіб оновлення</string>
-	<string name="onboarding_page_3_caption">Зазвичай, інкрементне оновлення (Incremental update) є оптимальним вибором, тому що під час нього завантажується менше файлів.\n\nОднак, такий спосіб не сумісний з рутованими пристроями. Якщо у вас пристрій з рут правами, виберіть \"Повне оновлення\" (Full update).\n\nЯкщо ви користуєтеся бета версіями OxygenOS, тоді виберіть спосіб \"Бета оновлення\" (Open Beta).</string>
-	<string name="onboarding_page_4_title">Ви готові до оновлення!</string>
-	<string name="onboarding_page_4_text">Сподіваємося, вам буде приємно користуватися цим застосунком!\n\nВи завжди можете змінити налаштування. Щоб це зробити, натисніть на три крапки в правому верхньому куті, і виберіть \"Налаштування\".</string>
+	<string name="onboarding_app_uses">Цей застосунок дозволить вам:\n\n&#8226; Отримувати миттєвий доступ до останніх оновлень Android для вашого пристрою під керуванням OxygenOS\n&#8226; Легко оновлювати пристрій з рутом\n&#8226; Переглядати, що нового на встановленій прошивці\n&#8226; Читати останні новини про OnePlus і OxygenOS</string>
+	<string name="onboarding_disclaimer">Це не офіційний застосунок від компанії OnePlus. Ви використовуєте його на свій страх і ризик. OnePlus і розробник цього застосунку не несуть відповідальності за заподіяння будь-якої шкоди вашому пристрою, спричинених цим застосунком. Використовуючи Oxygen Updater, ви погоджуєтеся з умовами, вказаними вище.</string>
+	<string name="onboarding_device_chooser_title">Виберіть ваш пристрій</string>
+	<string name="onboarding_device_chooser_caption">Зазвичай пристрій визначається автоматично. Якщо ні, тоді виберіть його зі списку.</string>
+	<string name="onboarding_method_chooser_title">Виберіть спосіб оновлення</string>
+	<string name="onboarding_method_chooser_caption">Зазвичай, інкрементне оновлення (Incremental update) є оптимальним вибором, тому що під час нього завантажується менше файлів. Однак, такий спосіб не сумісний з рутованими пристроями. Якщо у вас пристрій з рут правами, виберіть \"Повне оновлення\" (Full update). Якщо ви користуєтеся бета версіями OxygenOS, тоді виберіть спосіб \"Бета оновлення\" (Open Beta).</string>
+	<string name="onboarding_caption">Сподіваємося, вам буде приємно користуватися цим застосунком! Ви завжди можете змінити налаштування.</string>
 
 	<!-- Automatic install strings -->
 	<string name="install">Встановлення</string>
 
 	<!-- Install guide strings -->
-	<string name="install_guide_no_root">Встановіть оновлення відповідно до інструкції</string>
 	<string name="install_guide">Інструкція по встановленню</string>
-	<string name="install_guide_subtitle">Інструкція — крок %1$d з %2$d</string>
-	<string name="install_guide_tip">&#8226; Рекомендується записати всі кроки, тому що вам потрібно буде вимкнути пристрій, щоб встановити оновлення.</string>
-
-	<string name="install_guide_page_1_title">Завантаження оновлення</string>
-	<string name="install_guide_page_1_text">&#8226; Натисніть кнопку \"Завантажити\", щоб розпочати завантаження оновлення.\n\n&#8226; Внизу застосунку з\'явиться прогрес завантаження, який буде продубльовано в системному сповіщенні.\n\n&#8226; Коли завантаження завершиться, ви побачите сповіщення з текстом \"Завантаження завершено\".\nЯкщо під час завантаження трапиться помилка, відкрийте застосунок і спробуйте завантажити оновлення ще раз. Якщо і це на спрацює, тоді перевірте з\'єднання з інтернетом. Інакше, зв\'яжіться з розробником застосунку: знайдіть застосунок Oxygen Updater в Google Play > \"Контактні дані розробника\".</string>
-
-	<string name="install_guide_page_2_title">Підготовка до встановлення</string>
-	<string name="install_guide_page_2_text">"Увага: встановлення оновлення відбувається через спеціальний розділ в системних налаштуваннях вашого пристою. Якщо з якихось причин вам з'явилося системне вікно оновлення, ви можете встановити це оновлення. Після цього вікрийте Oxygen Updater і перевірте, чи систему оновлено.
-
-Інструкція:
-&#8226; Закрийте Oxygen Updater, натиснувши кнопку \"Головний екран\".
-
-&#8226; Відкрийте Параметри (або Налаштування). Має бути в панелі застосунків.
-
-&#8226; Прогорніть вниз і виберіть пункт \"Система\". Далі виберіть \"Оновлення системи\"."</string>
-
-	<string name="install_guide_page_3_title">Встановлення оновлення</string>
-	<string name="install_guide_page_3_text">"Час встановити оновлення. Не виходячи з вікна Оновлення системи:
-
-&#8226; Натисніть на значок зубчастого колеса в правому верхньому куті.
-
-&#8226; Виберіть пункт \"Локальне оновлення\". Має з'явитися вікно вибору файлу.
-
-&#8226; В цьому вікні виберіть файл оновлення, який було завантажено через застосунок Oxygen Updater. Назва файлу повинна починатися з \"%1$sOxygen\".
-
-&#8226; Натисніть \"Встановити зараз\". Після цього розпочнеться встановлення оновлення."</string>
-
-	<string name="install_guide_page_4_title">Дочекайтеся завершення встановлення</string>
-	<string name="install_guide_page_4_text">"&#8226; Під час встановлення оновлення буде показуватися його перебіг. Будь ласка, дочекайтеся завершення цього процесу. Встановлення може зайняти до 15 хвилин. Під час цього бажано якомога менше користуватися пристроєм і не закривати Оновлення системи.
-
-&#8226; Після того, як перебіг дійде до кінця, з'явиться кнопка \"Перезавантаження\". Натисніть її, щоб перезавантажити пристрій і завершити оновлення."</string>
-
-	<string name="install_guide_page_5_title">Готово. Насолоджуйтеся новою версією OxygenOS!</string>
-	<string name="install_guide_page_5_text">&#8226; Після того, як пристрій завершить оптимізацію застосунків, оновлення успішно завершиться.\nЩоб це перевірити, ви можете переглянути поточну версію OxygenOS наступним чином:\n\n&#8226; Зайдіть в Налаштування, в самому низу виберіть \"Про телефон\", і погляньте на номер складання.\n\n&#8226; Якщо вам сподобався цей застосунок, поставте йому 5 зірочок в Google Play!</string>
-
-	<string name="install_guide_close_button">Закрити інструкцію</string>
+	<string name="install_guide_download_instructions">&#8226; Натисніть кнопку \"Завантажити\", щоб розпочати завантаження оновлення.\n&#8226; Внизу застосунку з\'явиться прогрес завантаження, який буде продубльовано в системному сповіщенні.\n&#8226; Коли завантаження завершиться, ви побачите сповіщення з текстом \"Завантаження завершено\". Якщо під час завантаження трапиться помилка, відкрийте застосунок і спробуйте завантажити оновлення ще раз. Якщо і це на спрацює, тоді перевірте з\'єднання з інтернетом. Інакше, зв\'яжіться з розробником застосунку: знайдіть застосунок Oxygen Updater в Google Play > \"Контактні дані розробника\".</string>
 
 	<!-- Device information strings -->
 	<string name="device_information_supported_oxygen_os">Ваш пристрій підтримується</string>
@@ -213,7 +176,7 @@
 	<string name="device_information_image_description">Зображення пристрою</string>
 	<string name="device_information_incremental_os_version">Номер складання</string>
 	<string name="device_information_os_version">Версія Android</string>
-	<string name="device_information_oxygen_os_version">Версія OxygenOS</string>
+	<string name="device_information_oxygen_os_version">Версія OS</string>
 	<string name="device_information_oxygen_os_ota_version">Версія ПЗ</string>
 	<string name="device_information_patch_level_version">Дата патчу безпеки</string>
 	<string name="device_information_serial_number">Серійний номер</string>
@@ -232,6 +195,8 @@
 	<string name="about_email_button_text">Електронна пошта</string>
 
 	<!-- LocalNotifications strings -->
+	<string name="notification_permission_title">"Отримувати сповіщення"</string>
+	<string name="notification_permission_text">"Будь ласка, дозвольте додатку повідомляти вас про оновлення OTA, новини, поточний статус завантаження та інші важливі речі. Ви можете налаштувати свої уподобання пізніше в налаштуваннях програми."</string>
 	<string name="notification_new_device_text">Додано підтримку нового пристою — %1$s! Відкрити застосунок.</string>
 	<string name="notification_no_notification_support">Встановіть або оновіть Сервіси Google Play, щоб увімкнути пуш-сповіщення.</string>
 	<string name="notification_version">%1$s доступне для %2$s!</string>
@@ -257,25 +222,11 @@
 	<string name="general_notification_channel_description">Загальні сповіщення, які не підпадають ні під одну категорію</string>
 	<string name="url_submitted_notification_channel_description">Отримайте сповіщення, коли ви успішно надішлете URL-адреси OTA нашій команді.\nВи можете відмовитися від автоматичного надсилання URL-адрес у налаштуваннях програми.</string>
 
-	<!-- Help strings -->
-	<string name="help">Допомога</string>
-	<string name="help_updating_your_device_title">Оновлення вашого пристрою</string>
-	<string name="help_updating_your_device_text">Коли відкриєте застосунок, ви побачите, чи є доступне оновлення. Якщо оновлення доступне, ви зможете його встановити.\n\nЩоб завантажити оновлення, натисніть кнопку \"Завантажити\" (нижче опису оновлення). Після завершення завантаження, з\'явиться вікно встановлення. Якщо ви закрили застосунок, або вікно не з\'явилося, тоді натисніть кнопку \"Встановити\", яка буде розміщена біля кнопки \"Завантажити\".\n\nСпочатку застосунок перевірить, чи ваш пристрій має рут права. Якщо у вас рутований пристрій, надайте рут права застосункові і виберіть як ви хочете встановити оновлення. Інакше, дотримуйтесь інструкції для Ручного встановлення.\n\nАвтоматичне встановлення:\nВам лише потрібно вибрати параметри встановлення. Рекомендуються усталені параметри, однак ви також можете додати рут архів, щоб (пере)встановити рут права. Виберіть рут архів (zip файл), використовуючи зелену кнопку з текою і натисніть \"Почати встановлення\", щоб розпочати встановлення.\n\nРучне встановлення:\nВи побачите інструкцію по встановленню. Випишіть собі кроки встановлення з інструкції, перед тим як почнете встановлення.</string>
-	<string name="help_reading_news_title">Читання останніх новин</string>
-	<string name="help_reading_news_text">Новини відображаються ліворуч від екрану Оновлення. Найновіші елементи розміщуються зверху списку. Щоб його прочитати, просто натисніть на цей елемент.\nНатисніть стрілку назад, або кнопку Назад, щоб повернутися до екрану з новинами.</string>
-	<string name="help_device_information_title">Перегляд інформації про пристрій</string>
-	<string name="help_device_information_text">Ви можете переглянути специфікацію про ваш пристрій, використовуючи екран праворуч від екрану Оновлень. Це стане в нагоді, якщо ви захочете подати запит до підтримки, під час якого у вас можуть запитати про технічні характеристики вашого пристрою.</string>
-	<string name="help_change_settings_title">Змінення налаштувань</string>
-	<string name="help_change_settings_text">Ви можете змінювати налаштування натиснувши три крапки в правому верхньому куті і вибравши Налаштування.\nВи можете змінювати такі налаштування:\n\n• Пристрій і спосіб оновлення\n• Пуш-сповіщення\n• Сповіщення в застосунку\n• Налаштування приватності (ділитися журналом).\n\nВикористовуйте повзунки, щоб увімкнути чи вимкнути сповіщення / надсилання журналу. Список вибору пристрою / способу оновлення знаходиться вище повзунків. Список на з\'являється? Перевірте з\'єднання з Інтернетом і знову відкрийте вікно Налаштувань.</string>
-
 	<!-- News strings -->
 	<string name="news">Новини</string>
-	<string name="news_date_published">Останнє оновлення: %1$s</string>
-	<string name="news_empty">Ця стаття немає вмісту.</string>
-	<string name="news_load_network_error">Не вдалося відкрити статтю. Перевірте з\'єднання і натисніть кнопку \'ПОВТОРИТИ\', щоб відкрити статтю знову.</string>
-	<string name="news_load_id_error"><![CDATA[Не вдалося відкрити новину з недійсного URL: %1$s. Перевірте URL, або повідомте нам про це через <a href="mailto:support@oxygenupdater.com">електронну пошту</a> або напишіть в <a href="https://discord.gg/5TXdhKJ">чат на Discord</a>.]]></string>
-	<string name="news_unread_count_1">Є %1$d непрочитаних новин.\nНатисніть, щоб показати непрочитані новини</string>
-	<string name="news_unread_count_2">Є %1$d непрочитаних новин.\nНатисніть, щоб показати всі новини</string>
+	<string name="news_load_network_error">Не вдалося відкрити статтю. Перевірте з\'єднання і натисніть кнопку \'Повторити\', щоб відкрити статтю знову.</string>
+	<string name="news_unread_count_1">Є %1$d непрочитаних новин. Натисніть, щоб показати непрочитані новини</string>
+	<string name="news_unread_count_2">Є %1$d непрочитаних новин. Натисніть, щоб показати всі новини</string>
 	<string name="news_mark_read">Відзначити як прочитане</string>
 	<string name="news_mark_unread">Позначити як непрочитане</string>
 	<string name="news_mark_all_read">Позначити всі новини як прочитані</string>
@@ -299,12 +250,10 @@
 	<string name="error_app_outdated">От халепа!</string>
 	<string name="error_app_outdated_message">Цей застосунок застарів. Час його оновити! Натисніть на \"Google Play\" нижче. В Google Play, виберіть \"Оновлення\".</string>
 	<string name="error_app_requires_network_connection">Немає з\'єднання</string>
-	<string name="error_app_requires_network_connection_message">Не вдалося з\'єднатися з сервером. Будь ласка, переконайтеся, що у вас є доступ до мережі. Застосунок зараз закриється.</string>
 	<string name="error_google_play_button_text">Google Play</string>
-	<string name="error_no_internet_connection">Немає з\'єднання.</string>
 	<string name="error_maintenance">Сервер на обслуговуванні</string>
 	<string name="error_maintenance_message">Будь ласка, зачекайте. Сервер незабаром стане доступним.</string>
-	<string name="error_maintenance_retry">Сервер може бути закритий на обслуговування. Спробуйте знову через декілька хвилин, або повідомте нам про це через <a href="mailto:support@oxygenupdater.com">електронну пошту</a> або напишіть в <a href="https://discord.gg/5TXdhKJ">чат на Discord</a>.</string>
+	<string name="error_maintenance_retry"><![CDATA[Сервер може бути закритий на обслуговування. Спробуйте знову через декілька хвилин, або повідомте нам про це через <a href="mailto:support@oxygenupdater.com">електронну пошту</a> або напишіть в <a href="https://discord.gg/5TXdhKJ">чат на Discord</a>.]]></string>
 	<string name="error_reload">Перезавантажити</string>
 
 	<string name="error_unable_to_rate_app">Ви не можете оцінити застосунок, тому що Play Маркет відсутній на вашому пристрої.</string>
@@ -329,7 +278,6 @@
 	<string name="purchase_error_after_payment">Не вдалося купити видалення реклами, тому що виникла внутрішня помилка. Будь ласка, спробуйте знову через декілька хвилин. Якщо ви вже купляли, будь ласка, зверніться до підтримки Google Play за допомогою.</string>
 
 	<!-- Other strings-->
-	<string name="error">Помилка</string>
 	<string name="icon">Значок</string>
 	<string name="loading">Завантажується…</string>
 	<string name="processing">Опрацювання…</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,23 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools" tools:keep="@string/install_guide_page_*_*">
-	<string name="device_chooser_error_title">无法检索支持的设备列表</string>
-
+<resources>
 	<!-- Update information strings-->
 	<string name="enable">启用</string>
 	<string name="update_information_description_not_available">没有关于此更新的新功能亮点的官方信息。一般情况下，此类更新会为您的设备提供错误修复，性能改进或关键安全更新。</string>
 	<string name="update_information_file_name">文件名称： %1$s</string>
 	<string name="update_information_md5">MD5: %1$s</string>
-	<string name="update_information_download_link">由于下载出错，可能需要您重新下载。您也可以通过下面的链接在浏览器中自行下载，但必须将下载的文件从 \"Downloads\" 目录移动到它的上级目录。这个是 OnePlus 官方的 OTA 链接，本应用也是调用这个链接的数据 \n%1$s</string>
+	<string name="update_information_download_link">由于下载出错，可能需要您重新下载。您也可以通过下面的链接在浏览器中自行下载，但必须将下载的文件从 \"Downloads\" 目录移动到它的上级目录。这个是 OnePlus 官方的 OTA 链接，本应用也是调用这个链接的数据\n%1$s</string>
 	<string name="update_information_header">更新</string>
 	<string name="update_information_error_title">无法检索最新的更新数据信息</string>
 	<string name="update_information_banner_server">轻触此处以查看重要消息</string>
 	<string name="update_information_banner_advanced_mode_tip">您已选择“%1$s”更新通道。如果您想切换到该更新通道，请开启高级模式。</string>
 	<string name="update_information_header_advanced_mode_hint">启用高级模式</string>
-	<string name="update_information_header_advanced_mode_helper">由于您开启了高级模式，您可以手动下载 \"%1$s\" 的 zip 包。\n\n 您可以在设置中关闭高级模式。</string>
-	<string name="update_information_different_version_changelog_notice">您正在查看 \"%1$s\" 更新通道中最新版本的更新亮点。如果您要安装此更新，请在设置中打开高级模式 \n\n但如果您希望查看当前安装版本的更新亮点，则需要切换回正确的更新方法。</string>
-	<string name="update_information_last_checked_on">上一次检查更新在： %1$s</string>
+	<string name="update_information_header_advanced_mode_helper">由于您开启了高级模式，您可以手动下载 \"%1$s\" 的 zip 包。 您可以在设置中关闭高级模式。</string>
+	<string name="update_information_different_version_changelog_notice_base">注意：此更改日志适用于“%2$s”更新方法中的最新可用版本 (%1$s)</string>
+	<string name="update_information_different_version_changelog_notice_advanced">。 如果您打算安装此更新，则必须在设置中启用“高级模式”。</string>
 	<string name="update_information_no_update_data_available">没有可用的更新亮点</string>
-	<string name="update_information_oxygen_os_version">OxygenOS %1$s</string>
 	<string name="update_information_system_is_up_to_date">您的系统已是最新版本</string>
 	<string name="update_information_unknown_update_name">适用于 %1$s 的未知更新</string>
 	<string name="update_information_view_update_information">查看更新亮点</string>
@@ -89,9 +86,7 @@
 	<string name="summary_off">已禁用</string>
 	<string name="summary_please_wait">请稍等…</string>
 	<string name="summary_update_method">请先选择一个设备</string>
-	<string name="summary_important_notifications_disabled">一些重要的通知被禁用：\"%1$s\"</string>
-	<string name="summary_theme">设定主题</string>
-	<string name="summary_language">设定语言</string>
+	<string name="summary_important_notifications_disabled">一些重要的通知被禁用:</string>
 	<string name="summary_privacy_policy">在线查看</string>
 	<string name="summary_rate_app">留个 5 星好评</string>
 
@@ -121,76 +116,45 @@
 
 	<string name="settings_device">设备</string>
 	<string name="settings_entered_incorrectly">保存设置时出错。请返回并重新选择您的设备 / 更新方法。</string>
-	<string name="settings_explanation_incremental_full_update">增量更新可以在任何版本中安装（但是如果您解锁了 Bootloader，那么您将只能选择安装完整包）。\n\nOxygenOS 的公开测试版也可以在任何版本（包括正式版）中安装。如果您想从正式版升级到测试版，那么请在设置中打开高级模式。测试版和正式版一样，都会要求您在解锁了 Bootloader 的情况下下载全量包。</string>
 
 	<string name="settings_push_from_server">重要消息</string>
 
 	<string name="settings_saving">您的设置仍在保存中。如果时间过长，请检查您的网络连接，或尝试重新启动更新器。</string>
 
 	<string name="settings_advanced_mode">高级模式</string>
-	<string name="settings_advanced_mode_explanation">开启高级模式后，将隐藏“您的设备已是最新版本”的消息，使得您可以下载与安装任何设备的新版本系统，哪怕下载的文件与您的设备并不兼容。\n\n在如下情况下，该功能会很有用：\n&#8226; 您想从正式版更新为测试版系统\n&#8226; 从测试版恢复成正式版（需要您进行双清！）\n&#8226; 重新安装当前版本的系统</string>
+	<string name="settings_advanced_mode_explanation">"通常，应用程序会根据当前操作系统版本显示更新。使用高级模式后，无论设备/版本是否兼容，都会显示最新的可用更新。
+
+如果你想"</string>
+	<string name="settings_advanced_mode_uses">"&#8226; 重新下载最新版本，即使您已经在使用该版本
+&#8226; 切换到不同的更新轨道"</string>
+	<string name="settings_advanced_mode_caption">"只有在上述情况下才需要高级模式。除非你知道自己在做什么，否则不应该启用它。"</string>
 	<string name="settings_update_method">更新方式</string>
 	<string name="settings_upload_logs">分享使用数据与日志</string>
+	<string name="settings_ad_privacy">GDPR 广告同意书</string>
+	<string name="settings_ad_privacy_subtitle">"针对欧洲经济区/英国用户"</string>
 
 	<!-- FAQ strings -->
 	<string name="faq">常见问题</string>
 	<string name="faq_menu_item">常见问题</string>
 
 	<!-- First-time setup strings -->
-	<string name="onboarding">欢迎</string>
+	<string name="onboarding">设置</string>
 	<string name="onboarding_finished_button">开始吧！</string>
 
-	<string name="onboarding_page_1_title">欢迎使用 Oxygen 更新器！</string>
-	<string name="onboarding_page_1_text">这款 App 可以帮助您：\n\n&#8226; 更快地接收 OxygenOS 的最新更新\n&#8226; 更轻松地升级 Root 过的设备\n&#8226; 查看当前系统版本的更新亮点\n&#8226; 了解关于 OnePlus 与 OxygenOS 的最新消息\n\n向左轻扫以继续</string>
-	<string name="onboarding_page_1_caption">本应用并不是官方的 OnePlus 应用程序，使用此应用程序完全由您自己承担风险。OnePlus 和应用开发者都不对您的行为负责，包括使用此应用程序造成的任何损害。\n\n使用此应用程序即表示您同意上述条款。</string>
-	<string name="onboarding_page_2_title">选择您的设备：</string>
-	<string name="onboarding_page_2_caption">一般情况下，应用已经自动选择了您的设备。\n如果没有，请在上面选择。</string>
-	<string name="onboarding_page_3_title">选择您的更新方式：</string>
-	<string name="onboarding_page_3_caption">一般情况下，我们更加推荐增量更新，因为下载的更新包更加小巧。\n只是它与 Root 设备不兼容。 如果您的设备已经 Root，请选择全量更新。\n而如果您运行的是 OxygenOS 的测试版, 请选择开放测试版系统</string>
-	<string name="onboarding_page_4_title">一切就绪！</string>
-	<string name="onboarding_page_4_text">敬请使用吧！\n\n您可以随时在设置中更改您的设定。</string>
+	<string name="onboarding_app_uses">这款 App 可以帮助您：\n\n&#8226; 更快地接收 OxygenOS 的最新更新\n&#8226; 更轻松地升级 Root 过的设备\n&#8226; 查看当前系统版本的更新亮点\n&#8226; 了解关于 OnePlus 与 OxygenOS 的最新消息</string>
+	<string name="onboarding_disclaimer">本应用并不是官方的 OnePlus 应用程序，使用此应用程序完全由您自己承担风险。OnePlus 和应用开发者都不对您的行为负责，包括使用此应用程序造成的任何损害。 使用此应用程序即表示您同意上述条款。</string>
+	<string name="onboarding_device_chooser_title">选择您的设备：</string>
+	<string name="onboarding_device_chooser_caption">一般情况下，应用已经自动选择了您的设备。\n如果没有，请在上面选择。</string>
+	<string name="onboarding_method_chooser_title">选择您的更新方式：</string>
+	<string name="onboarding_method_chooser_caption">一般情况下，我们更加推荐增量更新，因为下载的更新包更加小巧。 只是它与 Root 设备不兼容。 如果您的设备已经 Root，请选择全量更新。 而如果您运行的是 OxygenOS 的测试版, 请选择开放测试版系统</string>
+	<string name="onboarding_caption">敬请使用吧！\n\n您可以随时在设置中更改您的设定。</string>
 
 	<!-- Automatic install strings -->
 	<string name="install">安装</string>
 
 	<!-- Install guide strings -->
-	<string name="install_guide_no_root">请根据安装指南中显示的说明安装更新。</string>
 	<string name="install_guide">安装指南</string>
-	<string name="install_guide_subtitle">安装指南 - 第 %1$d 页，共 %2$d 页</string>
-	<string name="install_guide_tip">&#8226; 推荐您把全部步骤都用纸笔写下来，因为在安装过程中，您的设备会关机。</string>
-
-	<string name="install_guide_page_1_title">下载更新包</string>
-	<string name="install_guide_page_1_text">&#8226; 轻触“下载”按钮以开始下载。\n\n&#8226; 下载进度会在 App 中显示，同时，它也会在通知中心里实时显示。\n\n&#8226; 当下载结束时，您将会看到“下载完成”的通知。\n如果下载中出现错误，请尝试前往 App 中重试一遍。如果仍出现错误，请您检查您的互联网连接。或者您也可以尝试通过 Google Play 中该应用留下的联系方式联系该应用的开发者。</string>
-
-	<string name="install_guide_page_2_title">准备安装</string>
-	<string name="install_guide_page_2_text">注意：更新的安装是通过设备的普通系统更新的特殊页面进行的。 万一在打开此部分时出现系统自带的系统更新页面，您也可以选择先安装该更新。 之后再打开 Oxygen Updater 来查看您是否完全是最新的。
-
-操作：
-&#8226; 长按 Home 键关闭 Oxygen 更新器
-
-&#8226; 打开设置应用
-
-&#8226; 下滑，并点击“系统更新”</string>
-	<string name="install_guide_page_3_title">安装更新</string>
-	<string name="install_guide_page_3_text">"现在，您已位于系统更新应用，是时候安装更新了
-
-&#8226; 点击右上角的三点图标
-
-&#8226; 选择“本地更新”，随后应该会要求您选择一个文件
-
-&#8226; 在这个界面选择您在 Oxygen 更新器中下载的更新包。一般开头都是 \"%1$sOxygen\"。
-
-&#8226; 点击 \"立即更新\"，随后更新将自动进行</string>
-
-	<string name="install_guide_page_4_title">请等待更新完成</string>
-	<string name="install_guide_page_4_text">"&#8226; 手机现在将安装更新并显示进度栏。 请等待安装完成。 安装过程可能需要几分钟到 15 分钟。
-
-&#8226; 重启后，您的设备即可完成更新了</string>
-
-	<string name="install_guide_page_5_title">大功告成！在全新的 OxygenOS 中尽情探索吧！</string>
-	<string name="install_guide_page_5_text">&#8226; 等您的设备优化完应用程序，那么这次更新就算是大功告成了！\n为了验证是否完成，您可以参见以下步骤来查看当前系统版本：\n\n&#8226; 打开设置，轻触“关于手机”，这里您就可以看到您的 OxygenOS 版本。\n\n&#8226; 如果您喜欢这个 App，别忘了去 Google Play 给个 5 星好评哦~</string>
-
-	<string name="install_guide_close_button">关闭安装指南</string>
+	<string name="install_guide_download_instructions">&#8226; 轻触“下载”按钮以开始下载。\n&#8226; 下载进度会在 App 中显示，同时，它也会在通知中心里实时显示。\n&#8226; 当下载结束时，您将会看到“下载完成”的通知。\n如果下载中出现错误，请尝试前往 App 中重试一遍。如果仍出现错误，请您检查您的互联网连接。或者您也可以尝试通过 Google Play 中该应用留下的联系方式联系该应用的开发者。</string>
 
 	<!-- Device information strings -->
 	<string name="device_information_supported_oxygen_os">您的设备受支持</string>
@@ -208,7 +172,7 @@
 	<string name="device_information_image_description">设备图片</string>
 	<string name="device_information_incremental_os_version">增量更新版本：</string>
 	<string name="device_information_os_version">Android 版本：</string>
-	<string name="device_information_oxygen_os_version">OxygenOS 版本：</string>
+	<string name="device_information_oxygen_os_version">OS 版本：</string>
 	<string name="device_information_oxygen_os_ota_version">OTA 版本</string>
 	<string name="device_information_patch_level_version">安全更新：</string>
 	<string name="device_information_serial_number">序列号：</string>
@@ -227,6 +191,8 @@
 	<string name="about_email_button_text">邮箱</string>
 
 	<!-- LocalNotifications strings -->
+	<string name="notification_permission_title">"保持通知"</string>
+	<string name="notification_permission_text">"请允许应用程序通知您 OTA 更新、新闻、正在进行的下载状态以及其他重要信息。您可以稍后在应用程序的设置中对偏好进行微调。"</string>
 	<string name="notification_new_device_text">现已支持 %1$s。打开 App 来选择您的设备。</string>
 	<string name="notification_no_notification_support">安装或升级您的 Google Play 服务来开启推送服务</string>
 	<string name="notification_version">恭喜 %2$s! 喜提 %1$s！</string>
@@ -252,24 +218,9 @@
 	<string name="general_notification_channel_description">不属于其他类别的常规通知</string>
 	<string name="url_submitted_notification_channel_description">当你成功提交OTA网址给我们的团队时得到通知。\n你可以在应用程序的设置中选择退出自动提交URL。</string>
 
-	<!-- Help strings -->
-	<string name="help">帮助</string>
-	<string name="help_updating_your_device_title">更新您的设备</string>
-	<string name="help_updating_your_device_text">您打开应用时，即可看到是否有可用的软件更新，如果有的话，您就可以方便地安装了。\n\n要开始安装，请点击“下载”按钮（就在更新信息下方）以开始下载。 下载完成后，将会出现安装界面。 如果您退出了应用或安装界面没有弹出，请手动点击“安装”按钮，该按钮一般显示在“下载”按钮旁边。\n\n安装界面会先检查您是否有 Root 权限。 如果您的设备有 Root 权限，请在询问时授予 Root 权限，并选择安装更新的方式。 否则，请按照手动安装的说明进行操作。\n\n自动安装：\n您只需选择安装选项即可。 建议使用默认设置，但您必须指定需要安装的 Root 包。 使用蓝色文件夹按钮选择 Root 包（支持 Zip 文件），然后点击“开始安装”来开始安装。\n\n手动安装：\n您将在屏幕上看到安装指南。 写下说明并按照说明执行它们以安装更新。</string>
-	<string name="help_reading_news_title">阅览最新消息</string>
-	<string name="help_reading_news_text">新闻显示在“更新”界面的左侧。 最新的消息显示在最顶部，只需点击一条新闻即可阅读。</string>
-	<string name="help_device_information_title">查看您设备的基本信息</string>
-	<string name="help_device_information_text">您可以使用“更新”栏右侧的界面来查看设备的属性。这在提出帮助请求时非常有用且方便，因为在寻求帮助时，可能会要求您提供设备的某些规格。</string>
-	<string name="help_change_settings_title">更改设置</string>
-	<string name="help_change_settings_text">您可以轻点右上角的三个点后，点击设置来更改设置选项。\n\n您可以更改以下设置：\n\n• 您的设备的更新方式\n• 何时为您推送通知\n• 何时在 App 中显示提示\n• 隐私设置与日志上传\n\n使用里面的开关来更改隐私与消息设置，选择您的设备与更新方式。选择窗中没有东西？ 请检查您的互联网连接，再次进入设置。</string>
-
 	<!-- News strings -->
 	<string name="news">新闻</string>
-	<string name="news_date_published">上次更新：%1$s</string>
-	<string name="news_empty">此文章还没有评论</string>
 	<string name="news_load_network_error">无法打开文章。请检查您的互联网连接并点击“重试”按钮重新打开。</string>
-
-	<string name="news_load_id_error"><![CDATA[无法从该链接打开文章： %1$s，请检查链接。 您也可以通过我们的 <a href="mailto:support@oxygenupdater.com">邮件</a> 或者我们的 <a href="https://discord.gg/5TXdhKJ">Discord 服务器</a> 发送反馈]]></string>
 
 	<string name="news_unread_count_1">您有 %1$d 篇未读文章，轻触即可浏览</string>
 	<string name="news_unread_count_2">您有 %1$d 篇未读文章，轻触即可全部显示</string>
@@ -279,7 +230,7 @@
 	<string name="news_empty_state_none_available_header">暂时没有文章</string>
 	<string name="news_empty_state_all_read_header">全部读完了</string>
 	<string name="news_empty_state_none_available_text">暂时没有可读的文章，请稍候再试</string>
-	<string name="news_empty_state_all_read_text">所有文章都已阅读完毕，干得漂亮！\n希望您喜欢我们的文章，并能够从中了解到新的信息。\n\n 再次点击横幅即可显示所有新闻文章。</string>
+	<string name="news_empty_state_all_read_text">所有文章都已阅读完毕，干得漂亮！\n希望您喜欢我们的文章，并能够从中了解到新的信息。\n\n再次点击横幅即可显示所有新闻文章。</string>
 
 	<!-- Contribute strings -->
 	<string name="contribute">参与共研</string>
@@ -296,12 +247,10 @@
 	<string name="error_app_outdated">糟糕！</string>
 	<string name="error_app_outdated_message">更新器不是最新版本，请前往 Google Play 商店进行更新。</string>
 	<string name="error_app_requires_network_connection">无互联网连接</string>
-	<string name="error_app_requires_network_connection_message">无法连接服务器，请您确保您已经连接到了互联网。应用即将关闭。</string>
 	<string name="error_google_play_button_text">Google Play</string>
-	<string name="error_no_internet_connection">无互联网连接</string>
 	<string name="error_maintenance">服务器维护中…</string>
 	<string name="error_maintenance_message">服务器马上就好，请待会儿再来吧~</string>
-	<string name="error_maintenance_retry">服务器也许正在维护中，请稍候尝试。您也可以通过我们的 <a href="mailto:support@oxygenupdater.com">邮件</a> 或者我们的 <a href="https://discord.gg/5TXdhKJ">Discord 服务器</a> 发送反馈</string>
+	<string name="error_maintenance_retry"><![CDATA[服务器也许正在维护中，请稍候尝试。您也可以通过我们的 <a href="mailto:support@oxygenupdater.com">邮件</a> 或者我们的 <a href="https://discord.gg/5TXdhKJ">Discord 服务器</a> 发送反馈]]></string>
 	<string name="error_reload">重新加载</string>
 
 	<string name="error_unable_to_rate_app">非常感谢您的好意，但是非常抱歉，您的设备缺少 Google Play 组件，无法为本应用做出评价。</string>
@@ -326,7 +275,6 @@
 	<string name="purchase_error_after_payment">由于内部错误，购买移除广告服务失败，请稍候重试。 如果您已付款，请与 Google Play 支持小组联系以获取帮助。</string>
 
 	<!-- Other strings-->
-	<string name="error">错误</string>
 	<string name="icon">图标</string>
 	<string name="loading">加载中…</string>
 	<string name="processing">正在处理…</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1,23 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools" tools:keep="@string/install_guide_page_*_*">
-	<string name="device_chooser_error_title">無法搜尋支援的裝置列表</string>
-
+<resources>
 	<!-- Update information strings-->
 	<string name="enable">啟用</string>
 	<string name="update_information_description_not_available">沒有關於此更新的新功能資訊的官方訊息。一般情況下，此類更新會為您的裝置提供錯誤修復，效能改進或關鍵安全性更新。</string>
 	<string name="update_information_file_name">檔案名稱： %1$s</string>
 	<string name="update_information_md5">MD5: %1$s</string>
-	<string name="update_information_download_link">由於下載發生錯誤，可能需要您重新下載。您也可以透過下面的連結在瀏覽器中自行下載，但必須將下載的檔案從 \"Downloads\" 目錄移動到它的上層目錄。這個是 OnePlus 官方的 OTA 連結，本應用程式也是使用這個連結的資源 \n%1$s</string>
+	<string name="update_information_download_link">由於下載發生錯誤，可能需要您重新下載。您也可以透過下面的連結在瀏覽器中自行下載，但必須將下載的檔案從 \"Downloads\" 目錄移動到它的上層目錄。這個是 OnePlus 官方的 OTA 連結，本應用程式也是使用這個連結的資源\n%1$s</string>
 	<string name="update_information_header">更新</string>
 	<string name="update_information_error_title">無法搜尋最新的更新訊息</string>
 	<string name="update_information_banner_server">點選此處以檢視重要訊息</string>
 	<string name="update_information_banner_advanced_mode_tip">您已選擇了“%1$s”更新頻道。如果您想切換到該更新頻道，請開啟進階模式。</string>
 	<string name="update_information_header_advanced_mode_hint">啟用進階模式</string>
-	<string name="update_information_header_advanced_mode_helper">由於您開啟了進階模式，您可以手動下載 \"%1$s\" 的 ZIP 包\n\n 您可以在設定中關閉進階模式。</string>
-	<string name="update_information_different_version_changelog_notice">您正在檢視 \"%1$s\" 更新通道中最新版本的更新訊息。如果您要安裝此更新，請在設定中打開進階模式 \n\n但如果您希望檢視目前安裝版本的更新訊息，則需要切換回正確的更新方法。</string>
-	<string name="update_information_last_checked_on">上一次檢查更新在： %1$s</string>
+	<string name="update_information_header_advanced_mode_helper">由於您開啟了進階模式，您可以手動下載 \"%1$s\" 的 ZIP 包。 您可以在設定中關閉進階模式。</string>
+	<string name="update_information_different_version_changelog_notice_base">注意：此更改日誌適用於“%2$s”更新方法中的最新可用版本 (%1$s)</string>
+	<string name="update_information_different_version_changelog_notice_advanced">。 如果您打算安裝此更新，則必須在設置中啟用“進階模式”。</string>
 	<string name="update_information_no_update_data_available">沒有可用的更新訊息</string>
-	<string name="update_information_oxygen_os_version">OxygenOS %1$s</string>
 	<string name="update_information_system_is_up_to_date">您的系統已是最新版本</string>
 	<string name="update_information_unknown_update_name">適用於 %1$s 的未知更新</string>
 	<string name="update_information_view_update_information">檢視更新訊息</string>
@@ -89,9 +86,7 @@
 	<string name="summary_off">已停用</string>
 	<string name="summary_please_wait">請稍等…</string>
 	<string name="summary_update_method">請先選擇一個裝置</string>
-	<string name="summary_important_notifications_disabled">一些重要的通知被停用。\"%1$s\"</string>
-	<string name="summary_theme">設定佈景主題</string>
-	<string name="summary_language">設定語言</string>
+	<string name="summary_important_notifications_disabled">一些重要的通知被停用。:</string>
 	<string name="summary_privacy_policy">線上檢視</string>
 	<string name="summary_rate_app">留下 5 星評分</string>
 
@@ -121,76 +116,45 @@
 
 	<string name="settings_device">裝置</string>
 	<string name="settings_entered_incorrectly">儲存設定時發生錯誤。請返回並重新選擇您的裝置 / 更新方法。</string>
-	<string name="settings_explanation_incremental_full_update">增量更新可以在任何版本中安裝（但是如果您解鎖了 Bootloader，那麼您將只能選擇安裝完整包）。\n\nOxygenOS 的公開測試版也可以在任何版本（包括正式版）中安裝。如果您想從正式版升級到測試版，那麼請在設定中打開進階模式。測試版和正式版一樣，都會要求您在解鎖了 Bootloader 的情況下下載全量包。</string>
 
 	<string name="settings_push_from_server">重要通知</string>
 
 	<string name="settings_saving">您的設定仍在儲存中。如果時間過長，請檢查您的網路連線，或嘗試重新啟動更新器。</string>
 
 	<string name="settings_advanced_mode">進階模式</string>
-	<string name="settings_advanced_mode_explanation">開啟進階模式後，將隱藏「您的裝置已是最新版本」的通知，使得您可以下載與安裝任何裝置的新版本系統，哪怕下載的檔案與您的裝置並不相容。\n\n在如下情況下，該功能會很有用：\n&#8226; 您想從正式版更新為測試版系統\n&#8226; 從測試版恢復成正式版（需要進行雙清！）\n&#8226; 重新安裝目前版本的系統</string>
+	<string name="settings_advanced_mode_explanation">"通常，該應用程序會根據您當前的操作系統版本向您顯示更新。 使用高級模式，無論設備/版本兼容性如何，都將始終顯示最新的可用更新。
+
+如果您想要執行以下操作，這會很有用："</string>
+	<string name="settings_advanced_mode_uses">"&#8226; 重新下載最新版本，即使您已經在使用它
+&#8226; 切換到不同的更新軌道"</string>
+	<string name="settings_advanced_mode_caption">"僅在上述情況下才可能需要高級模式。 除非您知道自己在做什麼，否則不應啟用它。"</string>
 	<string name="settings_update_method">更新方式</string>
 	<string name="settings_upload_logs">分享使用日誌</string>
+	<string name="settings_ad_privacy">GDPR 廣告同意書</string>
+	<string name="settings_ad_privacy_subtitle">"對於歐洲經濟區/英國用戶"</string>
 
 	<!-- FAQ strings -->
 	<string name="faq">常見問題</string>
 	<string name="faq_menu_item">常見問題</string>
 
 	<!-- First-time setup strings -->
-	<string name="onboarding">歡迎</string>
+	<string name="onboarding">設定</string>
 	<string name="onboarding_finished_button">開始吧！</string>
 
-	<string name="onboarding_page_1_title">歡迎使用 Oxygen 更新器！</string>
-	<string name="onboarding_page_1_text">這款 App 可以協助您：\n\n&#8226; 更快地接收 OxygenOS 的最新更新\n&#8226; 更輕鬆地升級 Root 過的裝置\n&#8226; 檢視目前系統版本的更新資訊\n&#8226; 了解關於 OnePlus 與 OxygenOS 的最新通知\n\n向左滑動以繼續</string>
-	<string name="onboarding_page_1_caption">本應用程式不是 OnePlus 官方推出的應用程式，使用此應用程式完全由您自己承擔風險。OnePlus 和本程式開發者都不對您的行為負責，包括使用此應用程式造成的任何損害。\n\n使用此應用程式即表示您同意上述條款。</string>
-	<string name="onboarding_page_2_title">選擇您的裝置：</string>
-	<string name="onboarding_page_2_caption">一般情況下，應用程式已經自動選擇了您的裝置。\n如果沒有，請在上面選擇。</string>
-	<string name="onboarding_page_3_title">選擇您的更新方式：</string>
-	<string name="onboarding_page_3_caption">一般情況下，我們更加推薦增量更新，因為下載的更新包更加小巧。\n只是它與 Root 裝置不相容。 如果您的裝置已經 Root，請選擇全量更新。\n而如果您使用的是 OxygenOS 的測試版, 請選擇開放測試版系統</string>
-	<string name="onboarding_page_4_title">一切就緒！</string>
-	<string name="onboarding_page_4_text">敬請使用吧！\n\n您可以隨時在設定中更改您的設定。</string>
+	<string name="onboarding_app_uses">這款 App 可以協助您：\n\n&#8226; 更快地接收 OxygenOS 的最新更新\n&#8226; 更輕鬆地升級 Root 過的裝置\n&#8226; 檢視目前系統版本的更新資訊\n&#8226; 了解關於 OnePlus 與 OxygenOS 的最新通知</string>
+	<string name="onboarding_disclaimer">本應用程式不是 OnePlus 官方推出的應用程式，使用此應用程式完全由您自己承擔風險。OnePlus 和本程式開發者都不對您的行為負責，包括使用此應用程式造成的任何損害。 使用此應用程式即表示您同意上述條款。</string>
+	<string name="onboarding_device_chooser_title">選擇您的裝置：</string>
+	<string name="onboarding_device_chooser_caption">一般情況下，應用程式已經自動選擇了您的裝置。\n如果沒有，請在上面選擇。</string>
+	<string name="onboarding_method_chooser_title">選擇您的更新方式：</string>
+	<string name="onboarding_method_chooser_caption">一般情況下，我們更加推薦增量更新，因為下載的更新包更加小巧。 只是它與 Root 裝置不相容。 如果您的裝置已經 Root，請選擇全量更新。 而如果您使用的是 OxygenOS 的測試版, 請選擇開放測試版系統</string>
+	<string name="onboarding_caption">敬請使用吧！\n\n您可以隨時在設定中更改您的設定。</string>
 
 	<!-- Automatic install strings -->
 	<string name="install">安裝</string>
 
 	<!-- Install guide strings -->
-	<string name="install_guide_no_root">請依照安裝教學中顯示的說明安裝更新。</string>
 	<string name="install_guide">安裝教學</string>
-	<string name="install_guide_subtitle">安裝教學 - 第 %1$d 頁，共 %2$d 頁</string>
-	<string name="install_guide_tip">&#8226; 建議您把全部步驟都用紙筆寫下來，因為在接下來的安裝過程中，您的裝置會關機。</string>
-
-	<string name="install_guide_page_1_title">下載更新包</string>
-	<string name="install_guide_page_1_text">&#8226; 點選「下載」按鈕以開始下載。\n\n&#8226; 下載進度會在 App 中顯示，同時，它也會在通知欄裡即時顯示。\n\n&#8226; 當下載結束時，您將會看到「下載完成」的通知。\n如果下載中出現錯誤，請嘗試前往 App 中重試一遍。如果仍出現錯誤，請您檢查您的網際網路連線。或者您也可以嘗試透過 Google Play 中該應用程式留下的聯絡方式聯絡該應用程式的開發者。</string>
-
-	<string name="install_guide_page_2_title">準備安裝</string>
-	<string name="install_guide_page_2_text">注意：更新的安裝過程是透過裝置普通系統更新的特殊畫面進行的。 萬一在打開此部分時出現系統內建的系統更新頁面，您也可以選擇先安裝該更新。 之後再打開 Oxygen Updater 來檢視您是否完全是最新的。
-
-操作指引：
-&#8226; 長按 Home 鍵關閉 Oxygen 更新器
-
-&#8226; 打開設定應用程式
-
-&#8226; 往下滑，並點選「系統更新」</string>
-	<string name="install_guide_page_3_title">安裝更新</string>
-	<string name="install_guide_page_3_text">"現在，您已位於系統更新應用程式，是時候安裝更新了
-
-&#8226; 點選右上角的三點圖示
-
-&#8226; 選擇「本地更新」，随後應該會要求您選擇一個檔案
-
-&#8226; 在這個界面選擇您在 Oxygen 更新器中下載的更新包。一般開頭都是 \"%1$sOxygen\"。
-
-&#8226; 點選「立即更新」，隨後更新將自動進行</string>
-
-	<string name="install_guide_page_4_title">請等待更新完成</string>
-	<string name="install_guide_page_4_text">"&#8226; 手機現在將安裝更新並顯示進度條。 請等待安裝完成。 安裝過程可能需要幾分鐘到 15 分鐘。
-
-&#8226; 重新開機後，您的裝置即可完成更新了</string>
-
-	<string name="install_guide_page_5_title">大功告成！在全新的 OxygenOS 中盡情探索吧！</string>
-	<string name="install_guide_page_5_text">&#8226; 等您的裝置完成最佳化應用程式，那麼這次更新就算是大功告成了！\n為了驗證是否完成，您可以參考以下步驟來檢視目前系統版本：\n\n&#8226; 打開設定，點選「關於手機」，這裡您就可以看到您的 OxygenOS 版本。\n\n&#8226; 如果您喜歡這個 App，别忘了去 Google Play 留下 5 星評分</string>
-
-	<string name="install_guide_close_button">關閉安裝教學</string>
+	<string name="install_guide_download_instructions">&#8226; 點選「下載」按鈕以開始下載。\n&#8226; 下載進度會在 App 中顯示，同時，它也會在通知欄裡即時顯示。\n&#8226; 當下載結束時，您將會看到「下載完成」的通知。\n如果下載中出現錯誤，請嘗試前往 App 中重試一遍。如果仍出現錯誤，請您檢查您的網際網路連線。或者您也可以嘗試透過 Google Play 中該應用程式留下的聯絡方式聯絡該應用程式的開發者。</string>
 
 	<!-- Device information strings -->
 	<string name="device_information_supported_oxygen_os">您的裝置受支援</string>
@@ -208,7 +172,7 @@
 	<string name="device_information_image_description">裝置圖片</string>
 	<string name="device_information_incremental_os_version">增量更新版本：</string>
 	<string name="device_information_os_version">Android 版本：</string>
-	<string name="device_information_oxygen_os_version">OxygenOS 版本：</string>
+	<string name="device_information_oxygen_os_version">OS 版本：</string>
 	<string name="device_information_oxygen_os_ota_version">OTA 版本</string>
 	<string name="device_information_patch_level_version">安全性修補更新：</string>
 	<string name="device_information_serial_number">序號：</string>
@@ -227,6 +191,8 @@
 	<string name="about_email_button_text">電子郵件</string>
 
 	<!-- LocalNotifications strings -->
+	<string name="notification_permission_title">"保持通知"</string>
+	<string name="notification_permission_text">"請允許應用程序通知您 OTA 更新、新聞、正在進行的下載狀態和其他重要信息。 您可以稍後在應用程序的設置中微調您的偏好。"</string>
 	<string name="notification_new_device_text">現已支援 %1$s。 打開應用程式來選擇您的裝置。</string>
 	<string name="notification_no_notification_support">安裝或升級您的 Google Play 服務來開啟推送服務</string>
 	<string name="notification_version">%1$s 現在可用於 %2$s！</string>
@@ -252,24 +218,9 @@
 	<string name="general_notification_channel_description">不屬於其他類別的一般通知</string>
 	<string name="url_submitted_notification_channel_description">當您成功向我們的團隊提交 OTA URL 時，您會收到通知。\n您可以在應用程序的設置中選擇退出自動提交 URL。</string>
 
-	<!-- Help strings -->
-	<string name="help">協助</string>
-	<string name="help_updating_your_device_title">更新您的裝置</string>
-	<string name="help_updating_your_device_text">您打開應用程式時，即可看到是否有可用的軟體更新，如果有的話，您就可以方便地安裝了。\n\n要開始安裝，請點選「下載」按鈕（就在更新訊息下方）以開始下載。 下載完成後，將會出現安裝界面。 如果您退出了應用程式或安裝界面沒有跳出，請手動點選「安裝」按鈕，該按鈕一般顯示在「下載」按鈕旁邊。\n\n安裝界面會先檢查您是否有 Root 權限。 如果您的裝置有 Root 權限，請在詢問時授予其 Root 權限，並選擇安裝更新的方式。 否則，請按照手動安裝的說明進行操作。\n\n自動安裝：\n您只需選擇安裝選項即可。 建議使用預設設定，但您必須指定需要安裝的 Root 包。 使用藍色資料夾按鈕選擇 Root 包（支援 ZIP 檔案），然後點選「開始安裝」來開始安裝。\n\n手動安裝：\n您將在螢幕上看到安裝教學。 寫下說明並按照說明執行它們以安裝更新。</string>
-	<string name="help_reading_news_title">閱讀最新通知</string>
-	<string name="help_reading_news_text">新聞顯示在「更新」界面的左侧。 最新的通知顯示在最頂部，只需點選一則新聞即可閱讀。</string>
-	<string name="help_device_information_title">檢視您裝置的基本訊息</string>
-	<string name="help_device_information_text">您可以使用「更新」欄右侧的界面來檢視裝置的資訊。這在提出協助請求時非常有用且方便，因為在尋求協助時，可能會要求您提供裝置的某些規格。</string>
-	<string name="help_change_settings_title">更改設定</string>
-	<string name="help_change_settings_text">您可以輕點右上角的三點圖示後，點選設定來變更設定選項。\n\n您可以調整以下設定：\n\n• 您的裝置的更新方式\n• 何時為您推送通知\n• 何時在 App 中顯示提示\n• 隱私設定與日誌上傳\n\n使用裡面的開關來更改隱私與通知設定，選擇您的裝置與更新方式。下拉列表沒有出現嗎？ 請檢查您的網際網路連線，並再次進入設定。</string>
-
 	<!-- News strings -->
 	<string name="news">新聞</string>
-	<string name="news_date_published">上次更新：%1$s</string>
-	<string name="news_empty">此文章還沒有留言</string>
 	<string name="news_load_network_error">無法打開文章。請檢查您的網際網路連線並點選「重試」按鈕重新打開。</string>
-
-	<string name="news_load_id_error"><![CDATA[無法從該連結打開文章： %1$s，請檢查連結。 您也可以透過我們的 <a href="mailto:support@oxygenupdater.com">Mail</a> 或者我們的 <a href="https://discord.gg/5TXdhKJ">Discord 伺服器</a> 傳送建議]]></string>
 
 	<string name="news_unread_count_1">您有 %1$d 篇未讀文章，點選即可瀏覽</string>
 	<string name="news_unread_count_2">您有 %1$d 篇未讀文章，點選即可全部顯示</string>
@@ -279,7 +230,7 @@
 	<string name="news_empty_state_none_available_header">暫時沒有文章</string>
 	<string name="news_empty_state_all_read_header">全部讀完了</string>
 	<string name="news_empty_state_none_available_text">暫時沒有可讀的文章，請稍候再試</string>
-	<string name="news_empty_state_all_read_text">所有文章都已閱讀完畢，做的真好！\n希望您喜歡我們的文章，並能夠從中了解到新的訊息。\n\n 再次點選横幅即可顯示所有新聞文章。</string>
+	<string name="news_empty_state_all_read_text">所有文章都已閱讀完畢，做的真好！\n希望您喜歡我們的文章，並能夠從中了解到新的訊息。\n\n再次點選横幅即可顯示所有新聞文章。</string>
 
 	<!-- Contribute strings -->
 	<string name="contribute">參與共研</string>
@@ -296,12 +247,10 @@
 	<string name="error_app_outdated">糟糕！</string>
 	<string name="error_app_outdated_message">更新器不是最新版本，請前往 Google Play 商店進行更新。</string>
 	<string name="error_app_requires_network_connection">無網際網路連線</string>
-	<string name="error_app_requires_network_connection_message">無法連線伺服器，請您確保您已經連線至網際網路。應用程式即將關閉。</string>
 	<string name="error_google_play_button_text">Google Play</string>
-	<string name="error_no_internet_connection">無網際網路連線</string>
 	<string name="error_maintenance">伺服器維護中…</string>
 	<string name="error_maintenance_message">伺服器馬上就好，請待會再來吧～</string>
-	<string name="error_maintenance_retry">伺服器也許正在維護中，請稍候嘗試。您也可以透過我們的 <a href="mailto:support@oxygenupdater.com">Mail</a> 或者我們的 <a href="https://discord.gg/5TXdhKJ">Discord 伺服器</a> 傳送建議</string>
+	<string name="error_maintenance_retry"><![CDATA[伺服器也許正在維護中，請稍候嘗試。您也可以透過我們的 <a href="mailto:support@oxygenupdater.com">Mail</a> 或者我們的 <a href="https://discord.gg/5TXdhKJ">Discord 伺服器</a> 傳送建議]]></string>
 	<string name="error_reload">重新載入</string>
 
 	<string name="error_unable_to_rate_app">非常感謝您的好意，但很抱歉，由於您的裝置缺少 Play 商店，因此無法為本應用程式做出評分。</string>
@@ -326,7 +275,6 @@
 	<string name="purchase_error_after_payment">由於內部錯誤，購買移除廣告服務失敗，請稍候重試。 如果您已付款，請與 Google Play 支援小組聯絡以取得協助。</string>
 
 	<!-- Other strings-->
-	<string name="error">錯誤</string>
 	<string name="icon">圖示</string>
 	<string name="loading">載入中…</string>
 	<string name="processing">正在處理…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="device_chooser_error_title">Couldn\'t retrieve list of supported devices</string>
-
 	<!-- Update information strings-->
 	<string name="enable">Enable</string>
 	<string name="update_information_description_not_available">There is no official information about the new features this update provides. Usually, such an update provides bug fixes, performance enhancements, and / or critical security updates for your device.</string>
@@ -11,13 +9,12 @@
 	<string name="update_information_header">Update</string>
 	<string name="update_information_error_title">Couldn\'t retrieve latest update data information</string>
 	<string name="update_information_banner_server">Tap here to view important notices</string>
-	<string name="update_information_banner_advanced_mode_tip">You\'ve selected the \"%1$s\" update track. Enable advanced mode if you plan to switch to this update track.</string>
+	<string name="update_information_banner_advanced_mode_tip">You\'ve selected the \"%1$s\" update method. Enable advanced mode if you plan to switch to this update method.</string>
 	<string name="update_information_header_advanced_mode_hint">Advanced mode is enabled</string>
-	<string name="update_information_header_advanced_mode_helper">Since you\'ve enabled advanced mode, you can download the latest ZIP for \"%1$s\".\n\nYou can turn advanced mode off from settings.</string>
-	<string name="update_information_different_version_changelog_notice">You\'re viewing a changelog for the latest update in the \"%1$s\" update track. If you intend to install this update, you must turn advanced mode on first (in settings).\n\nHowever, if you wish to see the changelog for the currently installed version instead, you\'ll need to switch back to the correct update method.</string>
-	<string name="update_information_last_checked_on">Last checked on: %1$s</string>
+	<string name="update_information_header_advanced_mode_helper">Since you\'ve enabled advanced mode, you can download the latest ZIP for \"%1$s\". You can turn advanced mode off from settings.</string>
+	<string name="update_information_different_version_changelog_notice_base">Note: this changelog is for the latest available version (%1$s) in the \"%2$s\" update method</string>
+	<string name="update_information_different_version_changelog_notice_advanced">. If you intend to install this update, you must enable \"Advanced mode\" in settings.</string>
 	<string name="update_information_no_update_data_available">No update information is available</string>
-	<string name="update_information_oxygen_os_version">OxygenOS %1$s</string>
 	<string name="update_information_system_is_up_to_date">Your system is up to date</string>
 	<string name="update_information_unknown_update_name">Unnamed update for %1$s</string>
 	<string name="update_information_view_update_information">View update information</string>
@@ -43,7 +40,7 @@
 	<string name="download_complete_notification">Tap to start the installation</string>
 
 	<string name="download_error">Download Error</string>
-	<string name="download_error_close">CLOSE</string>
+	<string name="download_error_close">Close</string>
 	<string name="download_error_corrupt">The downloaded update file is damaged! Please try downloading it again.</string>
 	<string name="download_error_server">A server error occurred while downloading the update. Please try downloading the update again.</string>
 	<string name="download_error_internal">Unfortunately, a technical error occurred while downloading the update. Try downloading it again. If this keeps occurring, please contact the developer of this app for assistance.</string>
@@ -52,8 +49,8 @@
 If you\'d like to know more, feel free to contact us either via <a href="mailto:support@oxygenupdater.com">email</a> or on our <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
 	<string name="download_error_could_not_move_temp_file">The file has been downloaded, but couldn\'t be moved to the correct directory. Open a file manager, navigate to \"%1$s\" and manually move the file to the topmost directory of internal storage.</string>
 
-	<string name="download_error_retry">RETRY</string>
-	<string name="download_error_resume">RESUME</string>
+	<string name="download_error_retry">Retry</string>
+	<string name="download_error_resume">Resume</string>
 	<string name="download_error_storage">There is insufficient storage space available on your device to download the update. Please remove some files and try downloading it again.</string>
 
 	<string name="download_failed">Download failed</string>
@@ -89,12 +86,9 @@ If you\'d like to know more, feel free to contact us either via <a href="mailto:
 	<string name="summary_off">Disabled</string>
 	<string name="summary_please_wait">Please wait…</string>
 	<string name="summary_update_method">Select a device first</string>
-	<string name="summary_important_notifications_disabled">Some important notifications are disabled: \"%1$s\"</string>
-	<string name="summary_theme">Set theme</string>
-	<string name="summary_language">Set language</string>
+	<string name="summary_important_notifications_disabled">Some important notifications are disabled:</string>
 	<string name="summary_privacy_policy">View online</string>
 	<string name="summary_rate_app">Leave a 5 star review</string>
-	<string name="summary_oxygen" translatable="false">v%1$s</string>
 
 	<string name="label_buy_ad_free">Remove ads</string>
 	<string name="label_theme">Theme</string>
@@ -107,25 +101,6 @@ If you\'d like to know more, feel free to contact us either via <a href="mailto:
 	<string name="theme_system">System</string>
 	<string name="theme_auto">Auto</string>
 
-	<string name="key_ad_free" translatable="false">34ejrtgalsJKDf;awljker;2k3jrpwosKjdfpio24uj3tp3oiwfjdscPOKj</string>
-	<string name="key_contributor" translatable="false">become_contributor</string>
-	<string name="key_category_device" translatable="false">key_category_device</string>
-	<string name="key_device" translatable="false">device</string>
-	<string name="key_device_id" translatable="false">device_id</string>
-	<string name="key_update_method" translatable="false">update_method</string>
-	<string name="key_update_method_id" translatable="false">update_method_id</string>
-	<string name="key_android_notifications" translatable="false">android_notifications</string>
-	<string name="key_theme" translatable="false">theme</string>
-	<string name="key_theme_id" translatable="false">theme_id</string>
-	<string name="key_language" translatable="false">language</string>
-	<string name="key_language_id" translatable="false">language_id</string>
-	<string name="key_advanced_mode" translatable="false">advanced_mode</string>
-	<!-- Value cannot be changed - is from older version where it was called 'upload_logs' -->
-	<string name="key_share_usage_data" translatable="false">upload_logs</string>
-	<string name="key_rate_app" translatable="false">rate</string>
-	<string name="key_privacy_policy" translatable="false">privacy_policy</string>
-	<string name="key_oxygen" translatable="false">oxygen_updater</string>
-
 	<string name="theme_light_subtitle">Theme with a white background and OnePlus Red primary color</string>
 	<string name="theme_dark_subtitle">Muted OnePlus Red primary color, with an almost-black background. Use this theme to save battery, especially on AMOLED screens.</string>
 	<string name="theme_system_subtitle">Use the system\'s night mode (you can set this either in Display settings or in developer options). Varies by device.</string>
@@ -134,87 +109,55 @@ If you\'d like to know more, feel free to contact us either via <a href="mailto:
 		conserve battery</string>
 
 	<string name="settings">Settings</string>
-	<string name="settings_buy_button_buy">Buy (%1$s)</string>
+	<string name="settings_buy_button_buy">Purchase (%1$s)</string>
 	<string name="settings_buy_button_bought">Purchased</string>
 	<string name="settings_buy_button_not_possible">Unavailable</string>
-	<string name="settings_buy_ad_free_label">Upgrade to Ad-Free</string>
+	<string name="settings_buy_ad_free_label">Upgrade to ad-free</string>
 
 	<string name="settings_contribute_label">Help improve the app</string>
 
 	<string name="settings_device">Device</string>
 	<string name="settings_entered_incorrectly">Error saving your settings. Please go back and select your device / update method again.</string>
-	<string name="settings_explanation_incremental_full_update">An incremental update can be installed from any version (except if you have an unlocked bootloader; then you should always pick the full update as update method).\n\nA beta update of OxygenOS can always be installed, as well when you\'re on a stable version. To switch from stable to beta, you have to enable the advanced mode in the settings. For the betas, the full and incremental update methods work the same way as on the stable versions.</string>
 
 	<string name="settings_push_from_server">Informational and warning messages</string>
 
 	<string name="settings_saving">Your settings are still being saved. If this takes too long: Check your network connection, exit the app and start it again.</string>
 
 	<string name="settings_advanced_mode">Advanced mode</string>
-	<string name="settings_advanced_mode_explanation">Advanced mode hides the message \"Your system is up to date\", allowing you to download and install all updates, even though they may not be compatible with your device.\n\nThis can be useful when:\n&#8226; Updating from a regular version to a beta version\n&#8226; Reverting from a beta version to the regular version (don\'t forget to factory reset your device)\n&#8226; Reinstalling your current system version.</string>
+	<string name="settings_advanced_mode_explanation">"Normally, the app shows you updates based on your current OS version. With advanced mode, the latest available update will always be shown regardless of device/version compatibility.
+
+This can be useful if you want to:"</string>
+	<string name="settings_advanced_mode_uses">"&#8226; Re-download the latest version even if you're already on it
+&#8226; Switch to a different update track"</string>
+	<string name="settings_advanced_mode_caption">"Advanced mode may be needed only in the above situations. You should not enable it unless you know what you're doing."</string>
 
 	<string name="settings_update_method">Update method</string>
 	<string name="settings_upload_logs">Share usage data and logs</string>
+	<string name="settings_ad_privacy">GDPR ad consent</string>
+	<string name="settings_ad_privacy_subtitle">"For EEA/UK users"</string>
 
 	<!-- FAQ strings -->
 	<string name="faq">FAQ</string>
 	<string name="faq_menu_item">FAQ</string>
 
 	<!-- First-time onboarding strings -->
-	<string name="onboarding">Welcome</string>
+	<string name="onboarding">Setup</string>
 	<string name="onboarding_finished_button">Start app</string>
 
-	<string name="onboarding_page_1_title">Welcome to Oxygen Updater!</string>
-	<string name="onboarding_page_1_text">This app will allow you to:\n\n&#8226; Get faster access to the latest Android updates for your OxygenOS powered device\n\n&#8226; Easily update a rooted device\n\n&#8226; View what\'s new in the system software you are currently using\n\n&#8226; Read the latest news about OnePlus and OxygenOS\n\nSwipe to the left to continue.</string>
-	<string name="onboarding_page_1_caption">This is not an official OnePlus application. Usage of this app is completely at your own risk. Neither OnePlus nor the developer of the app are liable for your actions, including any damage caused by using this app.\n\nBy using this app, you agree to the terms and conditions as stated above.</string>
-	<string name="onboarding_page_2_title">Choose your device</string>
-	<string name="onboarding_page_2_caption">Your device is usually already selected above. If not, select your device above.</string>
-	<string name="onboarding_page_3_title">Choose your update method</string>
-	<string name="onboarding_page_3_caption">Usually, the incremental update is the right choice here, because it offers much faster and smaller downloads.\n\nHowever, it\'s not compatible with rooted devices. If you have a rooted device, choose the Full update.\n\nIf you have a beta version of OxygenOS, choose (one of) the Open Beta update method(s).</string>
-	<string name="onboarding_page_4_title">You are ready to go!</string>
-	<string name="onboarding_page_4_text">Enjoy using this app!\n\nYou can always change your settings later on. To do so: Tap the three dots in the top right corner, and tap on \"Settings\".</string>
+	<string name="onboarding_app_uses">This app will allow you to:\n\n&#8226; Get faster access to the latest Android updates for your OxygenOS powered device\n&#8226; Easily update a rooted device\n&#8226; View what\'s new in the system software you are currently using\n&#8226; Read the latest news about OnePlus and OxygenOS</string>
+	<string name="onboarding_disclaimer">This is not an official OnePlus application. Usage of this app is completely at your own risk. Neither OnePlus nor the developer of the app are liable for your actions, including any damage caused by using this app. By using this app, you agree to the terms and conditions as stated above.</string>
+	<string name="onboarding_device_chooser_title">Choose your device</string>
+	<string name="onboarding_device_chooser_caption">Your device is usually already selected above. If not, select your device above.</string>
+	<string name="onboarding_method_chooser_title">Choose your update method</string>
+	<string name="onboarding_method_chooser_caption">Usually, the incremental update is the right choice here, because it offers much faster and smaller downloads. However, it\'s not compatible with rooted devices. If you have a rooted device, choose the Full update. If you have a beta version of OxygenOS, choose (one of) the Open Beta update method(s).</string>
+	<string name="onboarding_caption">Enjoy using this app! You can always change your settings later on.</string>
 
 	<!-- Automatic install strings -->
 	<string name="install">Install</string>
 
 	<!-- Install guide strings -->
-	<string name="install_guide_no_root">Install the update according to the instructions shown in the install guide.</string>
 	<string name="install_guide">Install guide</string>
-	<string name="install_guide_subtitle">Install guide - %1$d of %2$d</string>
-	<string name="install_guide_tip">&#8226; It\'s recommended to write all steps down, as you\'ll need to power off your device during the installation of the update.</string>
-
-	<string name="install_guide_page_1_title">Download the update</string>
-	<string name="install_guide_page_1_text">&#8226; Press the Download button to start downloading the update.\n\n&#8226; The download progress will appear in the app, and as a notification in your notifications screen.\n\n&#8226; When the download has finished, you\'ll see a notification with the text \"Download complete\".\nIf a download error occurred, open the app and try to downloading the update again. If this doesn\'t work, make sure you have a working connection. Otherwise, contact the developer of the app. You can do this by visiting the \"My apps\" section of the Google Play Store.</string>
-
-	<string name="install_guide_page_2_title">Prepare for installation</string>
-	<string name="install_guide_page_2_text">"Note: The installation of the update takes place from a special page of the standard System Updates section of your device. If, for some reason, a system update appears when opening this section, you may also opt to install that update first. Afterwards, open Oxygen Updater again to see if you're completely up-to-date.
-
-Instructions:
-&#8226; Close Oxygen Updater by pressing the home button.
-
-&#8226; Open the Settings app. It should be located in your app drawer.
-
-&#8226; Scroll down until you see System updates. Tap on it."</string>
-
-	<string name="install_guide_page_3_title">Install the update</string>
-	<string name="install_guide_page_3_text">"Now that you're in the System Updates app, it's time to install the update.
-
-&#8226; Within the System Updates section, tap the gear icon in the top right
-
-&#8226; Now, select \"Local upgrade\". A file selection screen should appear.
-
-&#8226; In this screen, tap on the update file you downloaded using Oxygen Updater. Its name should start with \"%1$sOxygen\".
-
-&#8226; Tap on \"Upgrade Now\". The installation should start automatically."</string>
-
-	<string name="install_guide_page_4_title">Wait until the installation completes</string>
-	<string name="install_guide_page_4_text">"&#8226; The phone will now install the update and displays a progress bar. Please wait until the installation has finished. Installation may take anywhere from a few minutes up to 15 minutes.
-
-&#8226; Afterwards, your phone will restart to complete the update."</string>
-
-	<string name="install_guide_page_5_title">Done. Enjoy the new OxygenOS version!</string>
-	<string name="install_guide_page_5_text">&#8226; After your device has finished optimizing its apps, the update has been successfully installed.\nTo verify this, you can check the current version of your system as following:\n\n&#8226; Go to Settings, tap on \"About Phone\", and check the OxygenOS Version.\n\n&#8226; If you like this app, give it 5 stars at Google Play!</string>
-
-	<string name="install_guide_close_button">Close Installation Guide</string>
+	<string name="install_guide_download_instructions">&#8226; Press the Download button to start downloading the update.\n&#8226; The download progress will appear in the app, and as a notification in your notifications screen.\n&#8226; When the download has finished, you\'ll see a notification with the text \"Download complete\". If a download error occurred, open the app and try to download it again. If this doesn\'t work, make sure you have a working connection. Otherwise, contact the developer of the app. You can do this by visiting the \"My apps\" section of the Google Play Store.</string>
 
 	<!-- Device information strings -->
 	<string name="device_information_supported_oxygen_os">Your device is supported</string>
@@ -227,13 +170,12 @@ Instructions:
 
 	<string name="device_information_amount_of_memory">Amount of RAM</string>
 	<string name="device_information_cpu_frequency">Processor Frequency</string>
-	<string name="device_information_device_name" translatable="false">%1$s %2$s</string>
 	<string name="device_information_gigahertz" translatable="false">%1$s GHz</string>
 	<string name="device_information_header">Device</string>
 	<string name="device_information_image_description">Device image</string>
 	<string name="device_information_incremental_os_version">Incremental OS version</string>
 	<string name="device_information_os_version">Android version</string>
-	<string name="device_information_oxygen_os_version">OxygenOS version</string>
+	<string name="device_information_oxygen_os_version">OS version</string>
 	<string name="device_information_oxygen_os_ota_version">OTA version</string>
 	<string name="device_information_patch_level_version">Security patch date</string>
 	<string name="device_information_serial_number">Serial number</string>
@@ -242,10 +184,10 @@ Instructions:
 
 	<!-- About screen strings -->
 	<string name="about">About</string>
-	<string name="about_description">This app downloads official updates directly from OnePlus servers, and even verifies the integrity of the downloaded ZIP before allowing you to install. By doing so, the app allows you to skip the rollout queue and install official updates ASAP. If you encounter bugs in the OS, report them to OnePlus directly: <a href="https://forums.oneplus.com/feedback">https://forums.oneplus.com/feedback</a>. You might want to join our <a href="https://discord.gg/5TXdhKJ">Discord server</a> as well, so that you can talk to other users about the latest updates. Otherwise feel free to email us at <a href="mailto:support@oxygenupdater.com">support@oxygenupdater.com</a> with your suggestions/feedback.</string>
-	<string name="about_support">If you\'d like to support us, you can either buy the ad-free unlock (app\'s settings), or check our <a href="https://patreon.com/oxygenupdater">Patreon page</a>.</string>
+	<string name="about_description"><![CDATA[This app downloads official updates directly from OnePlus servers, and even verifies the integrity of the downloaded ZIP before allowing you to install. By doing so, the app allows you to skip the rollout queue and install official updates ASAP. If you encounter bugs in the OS, report them to OnePlus directly: <a href="https://forums.oneplus.com/feedback">https://forums.oneplus.com/feedback</a>. You might want to join our <a href="https://discord.gg/5TXdhKJ">Discord server</a> as well, so that you can talk to other users about the latest updates. Otherwise feel free to email us at <a href="mailto:support@oxygenupdater.com">support@oxygenupdater.com</a> with your suggestions/feedback.]]></string>
+	<string name="about_support"><![CDATA[If you\'d like to support us, you can either buy the ad-free unlock (app\'s settings), or check our <a href="https://patreon.com/oxygenupdater">Patreon page</a>.]]></string>
 	<string name="about_background_story_header">Background story</string>
-	<string name="about_background_story">This app was originally developed by Arjan Vlek as a follow-up of another one of his apps, called <a href="https://cyanogenupdatetracker.com/">Cyanogen Update Tracker</a> (it provides similar functionality for Cyanogen OS users).\n\nAfter 4 years, in July 2019, Arjan decided to step down from both projects and transferred ownership of the app to a team of developers hailing from different countries. They took on the responsibility of providing the community with excellent service &amp; support of getting OnePlus updates faster.\nYou can find more information about the announcement <a href="https://oxygenupdater.com/article/81/">here</a>.\n\n14th August 2019 marked the first release under new ownership, which came with new features like dark mode and a complete redesign.\n\nFor more information on the team, check <a href="https://oxygenupdater.com/team/">the website</a>.</string>
+	<string name="about_background_story"><![CDATA[This app was originally developed by Arjan Vlek as a follow-up of another one of his apps, called <a href="https://cyanogenupdatetracker.com/">Cyanogen Update Tracker</a> (it provides similar functionality for Cyanogen OS users).\n\nAfter 4 years, in July 2019, Arjan decided to step down from both projects and transferred ownership of the app to a team of developers hailing from different countries. They took on the responsibility of providing the community with excellent service &amp; support of getting OnePlus updates faster.\nYou can find more information about the announcement <a href="https://oxygenupdater.com/article/81/">here</a>.\n\n14th August 2019 marked the first release under new ownership, which came with new features like dark mode and a complete redesign.\n\nFor more information on the team, check <a href="https://oxygenupdater.com/team/">the website</a>.]]></string>
 	<string name="about_third_party_app_notice">Please note, this is not an official OnePlus application.\nThe OnePlus name, the OnePlus Logo and OxygenOS are property of OnePlus.\nAndroid, Google, Google Play and the Google Play logo are registered trademarks of Google Inc.\nThis app uses data from OnePlus and its parent company Oppo to show update information.</string>
 	<string name="about_rate_button_text">Rate</string>
 	<string name="about_website_button_text">Website</string>
@@ -255,6 +197,8 @@ Instructions:
 	<string name="about_patreon_button_text" translatable="false">Patreon</string>
 
 	<!-- LocalNotifications strings -->
+	<string name="notification_permission_title">"Stay notified"</string>
+	<string name="notification_permission_text">"Please allow the app to notify you of OTA updates, news, ongoing download status, and other important things. You can fine-tune your preferences later in the app's settings."</string>
 	<string name="notification_new_device_text">The %1$s is now supported. Open the app to choose this device.</string>
 	<string name="notification_no_notification_support">Install or update Google Play services to enable push notifications.</string>
 	<string name="notification_version">%1$s is now available for the %2$s!</string>
@@ -280,23 +224,9 @@ Instructions:
 	<string name="general_notification_channel_description">General notifications that don\'t fit into other categories</string>
 	<string name="url_submitted_notification_channel_description">Get notified when you\'ve submitted OTA URLs successfully to our team.\nYou can opt-out of automatically submitting URLs in the app\'s settings.</string>
 
-	<!-- Help strings -->
-	<string name="help">Help</string>
-	<string name="help_updating_your_device_title">Updating your device</string>
-	<string name="help_updating_your_device_text">When opening the app, you\'ll see if a system update is available. If an update is available, you can install it.\n\nTo start the installation, tap the \"Download\" button (below the update description) to start the download. When the download has finished, the installation screen pops up. If you left the app or the screen didn\'t pop up, tap the \"Install\" button, which is now shown next to the \"Download\" button.\n\nThe install screen will first check if you have a rooted device. If you have a rooted device, grant root permission when asked and choose how you want to install the update. Otherwise, follow the instructions for Manual install.\n\nAutomatic install:\nYou\'ll only have to choose your install options. The default settings are recommended, except that you have to specify the root package which needs to be (re)installed. Select a root package (zip file) using the blue folder button and tap on \"Start install\" to start the installation.\n\nManual install:\nYou\'ll see an installation guide on your screen. Write the instructions down and perform them as stated to install the update.</string>
-	<string name="help_reading_news_title">Reading the latest news</string>
-	<string name="help_reading_news_text">News is displayed to the left of the Update screen. The most recent items appear on top. Just tap on an item to read it.\nTap the back arrow or press your back key to return to the news items screen.</string>
-	<string name="help_device_information_title">Viewing information about your device</string>
-	<string name="help_device_information_text">You may view some of the specifications of your device using the screen to the right of the Update screen. This comes in handy when making a support request, during which you might be asked for some of the specifications of your device.</string>
-	<string name="help_change_settings_title">Changing settings</string>
-	<string name="help_change_settings_text">You can change your settings by tapping the three dots in the top right, following a tap on Settings.\nYou can change the following settings:\n\n• Device and update method\n• Push notifications\n• In app notifications\n• Privacy settings (log uploading).\n\nUse the switches to turn notification / privacy settings on and off. Select a device and / or update method using the dropdown menus shown above the switches. Dropdown menus not visible? Check your Internet connection and open the Settings screen again.</string>
-
 	<!-- News strings -->
 	<string name="news">News</string>
-	<string name="news_date_published">Last update: %1$s</string>
-	<string name="news_empty">This article has no contents.</string>
-	<string name="news_load_network_error">Failed to open article. Check your connection and press the \"RETRY\" button to open the article.</string>
-	<string name="news_load_id_error"><![CDATA[Failed to open article from an invalid URL: %1$s. Check the URL or report this to us either via <a href="mailto:support@oxygenupdater.com">email</a> or on our <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
+	<string name="news_load_network_error">Failed to open article. Check your connection and press the \"Retry\" button to open the article.</string>
 	<string name="news_unread_count_1">You have %1$d unread news articles. Tap here to view them.</string>
 	<string name="news_unread_count_2">You have %1$d unread news articles. Tap to show all articles.</string>
 	<string name="news_mark_read">Mark as read</string>
@@ -322,12 +252,10 @@ Instructions:
 	<string name="error_app_outdated">Oh no!</string>
 	<string name="error_app_outdated_message">This version of the app is outdated. It\'s time to update it! Tap on \"Google Play\" below. Within Google Play, tap on \"Update\".</string>
 	<string name="error_app_requires_network_connection">No connection</string>
-	<string name="error_app_requires_network_connection_message">Failed to connect to the server. Please make sure you have a working connection. The app will now close.</string>
 	<string name="error_google_play_button_text">Google Play</string>
-	<string name="error_no_internet_connection">No connection.</string>
 	<string name="error_maintenance">Server maintenance</string>
 	<string name="error_maintenance_message">Please wait. The server will be available very soon.</string>
-	<string name="error_maintenance_retry">The server may be down for maintenance. Try again after some time, or report it to us either via <a href="mailto:support@oxygenupdater.com">email</a> or on our <a href="https://discord.gg/5TXdhKJ">Discord server</a>.</string>
+	<string name="error_maintenance_retry"><![CDATA[The server may be down for maintenance. Try again after some time, or report it to us either via <a href="mailto:support@oxygenupdater.com">email</a> or on our <a href="https://discord.gg/5TXdhKJ">Discord server</a>.]]></string>
 	<string name="error_reload">Reload</string>
 
 	<string name="error_unable_to_rate_app">You can\'t rate the app, because the Google Play Store is missing on your device.</string>
@@ -352,19 +280,8 @@ Instructions:
 	<string name="purchase_error_after_payment">The purchase of the ad-free version failed, because an internal error occurred. Please try again in a few minutes. If you have already paid, please contact Google Play support for assistance.</string>
 
 	<!-- Other strings-->
-	<string name="install_guide_transition_name" translatable="false">INSTALL_GUIDE_TRANSITION</string>
-	<string name="help_transition_name" translatable="false">HELP_TRANSITION</string>
-	<string name="faq_transition_name" translatable="false">FAQ_TRANSITION</string>
-	<string name="news_item_transition_name" translatable="false">NEWS_ITEM_TRANSITION_%d</string>
-
-	<string name="discord_url" translatable="false">https://discord.gg/5TXdhKJ</string>
-	<string name="github_url" translatable="false">https://github.com/oxygen-updater/oxygen-updater</string>
-	<string name="patreon_url" translatable="false">https://patreon.com/oxygenupdater</string>
-	<string name="website_url" translatable="false">https://oxygenupdater.com</string>
-	<string name="email_address" translatable="false">support@oxygenupdater.com</string>
-	<string name="error">Error</string>
 	<string name="icon">Icon</string>
 	<string name="loading">Loading…</string>
 	<string name="processing">Processing…</string>
-	<string name="asset_statements" translatable="false">[{\n  \"relation\": [\"delegate_permission/common.handle_all_urls\"],\n  \"target\": {\n    \"namespace\": \"web\",\n    \"site\": \"https://oxygenupdater.com\",\n  }\n}]</string>
+	<string name="asset_statements" translatable="false">[{\"relation\":[\"delegate_permission/common.handle_all_urls\"],\"target\":{\"namespace\":\"web\",\"site\":\"https://oxygenupdater.com\"}}]</string>
 </resources>


### PR DESCRIPTION
_This is a draft PR that's been created to help translators focus only on string changes between v5.11.3 and v6. This PR has no other use, and thus will never be merged to `master`._

~The `compose/main` branch will be pushed once we release v6 to stable. It will be merged to `master` via a PR so that it's easier for you to see code changes as well (keep in mind though, since it's a full rewrite, every piece of code has changed).~
See https://github.com/oxygen-updater/oxygen-updater/pull/243.

To save your time, we have outlined string changes below, including screenshots.

---

With the [v6 release](https://oxygenupdater.com/article/413/), there are quite a few string changes. We've translated all of them either via [DeepL](https://www.deepl.com/translator) or [Google Translate](https://translate.google.com/) to make sure the app still shows proper strings of reasonable quality instead of default English ones.

If you haven't already, please install v6 via Play Store Open Beta: https://oxygenupdater.com/article/413/ so that you can see for yourself what's changed and where these strings are being shown. Otherwise, we've provided screenshots where possible.

For your own benefit, all new strings should be wrapped in double quotes (`<string name="key">"…"</string>`). However, if any part of the string needs to explicitly show double quotes, they must be escaped like so: `<string name="key">"rest of string \"quoted word\" rest of string"</string>`.

---

## New strings
```xml
<string name="notification_permission_title">"Stay notified"</string>
<string name="notification_permission_text">"Please allow the app to notify you of OTA updates, news, ongoing download status, and other important things. You can fine-tune your preferences later in the app's settings."</string>
<string name="install_guide_download_instructions">"&#8226; Press the Download button to start downloading the update.
&#8226; The download progress will appear in the app, and as a notification in your notifications screen.
&#8226; When the download has finished, you'll see a notification with the text \"Download complete\". If a download error occurred, open the app and try to download it again. If this doesn't work, make sure you have a working connection. Otherwise, contact the developer of the app. You can do this by visiting the \"My apps\" section of the Google Play Store."</string>
<string name="settings_ad_privacy">GDPR ad consent</string>
<string name="settings_ad_privacy_subtitle">"For EEA/UK users"</string>
```
Note: `&#8226;` in XML is not an error; it's the bullet symbol `•`, often used for list items as you can see in screenshots below.

---

## Changed strings

**settings_advanced_mode_explanation** used to be:
> Advanced mode hides the message \"Your system is up to date\", allowing you to download and install all updates, even though they may not be compatible with your device.
> 
> This can be useful when:
> &#8226; Updating from a regular version to a beta version
> &#8226; Reverting from a beta version to the regular version (don't forget to factory reset your device)
> &#8226; Reinstalling your current system version.

but in v6 it's been split into 3 strings:
```xml
<string name="settings_advanced_mode_explanation">"Normally, the app shows you updates based on your current OS version. With advanced mode, the latest available update will always be shown regardless of device/version compatibility.

This can be useful if you want to:"</string>
<string name="settings_advanced_mode_uses">"&#8226; Re-download the latest version even if you're already on it
&#8226; Switch to a different update track"</string>
<string name="settings_advanced_mode_caption">"Advanced mode may be needed only in the above situations. You should not enable it unless you know what you're doing."</string>
```
Yes, the first string has the same key as before. All these strings **must** be kept separate, but the app **always** shows them together, one after another. See screenshot for example:

![image](https://github.com/oxygen-updater/oxygen-updater/assets/14949823/ccadc97a-d952-4f14-96cc-941e589e0aff)

---

**update_information_different_version_changelog_notice** used to be:
> You're viewing a changelog for the latest update in the \"%1$s\" update track. If you intend to install this update, you must turn advanced mode on first (in settings).
> 
> However, if you wish to see the changelog for the currently installed version instead, you'll need to switch back to the correct update method.

but in v6 it's been changed & split into 2 strings:
```xml
<string name="update_information_different_version_changelog_notice_base">"Note: this changelog is for the latest available version (%1$s) in the \"%2$s\" update method"</string>
<string name="update_information_different_version_changelog_notice_advanced">". If you intend to install this update, you must enable \"Advanced mode\" in settings."</string>
```
Yes, the 2nd string starts with a fullstop; not a typo. The app appends this to the first only if some conditions satisfy, so the first string **must not** end with its own fullstop.

![image](https://github.com/oxygen-updater/oxygen-updater/assets/14949823/6cfa6a9b-65b8-4cfe-98b9-77149046abcb)

---

**onboarding** used to be:
> Welcome

which was never displayed in the app, but in v6 it is, and changed to:
```xml
<string name="onboarding">"Setup"</string>
```
See example screenshot of where this string is used:

![image](https://github.com/oxygen-updater/oxygen-updater/assets/14949823/a86ccd72-e069-4174-8d60-8c4e3cee1df6)